### PR TITLE
Pin Alpine version to 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.19
 
 RUN apk --no-cache add \
     inkscape \


### PR DESCRIPTION
texmf-dist-science is not available on Alpine "edge" branch, nor on v3.20. The latest version where it is available is 3.19, so use that.

fixes KapJI/capital-gains-calculator#530