### PR TITLE
Simplifying abstraction by Using date as indices instead of numbers

### DIFF
--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 from decimal import Decimal
 
-from .dates import date_to_index, is_date
+from .dates import is_date
 from .exceptions import ExchangeRateMissingError
 from .model import BrokerTransaction
 
@@ -12,7 +12,7 @@ from .model import BrokerTransaction
 class CurrencyConverter:
     """Coverter which holds price history."""
 
-    def __init__(self, gbp_history: dict[int, Decimal]):
+    def __init__(self, gbp_history: dict[datetime.date, Decimal]):
         """Create from GBP/USD price history."""
         self.gbp_history = gbp_history
 
@@ -20,10 +20,10 @@ class CurrencyConverter:
         """Get GBP/USD price at given date."""
         assert is_date(date)
         # Set day to 1 to get monthly price
-        index = date_to_index(date.replace(day=1))
-        if index not in self.gbp_history:
+        index_date = date.replace(day=1)
+        if index_date not in self.gbp_history:
             raise ExchangeRateMissingError("USD", date)
-        return self.gbp_history[index]
+        return self.gbp_history[index_date]
 
     def to_gbp(self, amount: Decimal, currency: str, date: datetime.date) -> Decimal:
         """Convert amount from given currency to GBP."""

--- a/cgt_calc/dates.py
+++ b/cgt_calc/dates.py
@@ -1,26 +1,12 @@
 """Function to work with dates."""
 import datetime
 
-from .const import INTERNAL_START_DATE
-from .model import DateIndex
-
 
 def is_date(date: datetime.date) -> bool:
     """Check if date has only date but not time."""
     if not isinstance(date, datetime.date) or isinstance(date, datetime.datetime):
         raise Exception(f'should be datetime.date: {type(date)} "{date}"')
     return True
-
-
-def date_to_index(date: datetime.date) -> DateIndex:
-    """Convert datetime to DateIndex."""
-    assert is_date(date)
-    return (date - INTERNAL_START_DATE).days
-
-
-def date_from_index(date_index: int) -> datetime.date:
-    """Convert DateIndex to datetime."""
-    return INTERNAL_START_DATE + datetime.timedelta(days=date_index)
 
 
 def get_tax_year_start(tax_year: int) -> datetime.date:

--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -68,7 +68,7 @@ class UnexpectedColumnCountError(ParsingError):
         )
 
 
-class CalculatedAmountDiscrepancy(InvalidTransactionError):
+class CalculatedAmountDiscrepancyError(InvalidTransactionError):
     """Calculated amount discrepancy error."""
 
     def __init__(self, transaction: BrokerTransaction, calculated_amount: Decimal):

--- a/cgt_calc/initial_prices.py
+++ b/cgt_calc/initial_prices.py
@@ -5,24 +5,19 @@ from dataclasses import dataclass
 import datetime
 from decimal import Decimal
 
-from .dates import date_to_index, is_date
+from .dates import is_date
 from .exceptions import ExchangeRateMissingError
-from .model import DateIndex
 
 
 @dataclass
 class InitialPrices:
     """Class to store initial stock prices."""
 
-    initial_prices: dict[DateIndex, dict[str, Decimal]]
+    initial_prices: dict[datetime.date, dict[str, Decimal]]
 
     def get(self, date: datetime.date, symbol: str) -> Decimal:
         """Get initial stock price at given date."""
         assert is_date(date)
-        date_index = date_to_index(date)
-        if (
-            date_index not in self.initial_prices
-            or symbol not in self.initial_prices[date_index]
-        ):
+        if date not in self.initial_prices or symbol not in self.initial_prices[date]:
             raise ExchangeRateMissingError(symbol, date)
-        return self.initial_prices[date_index][symbol]
+        return self.initial_prices[date][symbol]

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -15,16 +15,10 @@ from . import render_latex
 from .args_parser import create_parser
 from .const import BED_AND_BREAKFAST_DAYS, CAPITAL_GAIN_ALLOWANCES, INTERNAL_START_DATE
 from .currency_converter import CurrencyConverter
