### PR TITLE
Update HMRC trade tariff API usage

### DIFF
--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -90,7 +90,7 @@ class CurrencyConverter:
         else:
             month_str = date.strftime("%Y-%m")
             url = (
-                "https://www.trade-tariff.service.gov.uk/api/v2/"
+                "https://www.trade-tariff.service.gov.uk/api/"
                 f"exchange_rates/files/monthly_xml_{month_str}.xml"
             )
         try:


### PR DESCRIPTION
https://www.trade-tariff.service.gov.uk/uk/api/v2/.. now returns 404, and according to the links [here](https://www.trade-tariff.service.gov.uk/exchange_rates/monthly), "https://www.trade-tariff.service.gov.uk/uk/api/" seems to be the correct one now