### PR TITLE
Fix calculation with sales in last day of tax year

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -535,7 +535,7 @@ class CapitalGainsCalculator:
         calculation_log: CalculationLog = {}
         for date_index in (
             begin_index + datetime.timedelta(days=x)
-            for x in range(0, (end_index - begin_index).days)
+            for x in range(0, (end_index - begin_index).days + 1)
         ):
             if date_index in acquisition_list:
                 for symbol in acquisition_list[date_index]:


### PR DESCRIPTION
The last day of tax year is included in the tax year.
Previously, a sale in the last day of the tax year was not
counted and produced a result with 0 disposal.

The previous code was off-by-one; it used the amount of days
in the period being checked as an argument to range(), but the end
in range() is exclusive.

To illustrate: if being_index and end_index are the same,
end_index - begin_index will be 0. Then we will do range(0, 0), which
is empty. But it should be one day instead! (the first and last day of
the imaginary tax year).

Note: I found this out exactly because I had one disposal in the last
day of the tax year!