### PR TITLE
Tidy up README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ apt install texlive-latex-base
 
 ## Usage
 
--  You need to supply transaction history for each account you have. See below for per-broker instructions. The history needs to contain all transactions since the beginning, or at least since you first acquired the shares owned during the relevant tax years.
--  Once you have all your transactions from all your brokers you need to supply them together, for example to generate the report for the tax year 2020/21:
+-   You need to supply transaction history for each account you have. See below for per-broker instructions. The history needs to contain all transactions since the beginning, or at least since you first acquired the shares owned during the relevant tax years.
+-   Once you have all your transactions from all your brokers you need to supply them together, for example to generate the report for the tax year 2020/21:
 
 ```shell
 cgt-calc --year 2020 --schwab schwab_transactions.csv --trading212 trading212/ --mssb mmsb_report/
 ```
--  Run `cgt-calc --help` for the full list of settings.
--  If your broker is not listed below you can still try to use the raw format. We also welcome PRs for new parsers.
+-   Run `cgt-calc --help` for the full list of settings.
+-   If your broker is not listed below you can still try to use the raw format. We also welcome PRs for new parsers.
 
 ## Broker-specific instructions
 
@@ -85,7 +85,6 @@ You will need:
     You can provide a folder containing several files since Trading 212 limit the statements to 1 year periods.
     [See example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/trading212).
 
-
 Example usage for the tax year 2024/25:
 
 ```shell
@@ -103,7 +102,6 @@ You will need:
     Since Morgan Stanley generates multiple files in a single report, please specify a directory produced from the report download page.
     [See example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/mssb).
 
-
 Example usage for the tax year 2024/25:
 
 ```shell
@@ -119,16 +117,16 @@ You will need:
 
 -   **Exported transaction history from Sharesight.**
     Sharesight is a portfolio tracking tool with support for multiple brokers.
-    -  You will need the "All Trades" and "Taxable Income" reports since the beginning. Make sure to select "Since Inception" for the period, and "Not Grouping".
-    -  Export both reports to Excel or Google Sheets, save as CSV, and place them in the same folder.
-    -  [See example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/sharesight).
+    -   You will need the "All Trades" and "Taxable Income" reports since the beginning. Make sure to select "Since Inception" for the period, and "Not Grouping".
+    -   Export both reports to Excel or Google Sheets, save as CSV, and place them in the same folder.
+    -   [See example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/sharesight).
 
 Comments:
 
--  Sharesight aggregates transactions from multiple brokers, but doesn't necessarily have balance information.
-Use the `--no-balance-check` flag to avoid spurious errors.
+-   Sharesight aggregates transactions from multiple brokers, but doesn't necessarily have balance information.
+    Use the `--no-balance-check` flag to avoid spurious errors.
 
--  Since there is no direct support for equity grants, add `Stock Activity` as part of the comment associated with any vesting transactions - making sure they have the grant price filled ([see example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/sharesight)).
+-   Since there is no direct support for equity grants, add `Stock Activity` as part of the comment associated with any vesting transactions - making sure they have the grant price filled ([see example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/sharesight)).
 
 Example usage for the tax year 2024/25:
 
@@ -160,8 +158,8 @@ cgt-calc --year 2024 --vanguard vanguard.csv
 
 You will need:
 
--  **CSV using the RAW format.** If your broker isn't natively supported you might choose to convert whatever report you can produce into this basic format. 
-[See example](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/test_data/raw/test_data.csv)
+-   **CSV using the RAW format.** If your broker isn't natively supported you might choose to convert whatever report you can produce into this basic format. 
+    [See example](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/test_data/raw/test_data.csv)
 
 Example usage for the tax year 2024/25:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ apt install texlive-latex-base
 ```shell
 cgt-calc --year 2020 --schwab schwab_transactions.csv --trading212 trading212/ --mssb mmsb_report/
 ```
-cberrbblucd
+
 -   Run `cgt-calc --help` for the full list of settings.
 -   If your broker is not listed below you can still try to use the raw format. We also welcome PRs for new parsers.
 
@@ -159,7 +159,7 @@ cgt-calc --year 2024 --vanguard vanguard.csv
 
 You will need:
 
--   **CSV using the RAW format.** If your broker isn't natively supported you might choose to convert whatever report you can produce into this basic format. 
+-   **CSV using the RAW format.** If your broker isn't natively supported you might choose to convert whatever report you can produce into this basic format.
     [See example](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/test_data/raw/test_data.csv)
 
 Example usage for the tax year 2024/25:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cgt-calc --year 2020 --schwab schwab_transactions.csv --trading212 trading212/ -
 ## Broker-specific instructions
 
 <details>
-    <summary>🔍 Instructions for broker "Charles Schwab"</summary>
+    <summary>🏦 Instructions for Charles Schwab</summary>
 
 You will need:
 
