### PR TITLE
Update trading212 parser

### DIFF
--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -34,6 +34,7 @@ COLUMNS: Final[list[str]] = [
     "Transaction fee (GBP)",
     "Transaction fee",
     "Finra fee (GBP)",
+    "Finra fee",
     "Stamp duty (GBP)",
     "Notes",
     "ID",
@@ -41,6 +42,7 @@ COLUMNS: Final[list[str]] = [
     "Currency conversion fee",
     "Currency (Currency conversion fee)",
     "Currency (Transaction fee)",
+    "Currency (Finra fee)",
 ]
 
 
@@ -120,6 +122,14 @@ class Trading212Transaction(BrokerTransaction):
                 )
             self.transaction_fee += transaction_fee_foreign
         self.finra_fee = Decimal(row.get("Finra fee (GBP)") or "0")
+        finra_fee_foreign = Decimal(row.get("Finra fee") or "0")
+        if finra_fee_foreign > 0:
+            if row.get("Currency (Finra fee)") != "GBP":
+                raise ParsingError(
+                    filename,
+                    "Finra fee is not in GBP which is not supported yet",
+                )
+            self.finra_fee += finra_fee_foreign
         self.stamp_duty = Decimal(row.get("Stamp duty (GBP)") or "0")
         self.conversion_fee = Decimal(row.get("Currency conversion fee (GBP)") or "0")
         conversion_fee_foreign = Decimal(row.get("Currency conversion fee") or "0")

--- a/tests/test_data/trading212/from_2020-09-11_to_2021-04-02.csv
+++ b/tests/test_data/trading212/from_2020-09-11_to_2021-04-02.csv
@@ -1,9 +1,9 @@
-Action,Time,ISIN,Ticker,Name,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result (GBP),Total (GBP),Withholding tax,Currency (Withholding tax),Charge amount (GBP),Transaction fee (GBP),Finra fee (GBP),Notes,ID
+Action,Time,ISIN,Ticker,Name,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result (GBP),Total (GBP),Withholding tax,Currency (Withholding tax),Charge amount (GBP),Transaction fee (GBP),Finra fee,Currency (Finra fee),Notes,ID
 Deposit,2020-11-24 04:06:06,,,,,,,,,9000.00,,,9000.00,,,"Transaction ID: xxxxxxx",123
-Market buy,2020-11-24 14:33:50,US3696041033,GE,"General Electric",1.0000000000,10.74,USD,1.33080,,8.07,,,,,,,124
+Market buy,2020-11-24 14:33:50,US3696041033,GE,"General Electric",1.0000000000,10.74,USD,1.33080,,8.07,,,,,,GBP,,124
 Deposit,2020-11-24 14:33:50,,,,,,,,,8.08,,,8.08,,,"Free Shares Promotion",125
-Market buy,2020-11-25 14:30:08,US36467W1099,GME,"GameStop",100.0000000000,14.75,USD,1.33332,,1106.25,,,,,,,EOF604506992
-Limit buy,2020-11-27 14:30:11,US67066G1040,NVDA,"Nvidia",1.0000000000,535.00,USD,1.33413,,401.01,,,,,,,EOF609036047
-Limit buy,2021-01-26 15:40:51,US36467W1099,GME,"GameStop",100.0000000000,90.00,USD,1.37304,,6554.80,,,,,,,EOF896442730
-Market sell,2021-02-01 14:30:40,US36467W1099,GME,"GameStop",200.0000000000,225.00,USD,1.38661,-421.96,32453.25,,,,,,,EOF1022055909
-Dividend (Ordinary),2021-04-02 10:15:07,US67066G1040,NVDA,"Nvidia",1.0000000000,0.14,USD,Not available,,0.10,0.02,USD,,,,,
+Market buy,2020-11-25 14:30:08,US36467W1099,GME,"GameStop",100.0000000000,14.75,USD,1.33332,,1106.25,,,,,,GBP,,EOF604506992
+Limit buy,2020-11-27 14:30:11,US67066G1040,NVDA,"Nvidia",1.0000000000,535.00,USD,1.33413,,401.01,,,,,,GBP,,EOF609036047
+Limit buy,2021-01-26 15:40:51,US36467W1099,GME,"GameStop",100.0000000000,90.00,USD,1.37304,,6554.80,,,,,,GBP,,EOF896442730
+Market sell,2021-02-01 14:30:40,US36467W1099,GME,"GameStop",200.0000000000,225.00,USD,1.38661,-421.96,32453.25,,,,,,GBP,,EOF1022055909
+Dividend (Ordinary),2021-04-02 10:15:07,US67066G1040,NVDA,"Nvidia",1.0000000000,0.14,USD,Not available,,0.10,0.02,USD,,,,GBP,,


### PR DESCRIPTION
The Finra fee might appear in two columns now in trading212. This updates the parser to support that while keeping backwards compatibility with the previous version.