### PR TITLE
Add CGT allowance for 2025/26

### DIFF
--- a/cgt_calc/const.py
+++ b/cgt_calc/const.py
@@ -30,6 +30,7 @@ CAPITAL_GAIN_ALLOWANCES: Final[dict[int, int]] = {
     2022: 12300,
     2023: 6000,
     2024: 3000,
+    2025: 3000,
 }
 
 # Dividend Tax annual allowance


### PR DESCRIPTION
Allowance for dividends isn't published yet.