### PR TITLE
Don't add automerge label in Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    labels:
-      - "dependencies"
-      - "automerge"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
-    labels:
-      - "dependencies"
-      - "automerge"


### PR DESCRIPTION
If I understand it correctly, it shouldn't be needed.