### PR TITLE
Add interest and dividends breakdown per broker/symbol

### DIFF
--- a/tests/test_data/raw/expected_output.txt
+++ b/tests/test_data/raw/expected_output.txt
@@ -13,6 +13,8 @@ Final portfolio:
 Final balance:
   Unknown: -28486.60 (USD)
 Dividends: £2719.29
+  OTGLY: £7.86
+  OPRA: £2711.43
 Dividend taxes: £0.00
 Interest: £0.00
 Disposal proceeds: £11422.10

--- a/tests/test_data/test_run_with_example_files_output.txt
+++ b/tests/test_data/test_run_with_example_files_output.txt
@@ -15,6 +15,7 @@ Final balance:
   Trading212: 33391.30 (GBP)
   Morgan Stanley: 1.00 (USD)
 Dividends: £0.10
+  NVDA: £0.10
 Dividend taxes: £0.00
 Interest: £0.00
 Disposal proceeds: £42783.83

--- a/tests/test_data/test_run_with_sharesight_files_no_balance_check_output.txt
+++ b/tests/test_data/test_run_with_sharesight_files_no_balance_check_output.txt
@@ -13,7 +13,11 @@ Final balance:
   Sharesight: -17855.31 (GBP)
   Sharesight: 7474.05 (USD)
 Dividends: £6.92
+  FOO.NASDAQ: £3.92
+  FUND1.UKF: £3.00
 Dividend taxes: £1.78
+  FOO.NASDAQ: £0.78
+  FUND1.UKF: £1.00
 Interest: £0.00
 Disposal proceeds: £12999.61
 

--- a/tests/test_data/vanguard/expected_output.txt
+++ b/tests/test_data/vanguard/expected_output.txt
@@ -11,8 +11,10 @@ Final portfolio:
 Final balance:
   Vanguard: 1423.59 (GBP)
 Dividends: £396.66
+  FOO: £396.66
 Dividend taxes: £0.00
-Interest: £0.00
+Interest: £0.41
+  Vanguard: £0.41
 Disposal proceeds: £104.06
 
 

--- a/tests/test_data/vanguard/report.csv
+++ b/tests/test_data/vanguard/report.csv
@@ -1,10 +1,10 @@
 Date,Details,Amount,Balance
 08/03/2022,Deposit for investment purchases,15000,15000
 09/03/2022,"Bought 1,550 Foo ETF Distributing (FOO)",-14982.06,17.94
-01/04/2022,Cash Account Interest,0.41,18.35
-01/04/2022,Regular Deposit,150,168.35
-07/04/2022,Account Fee for the period 08-Jan-2022 to 07-Apr-2022,-14.05,154.3
-09/04/2022,DIV: FOO.XLON.GB @ GBP 0.4106,225.83,380.13
+10/04/2022,Cash Account Interest,0.41,18.35
+10/04/2022,Regular Deposit,150,168.35
+12/04/2022,Account Fee for the period 08-Jan-2022 to 07-Apr-2022,-14.05,154.3
+13/04/2022,DIV: FOO.XLON.GB @ GBP 0.4106,225.83,380.13
 25/05/2022,Deposit for Investment Purchases,30000,30380.13
 28/05/2022,Bought 294 Bar ETF – Accumulating (BAR),-29947.28,432.85
 17/07/2022,Sold 1 Bar ETF - Accumulating (BAR),104.06,536.91


### PR DESCRIPTION
Interests should be reported in different sections of self-assesment depending if they are UK or foreign.
Dividends in addition can be reported as Interest or Dividends based on the type of Fund (Bond vs Shares).
To ease out these I'm adding breakdown per broker of interest received and per symbol of dividends.

Changed tests appropriately