### PR TITLE
schwab_equity_award_json.py parser: avoid unnecessary quantity recalculation.

### DIFF
--- a/tests/test_data/schwab_equity_award_v2_rounding.json
+++ b/tests/test_data/schwab_equity_award_v2_rounding.json
@@ -1,0 +1,499 @@
+{
+    "FromDate": "01/01/2020",
+    "ToDate": "01/06/2020",
+    "Transactions": [
+        {
+            "Date": "01/15/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/14/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/14/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/13/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/13/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/12/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/12/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/11/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/11/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/10/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/10/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/09/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/09/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/08/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/08/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/07/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/07/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/06/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/06/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/05/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/05/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/04/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/04/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/03/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "01/03/2020",
+            "Action": "Deposit",
+            "Symbol": "GOOG",
+            "Quantity": "7",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "01/01/2020",
+                        "AwardId": "A111",
+                        "VestDate": "01/02/2020",
+                        "VestFairMarketValue": "$123.45"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "04/24/2020",
+            "Action": "Sale",
+            "Symbol": "GOOG",
+            "Quantity": "91",
+            "Description": "Share Sale",
+            "FeesAndCommissions": "$0.49",
+            "DisbursementElection": "Journal",
+            "Amount": "$9,326.42",
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/02/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/03/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/04/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/05/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/06/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/07/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/08/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/09/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/10/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/11/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/12/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/13/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "7",
+                        "SalePrice": "$102.4935",
+                        "SubscriptionDate": "",
+                        "SubscriptionFairMarketValue": "",
+                        "PurchaseDate": "",
+                        "PurchasePrice": "",
+                        "PurchaseFairMarketValue": "",
+                        "DispositionType": null,
+                        "GrantId": "A111",
+                        "VestDate": "01/14/2020",
+                        "VestFairMarketValue": "$123.41",
+                        "GrossProceeds": "$717.45"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This can introduce rounding errors.

This fixes https://github.com/KapJI/capital-gains-calculator/issues/574.

Basically, there's some code in `cgt_calc/parsers/schwab_equity_award_json.py`, which tries to work around some issues in data exported from Schwab:
```
            # Schwab's data export sometimes lacks decimals on Sales
            # quantities, in which case we infer it from number of shares in
            # sub-transactions, or failing that from the amount and salePrice.
```
This codepath is triggered unconditionally when an integer number of shares is sold - even when there isn't an issue with the exported data. This change makes that codepath conditional on there actually being an issue with the exported data.

Without the change in `cgt_calc/parsers/schwab_equity_award_json.py`, the test triggers the following error:
```
FAILED tests/test_schwab_equity_award_json.py::test_schwab_transaction_v2_rounding - AssertionError: assert Decimal('91.00001463507441935342241215') == Decimal('91')
```

The test data is fictional and purely there to reproduce the error, but it is plausible based on data I've seen and I have seen the rounding errors happen in real data.

Note that because quantities matter for S104 pool calculations this may introduce deltas in outputs between
calculations before and after this change. However, without this change you may run into asserts, depending
on what kinds of trades/gifts you make.

This contribution has been developed in my spare time. Disclaimer: I'm not a financial advisor/accountant.