### PR TITLE
Add parsing support for gift transactions (Schwab Equity Awards JSON).

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -305,6 +305,10 @@ class CapitalGainsCalculator:
                 self.add_disposal(transaction)
                 if self.date_in_tax_year(transaction.date):
                     total_sells += self.converter.to_gbp_for(amount, transaction)
+            elif transaction.action is ActionType.GIFT:
+                raise NotImplementedError(
+                    f"{transaction.action} is not currently supported ({transaction})"
+                )
             elif transaction.action is ActionType.FEE:
                 amount = get_amount_or_fail(transaction)
                 new_balance += amount

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -66,6 +66,7 @@ class ActionType(Enum):
     WIRE_FUNDS_RECEIVED = 14
     STOCK_SPLIT = 15
     CASH_MERGER = 16
+    GIFT = 17
 
 
 @dataclass

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -148,6 +148,9 @@ def action_from_str(label: str) -> ActionType:
     if label == "Wire Funds Received":
         return ActionType.WIRE_FUNDS_RECEIVED
 
+    if label == "Gift":
+        return ActionType.GIFT
+
     raise ParsingError("schwab transactions", f"Unknown action: {label}")
 
 
@@ -222,6 +225,17 @@ class SchwabTransaction(BrokerTransaction):
                 f"{details[names.award_date]} "
                 f"(ID {details[names.award_id]})"
             )
+        elif row[names.action] == "Gift":
+            if OPTIONAL_DETAILS_NAME in row[names.transac_details][0]:
+                details = row[names.transac_details][0]["Details"]
+            else:
+                details = row[names.transac_details][0]
+            date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
+            if any((row[names.amount], row[names.fees])):
+                raise ParsingError(file, "Unexpected fees or amount for gifted shares.")
+            price = None
+            # Note that currently the default currency is used, because the model does
+            # not support a None currency.
         elif row[names.action] == "Sale":
             # Schwab's data export shows the settlement date,
             # whereas HMRC wants the trade date:

--- a/tests/test_data/schwab_equity_award_v1.json
+++ b/tests/test_data/schwab_equity_award_v1.json
@@ -1,6 +1,44 @@
 {
     "transactions": [
         {
+            "typeName": "DisbursementViewModel",
+            "eventDateSortValue": "2022-11-20T00:00:00",
+            "eventDate": "11/20/2022",
+            "action": "Gift",
+            "symbol": "GOOG",
+            "quantitySortValue": 2.0,
+            "quantity": "2",
+            "description": "Share Transfer",
+            "totalCommissionsAndFeesSortValue": null,
+            "totalCommissionsAndFees": null,
+            "disbursementElection": null,
+            "amountSortValue": null,
+            "amount": null,
+            "transactionDetails": [
+                {
+                    "shareLotType": "RS",
+                    "quantity": "2",
+                    "vestDate": "03/25/2021",
+                    "vestFMV": "$2,045.06",
+                    "grantId": "C111111",
+                    "typeName": "DisbursementDetail",
+                    "fieldNameToDisplayValueLookup": {
+                        "Type": "RS",
+                        "Shares": "53",
+                        "PurchaseDate": null,
+                        "PurchasePrice": null,
+                        "PurchaseFairMarketValue": null,
+                        "SubscriptionDate": null,
+                        "SubscriptionFairMarketValue": null,
+                        "DispositionType": null,
+                        "VestDate": "03/25/2021",
+                        "VestFairMarketValue": "$2,045.06",
+                        "GrantId": "C111111"
+                    }
+                }
+            ]
+        },
+        {
             "typeName": "ShareSaleViewModel",
             "eventDateSortValue": "2022-11-16:00:00",
             "eventDate": "11/16/2022",

--- a/tests/test_data/schwab_equity_award_v2.json
+++ b/tests/test_data/schwab_equity_award_v2.json
@@ -3,6 +3,33 @@
     "ToDate": "12/23/2023",
     "Transactions": [
         {
+            "Date": "09/29/2023",
+            "Action": "Gift",
+            "Symbol": "GOOG",
+            "Quantity": "2",
+            "Description": "Share Transfer",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "2",
+                        "PurchaseDate": null,
+                        "PurchasePrice": null,
+                        "PurchaseFairMarketValue": null,
+                        "SubscriptionDate": null,
+                        "SubscriptionFairMarketValue": null,
+                        "DispositionType": null,
+                        "VestDate": "09/25/2023",
+                        "VestFairMarketValue": "$131.25",
+                        "GrantId": "C987654"
+                    }
+                }
+            ]
+        },
+        {
             "Date": "09/27/2023",
             "Action": "Deposit",
             "Symbol": "GOOG",

--- a/tests/test_schwab_equity_award_json.py
+++ b/tests/test_schwab_equity_award_json.py
@@ -95,6 +95,15 @@ def test_schwab_transaction_v1() -> None:
     assert transactions[3].amount == Decimal("25745")
     assert transactions[3].fees == Decimal("0.50")
 
+    assert transactions[4].date == datetime.date(2022, 11, 20)
+    assert transactions[4].action == ActionType.GIFT
+    assert transactions[4].symbol == "GOOG"
+    assert transactions[4].quantity == Decimal("2")
+    assert transactions[4].price is None
+    assert transactions[4].fees == Decimal("0")
+    assert transactions[4].currency == "USD"
+    assert transactions[4].broker == "Charles Schwab"
+
 
 def test_schwab_transaction_v2() -> None:
     """Test read_schwab_equity_award_json_transactions() on v2 data."""
@@ -137,3 +146,12 @@ def test_schwab_transaction_v2() -> None:
     assert transactions[4].fees == Decimal("0")
     assert transactions[4].currency == "USD"
     assert transactions[4].broker == "Charles Schwab"
+
+    assert transactions[5].date == datetime.date(2023, 9, 29)
+    assert transactions[5].action == ActionType.GIFT
+    assert transactions[5].symbol == "GOOG"
+    assert transactions[5].quantity == Decimal("2")
+    assert transactions[5].price is None
+    assert transactions[5].fees == Decimal("0")
+    assert transactions[5].currency == "USD"
+    assert transactions[5].broker == "Charles Schwab"


### PR DESCRIPTION
This adds a new action type, as TRANSFER seems to deal with money transfers rather than share transfers, and SALEs also involve money whereas gifted shares do not.

The calculation code will raise a NotImplementedError if it encounters one of these transactions.

This may help #510. This contribution has been developed in my spare time.