### PR TITLE
Add Security Transfer to list of actions

### DIFF
--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -88,6 +88,7 @@ def action_from_str(label: str) -> ActionType:
         "Visa Purchase",
         "MoneyLink Deposit",
         "MoneyLink Adj",  # likely a returned transfer
+        "Security Transfer",
     ]:
         return ActionType.TRANSFER
 


### PR DESCRIPTION
Have this on my transactions from last year, seems to be with certain types of ACH transactions.