### PR TITLE
Don't print tracebacks by default

### DIFF
--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -11,16 +11,20 @@ if TYPE_CHECKING:
     from .model import BrokerTransaction
 
 
-class ParsingError(Exception):
+class CgtError(Exception):
+    """Base class for exceptions."""
+
+
+class ParsingError(CgtError):
     """Parsing error."""
 
     def __init__(self, file: str, message: str):
         """Initialise."""
-        self.message = f"While parsing {file}, {message}"
+        self.message = f"While parsing {file}: {message}"
         super().__init__(self.message)
 
 
-class InvalidTransactionError(Exception):
+class InvalidTransactionError(CgtError):
     """Invalid transaction error."""
 
     def __init__(self, transaction: BrokerTransaction, message: str):
@@ -94,7 +98,7 @@ class CalculatedAmountDiscrepancyError(InvalidTransactionError):
         )
 
 
-class CalculationError(Exception):
+class CalculationError(CgtError):
     """Calculation error."""
 
 

--- a/cgt_calc/parsers/__init__.py
+++ b/cgt_calc/parsers/__init__.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import datetime
 from decimal import Decimal
 from importlib import resources
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
@@ -33,6 +34,7 @@ INITIAL_PRICES_COLUMNS_NUM: Final = 3
 
 ISIN_TRANSLATION_HEADER: Final = ["ISIN", "symbol"]
 ISIN_TRANSLATION_COLUMNS_NUM: Final = len(ISIN_TRANSLATION_HEADER)
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -96,6 +98,7 @@ def read_broker_transactions(
 ) -> list[BrokerTransaction]:
     """Read transactions for all brokers."""
     transactions = []
+
     if schwab_transactions_file is not None:
         transactions += read_schwab_transactions(
             schwab_transactions_file, schwab_awards_transactions_file
@@ -134,6 +137,11 @@ def read_broker_transactions(
         transactions += read_vanguard_transactions(vanguard_transactions_file)
     else:
         print("INFO: No vanguard file provided")
+
+    if len(transactions) == 0:
+        LOGGER.warning("Found 0 broker transactions")
+    else:
+        print(f"Found {len(transactions)} broker transactions")
 
     transactions += read_eri_transactions(eri_raw_file)
 

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -238,7 +238,7 @@ def read_trading212_transactions(transactions_folder: str) -> list[BrokerTransac
             if len(cur_transactions) == 0:
                 LOGGER.warning("No transactions detected in file: %s", file)
             transactions += cur_transactions
-    # remove duplicates
+    # Remove duplicates
     transactions = list(set(transactions))
     transactions.sort(key=by_date_and_action)
     return list(transactions)

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -166,10 +166,9 @@ def read_vanguard_transactions(transactions_file: str) -> list[VanguardTransacti
 
             transactions.sort(key=by_date_and_action)
 
-    except FileNotFoundError:
-        LOGGER.warning(
-            "Couldn't locate Vanguard transactions file: %s", transactions_file
-        )
-        return []
+    except FileNotFoundError as err:
+        raise ParsingError(
+            transactions_file, "Couldn't locate Vanguard transactions file"
+        ) from err
 
     return transactions

--- a/tests/general/data/test_run_with_example_files_output.txt
+++ b/tests/general/data/test_run_with_example_files_output.txt
@@ -3,6 +3,7 @@ Parsing tests/trading212/data/from_2020-09-11_to_2021-04-02.csv...
 INFO: No sharesight file provided
 INFO: No raw file provided
 INFO: No vanguard file provided
+Found 27 broker transactions
 INFO: No ERI raw file provided
 First pass completed
 Final portfolio:

--- a/tests/raw/data/expected_output.txt
+++ b/tests/raw/data/expected_output.txt
@@ -4,6 +4,7 @@ INFO: No trading212 folder provided
 INFO: No mssb folder provided
 INFO: No sharesight file provided
 INFO: No vanguard file provided
+Found 16 broker transactions
 INFO: No ERI raw file provided
 First pass completed
 Final portfolio:

--- a/tests/schwab/data/2023/expected_output.txt
+++ b/tests/schwab/data/2023/expected_output.txt
@@ -4,6 +4,7 @@ INFO: No mssb folder provided
 INFO: No sharesight file provided
 INFO: No raw file provided
 INFO: No vanguard file provided
+Found 7 broker transactions
 INFO: No ERI raw file provided
 First pass completed
 Final portfolio:

--- a/tests/schwab/data/cash_merger/expected_output.txt
+++ b/tests/schwab/data/cash_merger/expected_output.txt
@@ -4,6 +4,7 @@ INFO: No mssb folder provided
 INFO: No sharesight file provided
 INFO: No raw file provided
 INFO: No vanguard file provided
+Found 5 broker transactions
 INFO: No ERI raw file provided
 First pass completed
 Final portfolio:

--- a/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
+++ b/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
@@ -4,6 +4,7 @@ INFO: No trading212 folder provided
 INFO: No mssb folder provided
 INFO: No raw file provided
 INFO: No vanguard file provided
+Found 16 broker transactions
 INFO: No ERI raw file provided
 First pass completed
 Final portfolio:

--- a/tests/trading212/data/2024/expected_output.txt
+++ b/tests/trading212/data/2024/expected_output.txt
@@ -5,6 +5,7 @@ INFO: No mssb folder provided
 INFO: No sharesight file provided
 INFO: No raw file provided
 INFO: No vanguard file provided
+Found 7 broker transactions
 INFO: No ERI raw file provided
 First pass completed
 Final portfolio:

--- a/tests/vanguard/data/expected_output.txt
+++ b/tests/vanguard/data/expected_output.txt
@@ -4,6 +4,7 @@ INFO: No trading212 folder provided
 INFO: No mssb folder provided
 INFO: No sharesight file provided
 INFO: No raw file provided
+Found 15 broker transactions
 INFO: No ERI raw file provided
 First pass completed
 Final portfolio:


### PR DESCRIPTION
- Print tracebacks only if `--verbose` is provided, this should make CLI output cleaner.
- Also print them as errors in red for better visibility.
- Unhandled exceptions are printer as CRITICAL level with tracebacks always included for easier debugging.
- Treat `FileNotFoundError` as an error.
- Improve some error messages.