### PR TITLE
Add py.typed marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cgt-calc"
-version = "0.1.1"
+version = "0.0.0"
 description = "UK capital gains tax calculator for Charles Schwab and Trading 212 accounts"
 authors = ["Ruslan Sayfutdinov <ruslan@sayfutdinov.com>"]
 license = "MIT"


### PR DESCRIPTION
The project is strictly typed now and we can export this typing information.

Also set version to dummy `0.0.0` because publishing action will set it to correct value.