-from .dates import (
-    date_from_index,
-    date_to_index,
-    get_tax_year_end,
-    get_tax_year_start,
-    is_date,
-)
+from .dates import get_tax_year_end, get_tax_year_start, is_date
 from .exceptions import (
     AmountMissingError,
-    CalculatedAmountDiscrepancy,
+    CalculatedAmountDiscrepancyError,
     CalculationError,
     InvalidTransactionError,
     PriceMissingError,
@@ -111,11 +105,11 @@ class CapitalGainsCalculator:
                 quantity * transaction.price + transaction.fees, 2
             )
             if transaction.amount != -calculated_amount:
-                raise CalculatedAmountDiscrepancy(transaction, -calculated_amount)
+                raise CalculatedAmountDiscrepancyError(transaction, -calculated_amount)
             amount = -transaction.amount
         add_to_list(
             acquisition_list,
-            date_to_index(transaction.date),
+            transaction.date,
             symbol,
             quantity,
             self.converter.to_gbp_for(amount, transaction),
@@ -158,10 +152,10 @@ class CapitalGainsCalculator:
             quantity * transaction.price - transaction.fees, 2
         )
         if amount != calculated_amount:
-            raise CalculatedAmountDiscrepancy(transaction, calculated_amount)
+            raise CalculatedAmountDiscrepancyError(transaction, calculated_amount)
         add_to_list(
             disposal_list,
-            date_to_index(transaction.date),
+            transaction.date,
             symbol,
             quantity,
             self.converter.to_gbp_for(amount, transaction),
@@ -214,7 +208,7 @@ class CapitalGainsCalculator:
                     raise SymbolMissingError(transaction)
                 add_to_list(
                     acquisition_list,
-                    date_to_index(transaction.date),
+                    transaction.date,
                     transaction.symbol,
                     transaction.quantity,
                     gbp_fees,
@@ -277,7 +271,7 @@ class CapitalGainsCalculator:
         bed_and_breakfast_list: HmrcTransactionLog,
         portfolio: dict[str, tuple[Decimal, Decimal]],
         symbol: str,
-        date_index: int,
+        date_index: datetime.date,
     ) -> list[CalculationEntry]:
         """Process single acquisition."""
         acquisition_quantity, acquisition_amount, acquisition_fees = acquisition_list[
@@ -349,7 +343,7 @@ class CapitalGainsCalculator:
         bed_and_breakfast_list: HmrcTransactionLog,
         portfolio: dict[str, tuple[Decimal, Decimal]],
         symbol: str,
-        date_index: int,
+        date_index: datetime.date,
     ) -> tuple[Decimal, list[CalculationEntry]]:
         """Process single disposal."""
         disposal_quantity, proceeds_amount, disposal_fees = disposal_list[date_index][
@@ -405,7 +399,7 @@ class CapitalGainsCalculator:
         # Bed and breakfast rule next
         if disposal_quantity > 0:
             for i in range(BED_AND_BREAKFAST_DAYS):
-                search_index = date_index + i + 1
+                search_index = date_index + datetime.timedelta(days=i + 1)
                 if has_key(acquisition_list, search_index, symbol):
                     (
                         acquisition_quantity,
@@ -442,8 +436,8 @@ class CapitalGainsCalculator:
                         continue
                     print(
                         f"WARNING: Bed and breakfasting for {symbol}."
-                        f" Disposed on {date_from_index(date_index)}"
-                        f" and acquired again on {date_from_index(search_index)}"
+                        f" Disposed on {date_index}"
+                        f" and acquired again on {search_index}"
                     )
                     available_quantity = min(
                         disposal_quantity,
@@ -543,9 +537,9 @@ class CapitalGainsCalculator:
         disposal_list: HmrcTransactionLog,
     ) -> CapitalGainsReport:
         """Calculate capital gain and return generated report."""
-        begin_index = date_to_index(INTERNAL_START_DATE)
-        tax_year_start_index = date_to_index(self.tax_year_start_date)
-        end_index = date_to_index(self.tax_year_end_date)
+        begin_index = INTERNAL_START_DATE
+        tax_year_start_index = self.tax_year_start_date
+        end_index = self.tax_year_end_date
         disposal_count = 0
         disposal_proceeds = Decimal(0)
         allowable_costs = Decimal(0)
@@ -554,7 +548,10 @@ class CapitalGainsCalculator:
         bed_and_breakfast_list: HmrcTransactionLog = {}
         portfolio: dict[str, tuple[Decimal, Decimal]] = {}
         calculation_log: CalculationLog = {}
-        for date_index in range(begin_index, end_index + 1):
+        for date_index in (
+            begin_index + datetime.timedelta(days=x)
+            for x in range(0, (end_index - begin_index).days)
+        ):
             if date_index in acquisition_list:
                 for symbol in acquisition_list[date_index]:
                     calculation_entries = self.process_acquisition(
@@ -595,7 +592,7 @@ class CapitalGainsCalculator:
                         transaction_quantity = disposal_list[date_index][symbol][0]
                         LOGGER.debug(
                             "DISPOSAL on %s of %s, quantity %d, capital gain $%s",
-                            date_from_index(date_index),
+                            date_index,
                             symbol,
                             transaction_quantity,
                             round_decimal(transaction_capital_gain, 2),

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -9,11 +9,8 @@ from typing import Dict, List, Tuple
 
 from .util import round_decimal
 
-# Number of days from some unspecified fixed date
-DateIndex = int
-
 # For mapping of dates to int
-HmrcTransactionLog = Dict[int, Dict[str, Tuple[Decimal, Decimal, Decimal]]]
+HmrcTransactionLog = Dict[datetime.date, Dict[str, Tuple[Decimal, Decimal, Decimal]]]
 
 
 class ActionType(Enum):
@@ -69,7 +66,7 @@ class CalculationEntry:  # noqa: SIM119 # this has non-trivial constructor
         new_pool_cost: Decimal,
         gain: Decimal | None = None,
         allowable_cost: Decimal | None = None,
-        bed_and_breakfast_date_index: int = 0,
+        bed_and_breakfast_date_index: datetime.date | None = None,
     ):
         """Create calculation entry."""
         self.rule_type = rule_type
@@ -102,7 +99,7 @@ class CalculationEntry:  # noqa: SIM119 # this has non-trivial constructor
         )
 
 
-CalculationLog = Dict[DateIndex, Dict[str, List[CalculationEntry]]]
+CalculationLog = Dict[datetime.date, Dict[str, List[CalculationEntry]]]
 
 
 @dataclass

--- a/cgt_calc/parsers/__init__.py
+++ b/cgt_calc/parsers/__init__.py
@@ -9,9 +9,8 @@ import operator
 from pathlib import Path
 
 from cgt_calc.const import DEFAULT_GBP_HISTORY_FILE, DEFAULT_INITIAL_PRICES_FILE
-from cgt_calc.dates import date_to_index
 from cgt_calc.exceptions import UnexpectedColumnCountError
-from cgt_calc.model import BrokerTransaction, DateIndex
+from cgt_calc.model import BrokerTransaction
 from cgt_calc.resources import RESOURCES_PACKAGE
 
 from .mssb import read_mssb_transactions
@@ -67,9 +66,11 @@ def read_broker_transactions(
     return transactions
 
 
-def read_gbp_prices_history(gbp_history_file: str | None) -> dict[int, Decimal]:
+def read_gbp_prices_history(
+    gbp_history_file: str | None,
+) -> dict[datetime.date, Decimal]:
     """Read GBP/USD history from CSV file."""
-    gbp_history: dict[int, Decimal] = {}
+    gbp_history: dict[datetime.date, Decimal] = {}
     if gbp_history_file is None:
         csv_file = importlib.resources.open_text(
             RESOURCES_PACKAGE, DEFAULT_GBP_HISTORY_FILE
@@ -84,15 +85,15 @@ def read_gbp_prices_history(gbp_history_file: str | None) -> dict[int, Decimal]:
         if len(row) != 2:
             raise UnexpectedColumnCountError(row, 2, gbp_history_file or "default")
         price_date = datetime.datetime.strptime(row[0], "%m/%Y").date()
-        gbp_history[date_to_index(price_date)] = Decimal(row[1])
+        gbp_history[price_date] = Decimal(row[1])
     return gbp_history
 
 
 def read_initial_prices(
     initial_prices_file: str | None,
-) -> dict[DateIndex, dict[str, Decimal]]:
+) -> dict[datetime.date, dict[str, Decimal]]:
     """Read initial stock prices from CSV file."""
-    initial_prices: dict[DateIndex, dict[str, Decimal]] = {}
+    initial_prices: dict[datetime.date, dict[str, Decimal]] = {}
     if initial_prices_file is None:
         csv_file = importlib.resources.open_text(
             RESOURCES_PACKAGE, DEFAULT_INITIAL_PRICES_FILE
@@ -105,7 +106,7 @@ def read_initial_prices(
     lines = lines[1:]
     for row in lines:
         entry = InitialPricesEntry(row, initial_prices_file or "default")
-        date_index = date_to_index(entry.date)
+        date_index = entry.date
         if date_index not in initial_prices:
             initial_prices[date_index] = {}
         initial_prices[date_index][entry.symbol] = entry.price

--- a/cgt_calc/render_latex.py
+++ b/cgt_calc/render_latex.py
@@ -8,7 +8,6 @@ import tempfile
 import jinja2
 
 from .const import PACKAGE_NAME, TEMPLATE_NAME
-from .dates import date_from_index
 from .model import CapitalGainsReport
 from .util import round_decimal, strip_zeros
 
@@ -36,7 +35,6 @@ def render_calculations(
     template = latex_template_env.get_template(TEMPLATE_NAME)
     output_text = template.render(
         report=report,
-        date_from_index=date_from_index,
         round_decimal=round_decimal,
         strip_zeros=strip_zeros,
         Decimal=Decimal,

--- a/cgt_calc/resources/template.tex.j2
+++ b/cgt_calc/resources/template.tex.j2
@@ -12,7 +12,7 @@
 
 \BLOCK{ for date_index, symbol_dict in report.calculation_log.items() }
 
-\section*{\VAR{ date_from_index(date_index).strftime("%d %B %Y") }}
+\section*{\VAR{ date_index.strftime("%d %B %Y") }}
 \BLOCK{ for symbol, entries in symbol_dict.items() }
 \BLOCK{ if symbol.startswith("sell$") }
     \BLOCK{ set symbol = symbol[5:] }
@@ -67,7 +67,7 @@
     \BLOCK{ endif }
     allowable
     \BLOCK{ if entry.rule_type.name == "BED_AND_BREAKFAST" }
-        cost on \mbox{\VAR{ date_from_index(entry.bed_and_breakfast_date_index).strftime("%d %b %Y") }:}
+        cost on \mbox{\VAR{ entry.bed_and_breakfast_date_index.strftime("%d %b %Y") }:}
     \BLOCK{ else }
         cost:
     \BLOCK{ endif }

--- a/cgt_calc/transaction_log.py
+++ b/cgt_calc/transaction_log.py
@@ -1,17 +1,20 @@
 """Functions to work with HMRC transaction log."""
+import datetime
 from decimal import Decimal
 
 from .model import HmrcTransactionLog
 
 
-def has_key(transactions: HmrcTransactionLog, date_index: int, symbol: str) -> bool:
+def has_key(
+    transactions: HmrcTransactionLog, date_index: datetime.date, symbol: str
+) -> bool:
     """Check if transaction log has entry for date_index and symbol."""
     return date_index in transactions and symbol in transactions[date_index]
 
 
 def add_to_list(
     current_list: HmrcTransactionLog,
-    date_index: int,
+    date_index: datetime.date,
     symbol: str,
     quantity: Decimal,
     amount: Decimal,

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -10,7 +10,6 @@ import sys
 import pytest
 
 from cgt_calc.currency_converter import CurrencyConverter
-from cgt_calc.dates import date_to_index
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.main import CapitalGainsCalculator
 from cgt_calc.model import (
@@ -125,7 +124,7 @@ test_basic_data = [
         1.00,  # Expected capital gain/loss
         None,
         {
-            date_to_index(datetime.date(day=1, month=5, year=2020)): {
+            datetime.date(day=1, month=5, year=2020): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.SECTION_104,
@@ -194,7 +193,7 @@ test_basic_data = [
         629.66,  # Expected capital gain/loss
         None,
         {
-            date_to_index(datetime.date(day=1, month=5, year=2020)): {
+            datetime.date(day=1, month=5, year=2020): {
                 "sell$LOB": [
                     CalculationEntry(
                         RuleType.SECTION_104,
@@ -208,7 +207,7 @@ test_basic_data = [
                     ),
                 ],
             },
-            date_to_index(datetime.date(day=1, month=2, year=2021)): {
+            datetime.date(day=1, month=2, year=2021): {
                 "sell$LOB": [
                     CalculationEntry(
                         RuleType.SECTION_104,
@@ -258,7 +257,7 @@ test_basic_data = [
         -100,  # Expected capital gain/loss
         None,
         {
-            date_to_index(datetime.date(day=30, month=8, year=2020)): {
+            datetime.date(day=30, month=8, year=2020): {
                 "sell$MSP": [
                     CalculationEntry(
                         RuleType.BED_AND_BREAKFAST,
@@ -269,7 +268,7 @@ test_basic_data = [
                         fees=Decimal(0),
                         new_quantity=Decimal(9000),
                         new_pool_cost=Decimal(13500),
-                        bed_and_breakfast_date_index=date_to_index(
+                        bed_and_breakfast_date_index=(
                             datetime.date(day=11, month=9, year=2020)
                         ),
                     ),
@@ -285,7 +284,7 @@ test_basic_data = [
                     ),
                 ],
             },
-            date_to_index(datetime.date(day=11, month=9, year=2020)): {
+            datetime.date(day=11, month=9, year=2020): {
                 "buy$MSP": [
                     CalculationEntry(
                         RuleType.BED_AND_BREAKFAST,
@@ -350,7 +349,7 @@ test_basic_data = [
         222.82,  # Expected capital gain/loss
         None,
         {
-            date_to_index(datetime.date(day=2, month=3, year=2021)): {
+            datetime.date(day=2, month=3, year=2021): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.SECTION_104,
@@ -363,7 +362,7 @@ test_basic_data = [
                     ),
                 ],
             },
-            date_to_index(datetime.date(day=3, month=3, year=2021)): {
+            datetime.date(day=3, month=3, year=2021): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.SECTION_104,
@@ -398,7 +397,7 @@ test_basic_data = [
                     ),
                 ],
             },
-            date_to_index(datetime.date(day=6, month=3, year=2021)): {
+            datetime.date(day=6, month=3, year=2021): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.SECTION_104,
@@ -483,7 +482,7 @@ test_basic_data = [
         62.05,  # Expected capital gain/loss
         None,
         {
-            date_to_index(datetime.date(day=2, month=3, year=2021)): {
+            datetime.date(day=2, month=3, year=2021): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.SECTION_104,
@@ -496,7 +495,7 @@ test_basic_data = [
                     ),
                 ],
             },
-            date_to_index(datetime.date(day=3, month=3, year=2021)): {
+            datetime.date(day=3, month=3, year=2021): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.SECTION_104,
@@ -528,7 +527,7 @@ test_basic_data = [
                         fees=Decimal("1.8012"),
                         new_quantity=Decimal(69.5),
                         new_pool_cost=Decimal("1741.67"),
-                        bed_and_breakfast_date_index=date_to_index(
+                        bed_and_breakfast_date_index=(
                             datetime.date(day=2, month=4, year=2021)
                         ),
                     ),
@@ -544,7 +543,7 @@ test_basic_data = [
                     ),
                 ],
             },
-            date_to_index(datetime.date(day=6, month=3, year=2021)): {
+            datetime.date(day=6, month=3, year=2021): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.SECTION_104,
@@ -569,7 +568,7 @@ test_basic_data = [
                     ),
                 ],
             },
-            date_to_index(datetime.date(day=2, month=4, year=2021)): {
+            datetime.date(day=2, month=4, year=2021): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.BED_AND_BREAKFAST,
@@ -642,7 +641,7 @@ test_basic_data = [
         62.05,  # Expected capital gain/loss
         None,
         {
-            date_to_index(datetime.date(day=2, month=3, year=2021)): {
+            datetime.date(day=2, month=3, year=2021): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.SECTION_104,
@@ -655,7 +654,7 @@ test_basic_data = [
                     ),
                 ],
             },
-            date_to_index(datetime.date(day=3, month=3, year=2021)): {
+            datetime.date(day=3, month=3, year=2021): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.SECTION_104,
@@ -688,7 +687,7 @@ test_basic_data = [
                         new_quantity=Decimal(10),
                         new_pool_cost=Decimal("250.60"),
                         bed_and_breakfast_date_index=(
-                            date_to_index(datetime.date(day=5, month=3, year=2021))
+                            datetime.date(day=5, month=3, year=2021)
                         ),
                     ),
                     CalculationEntry(
@@ -701,12 +700,12 @@ test_basic_data = [
                         new_quantity=Decimal(0),
                         new_pool_cost=Decimal(0),
                         bed_and_breakfast_date_index=(
-                            date_to_index(datetime.date(day=2, month=4, year=2021))
+                            datetime.date(day=2, month=4, year=2021)
                         ),
                     ),
                 ],
             },
-            date_to_index(datetime.date(day=5, month=3, year=2021)): {
+            datetime.date(day=5, month=3, year=2021): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.BED_AND_BREAKFAST,
@@ -719,7 +718,7 @@ test_basic_data = [
                     ),
                 ],
             },
-            date_to_index(datetime.date(day=6, month=3, year=2021)): {
+            datetime.date(day=6, month=3, year=2021): {
                 "sell$FOO": [
                     CalculationEntry(
                         RuleType.BED_AND_BREAKFAST,
@@ -731,7 +730,7 @@ test_basic_data = [
                         new_quantity=Decimal(69.5),
                         new_pool_cost=Decimal(1741.6700),
                         bed_and_breakfast_date_index=(
-                            date_to_index(datetime.date(day=2, month=4, year=2021))
+                            datetime.date(day=2, month=4, year=2021)
                         ),
                     ),
                     CalculationEntry(
@@ -746,7 +745,7 @@ test_basic_data = [
                     ),
                 ],
             },
-            date_to_index(datetime.date(day=2, month=4, year=2021)): {
+            datetime.date(day=2, month=4, year=2021): {
                 "buy$FOO": [
                     CalculationEntry(
                         RuleType.BED_AND_BREAKFAST,
@@ -773,15 +772,12 @@ def test_basic(
     tax_year: int,
     broker_transactions: list[BrokerTransaction],
     expected: float,
-    gbp_prices: dict[int, Decimal] | None,
+    gbp_prices: dict[datetime.date, Decimal] | None,
     calculation_log: CalculationLog | None,
 ) -> None:
     """Generate basic tests for test data."""
     if gbp_prices is None:
-        gbp_prices = {
-            date_to_index(t.date.replace(day=1)): Decimal(1)
-            for t in broker_transactions
-        }
+        gbp_prices = {(t.date.replace(day=1)): Decimal(1) for t in broker_transactions}
     converter = CurrencyConverter(gbp_prices)
     initial_prices = InitialPrices({})
     calculator = CapitalGainsCalculator(tax_year, converter, initial_prices)


### PR DESCRIPTION
As mentioned in the title we don't need to pass for an intermediate abstractions as dates are hashable and sortable already