### PR TITLE
Add schwab refund trx support

### DIFF
--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -87,6 +87,7 @@ def action_from_str(label: str) -> ActionType:
         "Cash In Lieu",
         "Visa Purchase",
         "MoneyLink Deposit",
+        "MoneyLink Adj",  # likely a returned transfer
     ]:
         return ActionType.TRANSFER
 

--- a/tests/test_data/schwab_cash_merger/transactions.csv
+++ b/tests/test_data/schwab_cash_merger/transactions.csv
@@ -2,4 +2,6 @@ Date,Action,Symbol,Description,Price,Quantity,Fees & Comm,Amount
 03/02/2021,Cash Merger,FOO,FOO INC,,,,$1000
 03/02/2021,Cash Merger Adj,FOO,FOO INC,,-100,,
 03/02/2021,Buy,FOO,FOO INC,$25,100,$6,-$2506
+07/01/2016,MoneyLink Adj,,Tfr BANK,,,,$10.00
+05/01/2016,MoneyLink Transfer,,Tfr BANK,,,,-$10.00
 03/01/2016,MoneyLink Transfer,,Tfr BANK,,,,$2506.00


### PR DESCRIPTION
I did an online transfer but the account had been migrated, the money came back to Schwab with this transaction type.