### PR TITLE
Add basic support for ticker renames

### DIFF
--- a/cgt_calc/const.py
+++ b/cgt_calc/const.py
@@ -37,3 +37,7 @@ DEFAULT_INITIAL_PRICES_FILE: Final = "initial_prices.csv"
 TEMPLATE_NAME: Final = "template.tex.j2"
 
 BED_AND_BREAKFAST_DAYS: Final = 30
+
+TICKER_RENAMES: Final[dict[str, str]] = {
+    "FB": "META",
+}

--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Final
 
+from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
 from cgt_calc.model import ActionType, BrokerTransaction
 
@@ -73,11 +74,13 @@ def _init_from_release_report(row_raw: list[str], filename: str) -> BrokerTransa
     quantity = _hacky_parse_decimal(row["Net Share Proceeds"])
     price = _hacky_parse_decimal(row["Price"][1:])
     amount = quantity * price
+    symbol = KNOWN_SYMBOL_DICT[row["Plan"]]
+    symbol = TICKER_RENAMES.get(symbol, symbol)
 
     return BrokerTransaction(
         date=datetime.strptime(row["Vest Date"], "%d-%b-%Y").date(),
         action=ActionType.STOCK_ACTIVITY,
-        symbol=KNOWN_SYMBOL_DICT[row["Plan"]],
+        symbol=symbol,
         description=row["Plan"],
         quantity=quantity,
         price=price,

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 import itertools
 from pathlib import Path
 
+from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import (
     ParsingError,
     SymbolMissingError,
@@ -29,6 +30,7 @@ class AwardPrices:
         # Award dates may go back for few days, depending on
         # holidays or weekends, so we do a linear search
         # in the past to find the award price
+        symbol = TICKER_RENAMES.get(symbol, symbol)
         for i in range(7):
             to_search = date - datetime.timedelta(days=i)
 
@@ -119,6 +121,8 @@ class SchwabTransaction(BrokerTransaction):
         self.raw_action = row[1]
         action = action_from_str(self.raw_action)
         symbol = row[2] if row[2] != "" else None
+        if symbol is not None:
+            symbol = TICKER_RENAMES.get(symbol, symbol)
         description = row[3]
         quantity = Decimal(row[4]) if row[4] != "" else None
         price = Decimal(row[5].replace("$", "")) if row[5] != "" else None
@@ -253,5 +257,6 @@ def _read_schwab_awards(
         symbol = lapse_main[2] if lapse_main[2] != "" else None
         price = Decimal(lapse_data[3].replace("$", "")) if lapse_data[3] != "" else None
         if symbol is not None and price is not None:
-            initial_prices[date][symbol] = price
+            symbol = TICKER_RENAMES.get(symbol, symbol)
+            initial_prices[date][symbol] = price  # type: ignore[index]
     return AwardPrices(award_prices=dict(initial_prices))

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -19,6 +19,7 @@ from typing import Any
 from pandas.tseries.holiday import USFederalHolidayCalendar  # type: ignore
 from pandas.tseries.offsets import CustomBusinessDay  # type: ignore
 
+from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType, BrokerTransaction
 from cgt_calc.util import round_decimal
@@ -140,6 +141,7 @@ class SchwabTransaction(BrokerTransaction):
         self.raw_action = row["action"]
         action = action_from_str(self.raw_action)
         symbol = row.get("symbol")
+        symbol = TICKER_RENAMES.get(symbol, symbol)
         quantity = _decimal_from_number_or_str(row, "quantity")
         amount = _decimal_from_number_or_str(row, "amount")
         fees = _decimal_from_number_or_str(row, "totalCommissionsAndFees")

--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -7,6 +7,7 @@ from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Final, Iterable, Iterator, List
 
+from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import InvalidTransactionError, ParsingError
 from cgt_calc.model import ActionType, BrokerTransaction
 
@@ -80,6 +81,7 @@ def parse_dividend_payments(
 
         dividend_date = parse_date(row_dict["Date Paid"])
         symbol = row_dict["Code"]
+        symbol = TICKER_RENAMES.get(symbol, symbol)
         description = row_dict["Comments"]
         broker = "Sharesight"
 

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Final
 
+from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType, BrokerTransaction
 
@@ -76,6 +77,8 @@ class Trading212Transaction(BrokerTransaction):
         self.raw_action = row["Action"]
         action = action_from_str(self.raw_action, filename)
         symbol = row["Ticker"] if row["Ticker"] != "" else None
+        if symbol is not None:
+            symbol = TICKER_RENAMES.get(symbol, symbol)
         description = row["Name"]
         quantity = decimal_or_none(row["No. of shares"])
         self.price_foreign = decimal_or_none(row["Price / share"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,5 @@ show_error_codes = true
 strict = true
 disallow_any_explicit = true
 disallow_any_unimported = true
-show_none_errors = true
 warn_no_return = true
 warn_unreachable = true


### PR DESCRIPTION
- FB was renamed to META. Replace symbol name even for older entries to make them match.
- Remove outdated mypy setting.