### PR TITLE
Calculate unrealized gains

### DIFF
--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -104,6 +104,16 @@ def create_parser() -> argparse.ArgumentParser:
         default=True,
     )
     parser.add_argument(
+        "--unrealized-gains",
+        dest="calc_unrealized_gains",
+        action="store_true",
+        default=False,
+        help=(
+            "show an estimation of the gains/loss you would incur"
+            " if you were to sell your holdings, under the standard 104 rule."
+        ),
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="enable extra logging",

--- a/cgt_calc/current_price_fetcher.py
+++ b/cgt_calc/current_price_fetcher.py
@@ -1,0 +1,38 @@
+"""Obtain current prices to calculate unrealized gains."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from typing import Optional
+
+import yfinance as yf  # type: ignore
+
+from .currency_converter import CurrencyConverter
+
+
+class CurrentPriceFetcher:
+    """Converter which holds rate history."""
+
+    def __init__(
+        self,
+        converter: CurrencyConverter,
+        current_prices_data: dict[str, Decimal | None] | None = None,
+    ):
+        """Load data from exchange_rates_file and optionally from initial_data."""
+        self.current_prices_data = current_prices_data
+        self.converter = converter
+
+    def get_current_market_price(self, symbol: str) -> Optional[Decimal]:
+        """Given a symbol gets the current market price."""
+        if self.current_prices_data is not None and symbol in self.current_prices_data:
+            return self.current_prices_data[symbol]
+
+        ticker = yf.Ticker(symbol).info
+        if not ticker or "currentPrice" not in ticker:
+            return None
+        market_price_str = ticker["currentPrice"]
+        market_price_usd = Decimal(format(market_price_str, ".15g"))
+        return self.converter.to_gbp(
+            market_price_usd, "USD", datetime.datetime.now().date()
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ Jinja2 = ">=2.11.3,<4.0.0"
 pandas = "^2.0.3"
 requests = "^2.27.1"
 types-requests = "^2.27.7"
+yfinance = "^0.2.36"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.1"

--- a/tests/test_data/calc_test_data.py
+++ b/tests/test_data/calc_test_data.py
@@ -100,7 +100,9 @@ calc_basic_data = [
             ),
         ],
         1.00,  # Expected capital gain/loss
-        None,
+        None,  # Expected unrealized gains
+        None,  # GBP/USD prices
+        None,  # Current prices
         {
             datetime.date(day=1, month=5, year=2020): {
                 "buy$FOO": [
@@ -169,7 +171,9 @@ calc_basic_data = [
         ],
         # exact amount would be £629+2/3
         629.66,  # Expected capital gain/loss
-        None,
+        None,  # Expected unrealized gains
+        None,  # GBP/USD prices
+        None,  # Current prices
         {
             datetime.date(day=1, month=5, year=2020): {
                 "sell$LOB": [
@@ -233,7 +237,9 @@ calc_basic_data = [
             ),
         ],
         -100,  # Expected capital gain/loss
-        None,
+        None,  # Expected unrealized gains
+        None,  # GBP/USD prices
+        None,  # Current prices
         {
             datetime.date(day=30, month=8, year=2020): {
                 "sell$MSP": [
@@ -325,7 +331,9 @@ calc_basic_data = [
             ),
         ],
         222.82,  # Expected capital gain/loss
-        None,
+        None,  # Expected unrealized gains
+        None,  # GBP/USD prices
+        None,  # Current prices
         {
             datetime.date(day=2, month=3, year=2021): {
                 "buy$FOO": [
@@ -458,7 +466,9 @@ calc_basic_data = [
             ),
         ],
         62.05,  # Expected capital gain/loss
-        None,
+        None,  # Expected unrealized gains
+        None,  # GBP/USD prices
+        None,  # Current prices
         {
             datetime.date(day=2, month=3, year=2021): {
                 "buy$FOO": [
@@ -617,7 +627,9 @@ calc_basic_data = [
             ),
         ],
         62.05,  # Expected capital gain/loss
-        None,
+        None,  # Expected unrealized gains
+        None,  # GBP/USD prices
+        None,  # Current prices
         {
             datetime.date(day=2, month=3, year=2021): {
                 "buy$FOO": [
@@ -778,7 +790,9 @@ calc_basic_data = [
             ),
         ],
         -41.16,  # Expected capital gain/loss
-        None,
+        None,  # Expected unrealized gains
+        None,  # GBP/USD prices
+        None,  # Current prices
         {
             datetime.date(day=25, month=6, year=2023): {
                 "sell$FOO": [
@@ -879,7 +893,9 @@ calc_basic_data = [
             ),
         ],
         62.94,  # Expected capital gain/loss
-        None,
+        None,  # Expected unrealized gains
+        None,  # GBP/USD prices
+        None,  # Current prices
         {
             datetime.date(day=25, month=6, year=2023): {
                 "sell$FOO": [

--- a/tests/test_data/calc_test_data_2.py
+++ b/tests/test_data/calc_test_data_2.py
@@ -1,0 +1,48 @@
+"""Additional tests for calc."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+
+from cgt_calc.model import CalculationEntry, RuleType
+from tests.test_data.calc_test_data import buy_transaction, transfer_transaction
+
+calc_basic_data_2 = [
+    pytest.param(
+        2023,  # tax year
+        [
+            transfer_transaction(datetime.date(day=1, month=5, year=2023), 5000),
+            buy_transaction(
+                date=datetime.date(day=1, month=5, year=2023),
+                symbol="FOO",
+                quantity=3,
+                price=5,
+                fees=1,
+                amount=-16,
+            ),
+        ],
+        0.0,  # Expected capital gain/loss
+        2.0,  # Expected unrealized gains
+        None,  # GBP/USD prices
+        {"FOO": 6},  # Current prices
+        {
+            datetime.date(day=1, month=5, year=2023): {
+                "buy$FOO": [
+                    CalculationEntry(
+                        RuleType.SECTION_104,
+                        quantity=Decimal(3),
+                        amount=Decimal(-16),
+                        allowable_cost=Decimal(16),
+                        fees=Decimal(1),
+                        new_quantity=Decimal(3),
+                        new_pool_cost=Decimal(16),
+                    ),
+                ],
+            },
+        },
+        id="unrealized_gains_test",
+    ),
+]


### PR DESCRIPTION
This introduces unrealized gains calculations (proposed in #495). This is an estimation of the amount of gains/loss you could have if you sell all your shares. Features:
- The flag `--unrealized-gains` to enable it.
- Breakdown by symbol.
- Uses yahoo finance api to get the current market prices (it shows unknown and a warning when it can't fetch it).
- No changes to the PDF report, only the console output.

Preview of the output:
```
Portfolio at the end of 2023/2024 tax year:
  FOO: 423.00, £10000.00 (unrealized gains: £1000.00)
  UNKNOWN_COMPANY: 200.00, £400.00 (unrealized gains: unknown)
For tax year 2023/2024:
Number of disposals: 0
Disposal proceeds: £0.00
Allowable costs: £0.00
Capital gain: £0.00
Capital loss: £0.00
Total capital gain: £0.00
Taxable capital gain: £0
Total unrealized gains: £1000.00
WARNING: Some unrealized gains couldn't be calculated. Take a look at the symbols with unknown unrealized gains above and factor in their prices.

Generate calculations report
All done!
```