### PR TITLE
Fix sale dates in schwab_equity_award_json.

### DIFF
--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -14,4 +14,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5.0.0
+        uses: crazy-max/ghaction-github-labeler@v5.1.0

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -21,16 +21,11 @@ import json
 from pathlib import Path
 from typing import Any, Final
 
-from pandas.tseries.holiday import USFederalHolidayCalendar
-from pandas.tseries.offsets import CustomBusinessDay
-
 from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType, BrokerTransaction
 from cgt_calc.util import round_decimal
 
-# Delay between a (sale) trade, and when it is settled.
-SETTLEMENT_DELAY: Final = 2 * CustomBusinessDay(calendar=USFederalHolidayCalendar())
 OPTIONAL_DETAILS_NAME: Final = "Details"
 FIELD_TO_SCHEMA: Final = {"transactions": 1, "Transactions": 2}
 
@@ -227,12 +222,7 @@ class SchwabTransaction(BrokerTransaction):
                 f"(ID {details[names.award_id]})"
             )
         elif row[names.action] == "Sale":
-            # Schwab's data export shows the settlement date,
-            # whereas HMRC wants the trade date:
-            date = (
-                datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
-                - SETTLEMENT_DELAY
-            ).date()  # type: ignore[attr-defined]
+            date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
 
             # Schwab's data export sometimes lacks decimals on Sales
             # quantities, in which case we infer it from number of shares in

--- a/tests/test_schwab_equity_award_json.py
+++ b/tests/test_schwab_equity_award_json.py
@@ -64,7 +64,7 @@ def test_schwab_transaction_v1() -> None:
     assert transactions[0].currency == "USD"
     assert transactions[0].broker == "Charles Schwab"
 
-    assert transactions[1].date == datetime.date(2022, 6, 10)
+    assert transactions[1].date == datetime.date(2022, 6, 14)
     assert transactions[1].action == ActionType.SELL
     assert transactions[1].quantity == Decimal("62.601495")
     assert transactions[1].price == Decimal("113.75")
@@ -76,7 +76,7 @@ def test_schwab_transaction_v1() -> None:
     assert transactions[2].price == Decimal("112.42")
     assert transactions[2].fees == Decimal("0")
 
-    assert transactions[3].date == datetime.date(2022, 11, 14)
+    assert transactions[3].date == datetime.date(2022, 11, 16)
     assert transactions[3].action == ActionType.SELL
     assert transactions[3].quantity == Decimal("12.549")
     assert transactions[3].price is not None
@@ -105,7 +105,7 @@ def test_schwab_transaction_v2() -> None:
     assert transactions[1].price == Decimal("106.78")
     assert transactions[1].fees == Decimal("0")
 
-    assert transactions[2].date == datetime.date(2023, 8, 29)
+    assert transactions[2].date == datetime.date(2023, 8, 31)
     assert transactions[2].action == ActionType.SELL
     assert transactions[2].quantity == Decimal("14.40")
     assert transactions[2].price == Decimal("137.90")


### PR DESCRIPTION
The previous logic was actually incorrect, as confirmed by comparing the output of cgt-calc with historical prices at https://www.nasdaq.com/market-activity/stocks/goog/historical.

This is because Schwab provides the trades date (which are the ones that matter for HMRC) and not the settlement dates as previously thought.