@@ -78,7 +78,7 @@ _Note: For historic reasons, it is possible to provide the Equity Awards history
 </details>
  <br />
 <details>
-    <summary>🔍 Instructions for broker "Trading212"</summary>
+    <summary>🏦 Instructions for Trading212</summary>
 
 You will need:
 
@@ -95,7 +95,7 @@ cgt-calc --year 2024 --trading212 trading212_trxs_dir/
 </details>
  <br />
 <details>
-    <summary>🔍 Instructions for broker "Morgan Stanley"</summary>
+    <summary>🏦 Instructions for Morgan Stanley</summary>
 
 You will need:
 
@@ -112,7 +112,7 @@ cgt-calc --year 2024 --mssb morgan_stanley_trxs_dir/
 </details>
  <br />
 <details>
-    <summary>🔍 Instructions for broker "Sharesight"</summary>
+    <summary>🏦 Instructions for Sharesight</summary>
 
 You will need:
 
@@ -138,7 +138,7 @@ cgt-calc --year 2024 --no-balance-check --sharesight sharesight_trxs_dir/
 </details>
  <br />
 <details>
-    <summary>🔍 Instructions for broker "Vanguard"</summary>
+    <summary>🏦 Instructions for Vanguard</summary>
 
 You will need:
 
@@ -155,7 +155,7 @@ cgt-calc --year 2024 --vanguard vanguard.csv
 </details>
  <br />
 <details>
-    <summary>🔍 Instructions for RAW format</summary>
+    <summary>🏦 Instructions for RAW format</summary>
 
 You will need:
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ apt install texlive-latex-base
 
 ## Usage
 
-- You need to supply transaction history for each account you have. See below for per-broker instructions. The history needs to contain all transactions since the beginning, or at least since you first acquired the shares owned during the relevant tax years.
-- Once you have all your transactions from all your brokers you need to supply them together, for example to generate the report for the tax year 2020/21:
+-  You need to supply transaction history for each account you have. See below for per-broker instructions. The history needs to contain all transactions since the beginning, or at least since you first acquired the shares owned during the relevant tax years.
+-  Once you have all your transactions from all your brokers you need to supply them together, for example to generate the report for the tax year 2020/21:
+
 ```shell
 cgt-calc --year 2020 --schwab schwab_transactions.csv --trading212 trading212/ --mssb mmsb_report/
 ```
-- Run `cgt-calc --help` for the full list of settings.
-- If your broker is not listed below you can still try to use the raw format. We also welcome PRs for new parsers.
+-  Run `cgt-calc --help` for the full list of settings.
+-  If your broker is not listed below you can still try to use the raw format. We also welcome PRs for new parsers.
 
 ## Broker-specific instructions
 
@@ -58,6 +59,7 @@ cgt-calc --year 2020 --schwab schwab_transactions.csv --trading212 trading212/ -
     <summary>🔍 Instructions for broker "Charles Schwab"</summary>
 
 You will need:
+
 -   **Exported transaction history in CSV format.**
     Schwab only allows to download transaction for the last 4 years. If you require more, you can download the history in 4-year chunks and combine them.
     [See example](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/test_data/schwab_transactions.csv).
@@ -65,11 +67,12 @@ You will need:
     Only applicable if you receive equity awards in your account (e.g. for Alphabet/Google employees). Follow the same procedure as in the normal transaction history but selecting your Equity Award account.
 
 Example usage for the tax year 2020/21:
+
 ```shell
 cgt-calc --year 2020 --schwab schwab_transactions.csv --schwab-award schwab_awards.csv
 ```
 
-*Note: For historic reasons, it is possible to provide the Equity Awards history in JSON format with `--schwab_equity_award_json`. Instructions are available at the top of this [parser file](../main/cgt_calc/parsers/schwab_equity_award_json.py). Please use the CSV method above if possible.*
+_Note: For historic reasons, it is possible to provide the Equity Awards history in JSON format with `--schwab_equity_award_json`. Instructions are available at the top of this [parser file](../main/cgt_calc/parsers/schwab_equity_award_json.py). Please use the CSV method above if possible._
 
 </details>
  <br />
@@ -77,12 +80,14 @@ cgt-calc --year 2020 --schwab schwab_transactions.csv --schwab-award schwab_awar
     <summary>🔍 Instructions for broker "Trading212"</summary>
 
 You will need:
+
 -   **Exported transaction history from Trading 212.**
     You can provide a folder containing several files since Trading 212 limit the statements to 1 year periods.
     [See example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/trading212).
 
 
 Example usage for the tax year 2024/25:
+
 ```shell
 cgt-calc --year 2024 --trading212 trading212_trxs_dir/
 ```
@@ -93,12 +98,14 @@ cgt-calc --year 2024 --trading212 trading212_trxs_dir/
     <summary>🔍 Instructions for broker "Morgan Stanley"</summary>
 
 You will need:
