### PR TITLE
Rename --schwab_equity_award_json arg

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -1334,11 +1334,11 @@ def main() -> int:
     args = create_parser().parse_args()
 
     if args.version:
-        print(f"cgt-calc {importlib.metadata.version(__package__)}")
+        LOGGER.info("cgt-calc %s", importlib.metadata.version(__package__))
         return 0
 
     if args.report == "":
-        print("error: report name can't be empty")
+        LOGGER.error("error: report name can't be empty")
         return 1
 
     default_logging_level = logging.DEBUG if args.verbose else logging.WARNING

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -212,7 +212,7 @@ class Dividend:
         return self.amount * self.tax_treaty.treaty_rate
 
 
-class CalculationEntry:  # noqa: SIM119 # this has non-trivial constructor
+class CalculationEntry:
     """Calculation entry for final report."""
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dependencies = [
   "Jinja2>=2.11.3,<4.0.0",
   "pandas>=2.2",
   "requests>=2.27.1",
-  "yfinance>=0.2.36",
   "requests-ratelimiter>=0.7.0",
+  "yfinance>=0.2.36",
 ]
 
 [project.urls]


### PR DESCRIPTION
It didn't follow naming for other arguments.

Added `DeprecatedAction` which allows to print deprecation warning when it's being used.