### PR TITLE
Parse json numbers directly as Decimals in Schwab Equity Award parser.

### DIFF
--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -28,6 +28,10 @@ SETTLEMENT_DELAY = 2 * CustomBusinessDay(calendar=USFederalHolidayCalendar())
 
 # We want enough decimals to cover what Schwab gives us (up to 4 decimals)
 # divided by the share-split factor (20), so we keep 6 decimals.
+# We don't want more decimals than necessary or we risk converting
+# the float number format approximations into Decimals
+# (e.g. a number 1.0001 in JSON may become 1.00010001 when parsed
+# into float, but we want to get Decimal('1.0001'))
 ROUND_DIGITS = 6
 
 JsonRowType = Any  # type: ignore

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -92,7 +92,7 @@ def action_from_str(label: str) -> ActionType:
 def _decimal_from_str(price_str: str) -> Decimal:
     """Convert a number as string to a Decimal.
 
-    Remove $ sign, and coma thousand separators so as to handle dollar amounts
+    Remove $ sign, and comma thousand separators so as to handle dollar amounts
     such as "$1,250.00".
     """
     return Decimal(price_str.replace("$", "").replace(",", ""))

--- a/tests/test_schwab_equity_award_json.py
+++ b/tests/test_schwab_equity_award_json.py
@@ -8,73 +8,54 @@ from cgt_calc.model import ActionType
 from cgt_calc.parsers import schwab_equity_award_json
 
 
-def test_get_decimal_or_default_present_int() -> None:
-    """Test get_decimal_or_default() on an int."""
-    assert schwab_equity_award_json._get_decimal_or_default(  # pylint: disable=W0212
-        {"key": 1}, "key"
-    ) == Decimal(1)
-
-
-def test_get_decimal_or_default_present_float() -> None:
-    """Test get_decimal_or_default() on a float."""
-    assert schwab_equity_award_json._get_decimal_or_default(  # pylint: disable=W0212
-        {"key": 1.0}, "key"
-    ) == Decimal(1.0)
-
-
-def test_get_decimal_or_default_absent() -> None:
-    """Test get_decimal_or_default() on absent key."""
-    assert schwab_equity_award_json._get_decimal_or_default(  # pylint: disable=W0212
-        {"key": 1}, "otherkey", Decimal(0)
-    ) == Decimal(0)
-
-
-def test_price_from_str() -> None:
-    """Test _price_from_str()."""
-    assert schwab_equity_award_json._price_from_str(  # pylint: disable=W0212
+def test_decimal_from_str() -> None:
+    """Test _decimal_from_str()."""
+    assert schwab_equity_award_json._decimal_from_str(  # pylint: disable=W0212
         "$123,456.23"
     ) == Decimal("123456.23")
 
 
-def test_price_from_str_or_float_str() -> None:
-    """Test _price_from_str_or_float() on string."""
-    assert schwab_equity_award_json._price_from_str_or_float(  # pylint: disable=W0212
-        {"key": "123.45", "keySortValue": 67.89}, "key"
-    ) == Decimal("123.45")
+def test_decimal_from_number_or_str_both() -> None:
+    """Test _decimal_from_number_or_str() on float."""
+    assert (
+        schwab_equity_award_json._decimal_from_number_or_str(  # pylint: disable=W0212
+            {"key": "123.45", "keySortValue": Decimal("67.89")}, "key"
+        )
+        == Decimal("67.89")
+    )
 
 
-def test_price_from_str_or_float_str_null() -> None:
-    """Test _price_from_str_or_float() on None string."""
-    assert schwab_equity_award_json._price_from_str_or_float(  # pylint: disable=W0212
-        {"key": None, "keySortValue": 67.89}, "key"
-    ) == Decimal("67.89")
+def test_decimal_from_number_or_str_float_null() -> None:
+    """Test _decimal_from_number_or_str() on None float."""
+    assert (
+        schwab_equity_award_json._decimal_from_number_or_str(  # pylint: disable=W0212
+            {"key": "67.89", "keySortValue": None}, "key"
+        )
+        == Decimal("67.89")
+    )
 
 
-def test_price_from_str_or_float_float_default_suffix() -> None:
-    """Test _price_from_str_or_float_default_suffix() on float.
-
-    With the default suffix.
-    """
-    assert schwab_equity_award_json._price_from_str_or_float(  # pylint: disable=W0212
-        {"keySortValue": 67.89}, "key"
-    ) == Decimal("67.89")
-
-
-def test_price_from_str_or_float_float_custom_suffix() -> None:
-    """Test _price_from_str_or_float_default_suffix() on float.
+def test_decimal_from_number_or_str_float_custom_suffix() -> None:
+    """Test _decimal_from_number_or_str_default_suffix() on float.
 
     With a custom suffix.
     """
-    assert schwab_equity_award_json._price_from_str_or_float(  # pylint: disable=W0212
-        {"keyMySuffix": 67.89}, "key", "MySuffix"
-    ) == Decimal("67.89")
+    assert (
+        schwab_equity_award_json._decimal_from_number_or_str(  # pylint: disable=W0212
+            {"keyMySuffix": Decimal("67.89")}, "key", "MySuffix"
+        )
+        == Decimal("67.89")
+    )
 
 
-def test_price_from_str_or_float_default() -> None:
-    """Test _price_from_str_or_float() with absent keys."""
-    assert schwab_equity_award_json._price_from_str_or_float(  # pylint: disable=W0212
-        {"key": "123.45", "keySortValue": 67.89}, "otherkey"
-    ) == Decimal("0")
+def test_decimal_from_number_or_str_default() -> None:
+    """Test _decimal_from_number_or_str() with absent keys."""
+    assert (
+        schwab_equity_award_json._decimal_from_number_or_str(  # pylint: disable=W0212
+            {"key": "123.45", "keySortValue": 67.89}, "otherkey"
+        )
+        == Decimal("0")
+    )
 
 
 def test_schwab_transaction() -> None:


### PR DESCRIPTION
We use json.load() custom parser options. This is simpler and safer than the previous default loading as floats, then converted to Decimals as this exposes us to the imprecision of floats.

**Note**: this should be merged after https://github.com/KapJI/capital-gains-calculator/pull/305 and https://github.com/KapJI/capital-gains-calculator/pull/306 as this branch 'builds' on them to ensure this PR only adds a single logical change to 'main'.
