### PR TITLE
Add the Wire Sent transfer action to the Schwab parser

### DIFF
--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -55,6 +55,7 @@ def action_from_str(label: str) -> ActionType:
         "Misc Cash Entry",
         "Service Fee",
         "Wire Funds",
+        "Wire Sent",
         "Funds Received",
         "Journal",
         "Cash In Lieu",


### PR DESCRIPTION
Example:
```
"06/24/2022","Wire Sent","","WIRED FUNDS DISBURSED","","","","-$666.66"
"06/24/2022","Misc Cash Entry","","WAIVE WIRE FEE","","","","$6.66"
"06/24/2022","Service Fee","","WIRED FUNDS FEE","","","","-$6.66"
"05/23/2022","Wire Sent","","WIRED FUNDS DISBURSED","","","","-$666.66"
"05/23/2022","Misc Cash Entry","","WAIVE WIRE FEE","","","","$6.66"
```