+
 -   **Exported transaction history from Morgan Stanley.**
     Since Morgan Stanley generates multiple files in a single report, please specify a directory produced from the report download page.
-[See example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/mssb).
+    [See example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/mssb).
 
 
 Example usage for the tax year 2024/25:
+
 ```shell
 cgt-calc --year 2024 --mssb morgan_stanley_trxs_dir/
 ```
@@ -109,19 +116,22 @@ cgt-calc --year 2024 --mssb morgan_stanley_trxs_dir/
     <summary>🔍 Instructions for broker "Sharesight"</summary>
 
 You will need:
+
 -   **Exported transaction history from Sharesight.**
     Sharesight is a portfolio tracking tool with support for multiple brokers.
-    - You will need the "All Trades" and "Taxable Income" reports since the beginning. Make sure to select "Since Inception" for the period, and "Not Grouping".
-    - Export both reports to Excel or Google Sheets, save as CSV, and place them in the same folder.
-    - [See example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/sharesight).
+    -  You will need the "All Trades" and "Taxable Income" reports since the beginning. Make sure to select "Since Inception" for the period, and "Not Grouping".
+    -  Export both reports to Excel or Google Sheets, save as CSV, and place them in the same folder.
+    -  [See example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/sharesight).
 
 Comments:
-- Sharesight aggregates transactions from multiple brokers, but doesn't necessarily have balance information.
+
+-  Sharesight aggregates transactions from multiple brokers, but doesn't necessarily have balance information.
 Use the `--no-balance-check` flag to avoid spurious errors.
 
-- Since there is no direct support for equity grants, add `Stock Activity` as part of the comment associated with any vesting transactions - making sure they have the grant price filled ([see example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/sharesight)).
+-  Since there is no direct support for equity grants, add `Stock Activity` as part of the comment associated with any vesting transactions - making sure they have the grant price filled ([see example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/test_data/sharesight)).
 
 Example usage for the tax year 2024/25:
+
 ```shell
 cgt-calc --year 2024 --no-balance-check --sharesight sharesight_trxs_dir/
 ```
@@ -132,11 +142,13 @@ cgt-calc --year 2024 --no-balance-check --sharesight sharesight_trxs_dir/
     <summary>🔍 Instructions for broker "Vanguard"</summary>
 
 You will need:
+
 -   **Exported transaction history from Vanguard.**
     Vanguard can generate a report in Excel format with all transactions across all periods of time and all accounts (ISA, GA, etc). Grab the ones you're interested into (normally GA account) and put them in a single CSV file.
     [See example](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/test_data/vanguard/report.csv).
 
 Example usage for the tax year 2024/25:
+
 ```shell
 cgt-calc --year 2024 --vanguard vanguard.csv
 ```
@@ -147,10 +159,12 @@ cgt-calc --year 2024 --vanguard vanguard.csv
     <summary>🔍 Instructions for RAW format</summary>
 
 You will need:
-- **CSV using the RAW format.** If your broker isn't natively supported you might choose to convert whatever report you can produce into this basic format. 
+
+-  **CSV using the RAW format.** If your broker isn't natively supported you might choose to convert whatever report you can produce into this basic format. 
 [See example](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/test_data/raw/test_data.csv)
 
 Example usage for the tax year 2024/25:
+
 ```shell
 cgt-calc --year 2024 --raw sharesight_trxs_dir/
 ```
@@ -164,8 +178,6 @@ cgt-calc --year 2024 --raw sharesight_trxs_dir/
     [`initial_prices.csv`](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/resources/initial_prices.csv) comes pre-packaged, you need to use the same format. The program will inform when some required price is missing.
 -   **(Automatic) Monthly exchange rates prices from [gov.uk](https://www.gov.uk/government/collections/exchange-rates-for-customs-and-vat).** This is needed to convert foreign currencies into GBP amounts. `exchange_rates.csv` gets generated automatically using HMRC API, you need to use the same format if you want to override it.
 -   **Spin-off file.** Supplies extra information needed for spin-offs transactions through `--spin-offs-file`.
-
-
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ apt install texlive-latex-base
 ```shell
 cgt-calc --year 2020 --schwab schwab_transactions.csv --trading212 trading212/ --mssb mmsb_report/
 ```
+cberrbblucd
 -   Run `cgt-calc --help` for the full list of settings.
 -   If your broker is not listed below you can still try to use the raw format. We also welcome PRs for new parsers.
 


### PR DESCRIPTION
- I rewrote the Usage section, now each broker has separate collapsible instructions.
- I also noticed we had some confusions regarding how to load Schwab equity award data. This should make it clear that the CSV is the preferred format.
- Moved docker down below, usage instructions are more important.

<img width="638" height="430" alt="Screenshot 2025-09-23 at 21 32 38" src="https://github.com/user-attachments/assets/952d0080-89c6-41c5-9373-56252cd8e7c0" />
