### PR TITLE
Use RSU settlement date as acquisition date in Schwab

### DIFF
--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -164,8 +164,8 @@ class SchwabTransaction(BrokerTransaction):
         as_of_str = " as of "
         date_header = SchwabTransactionsFileRequiredHeaders.DATE.value
         if as_of_str in row_dict[date_header]:
-            index = row_dict[date_header].find(as_of_str) + len(as_of_str)
-            date_str = row_dict[date_header][index:]
+            index = row_dict[date_header].find(as_of_str)
+            date_str = row_dict[date_header][:index]
         else:
             date_str = row_dict[date_header]
         try:
@@ -240,9 +240,7 @@ class SchwabTransaction(BrokerTransaction):
             # for awards which don't match the PDF statements.
             # We want to make sure to match date and price form the awards
             # spreadsheet.
-            transaction.date, transaction.price = awards_prices.get(
-                transaction.date, symbol
-            )
+            _vest_date, transaction.price = awards_prices.get(transaction.date, symbol)
         return transaction
 
 

--- a/tests/schwab/data/rsu_settlement/awards.csv
+++ b/tests/schwab/data/rsu_settlement/awards.csv
@@ -1,0 +1,3 @@
+"Date","Action","Symbol","Description","Quantity","FeesAndCommissions","DisbursementElection","Amount","AwardDate","AwardId","FairMarketValuePrice","SalePrice","SharesSoldWithheldForTaxes","NetSharesDeposited","Taxes"
+"08/15/2023","Lapse","BAR","Restricted Stock Lapse","400","","","","","","","","","",""
+"","","","","","","","","03/21/2022","101883189","$140.35","","200","200","$13,192.90"

--- a/tests/schwab/data/rsu_settlement/expected_output.txt
+++ b/tests/schwab/data/rsu_settlement/expected_output.txt
@@ -1,0 +1,29 @@
+Parsing tests/schwab/data/rsu_settlement/awards.csv...
+Parsing tests/schwab/data/rsu_settlement/transactions.csv...
+Found 4 broker transactions
+First pass completed
+Final portfolio:
+  BAR: 300.00
+Final balance:
+  Charles Schwab: 28068.66 (USD)
+Disposal proceeds: £21783.33
+
+Second pass completed
+Portfolio at the end of 2023/2024 tax year:
+  BAR: 300.00, £32533.02
+For tax year 2023/2024:
+Number of disposals: 1
+Disposal proceeds: £21783.33
+Allowable costs: £21784.37
+Capital gain: £0.00
+Capital loss: £1.04
+Total capital gain: £-1.04
+Taxable capital gain: £0
+Total dividends proceeds: £0.00
+Total amount of dividends tax yearly allowance: £1000.00
+Total taxable dividends proceeds: £0.00
+Total UK interest proceeds: £0.00
+Total foreign interest proceeds: £0.00
+
+Generating PDF report...
+All done!

--- a/tests/schwab/data/rsu_settlement/transactions.csv
+++ b/tests/schwab/data/rsu_settlement/transactions.csv
@@ -1,0 +1,5 @@
+"Date","Action","Symbol","Description","Quantity","Price","Fees & Comm","Amount"
+"08/18/2023","Sell","BAR","BAR CORP","200","$140.35","$1.34","$28068.66"
+"08/18/2023 as of 08/15/2023","Stock Plan Activity","BAR","BAR CORP INC CLASS A","200","","",""
+"05/01/2023","Buy","BAR","BAR CORP INC CLASS A","300","$135.0075","$1.34","-$40503.61"
+"03/01/2022","MoneyLink Transfer","","Tfr BANK","","","","$40503.61"

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -66,3 +66,34 @@ def test_run_with_schwab_cash_merger_files() -> None:
         "if you added new features update the test with:\n"
         f"{cmd_str} > {expected_file}"
     )
+
+
+def test_run_with_schwab_rsu_settlement_files() -> None:
+    """Runs the script and verifies it doesn't fail."""
+    cmd = build_cmd(
+        "--year",
+        "2023",
+        "--schwab-file",
+        "tests/schwab/data/rsu_settlement/transactions.csv",
+        "--schwab-award-file",
+        "tests/schwab/data/rsu_settlement/awards.csv",
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode:
+        pytest.fail(
+            "Integration test failed\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    stderr = result.stderr.strip()
+    assert stderr == ""
+    expected_file = (
+        Path("tests") / "schwab" / "data" / "rsu_settlement" / "expected_output.txt"
+    )
+    expected = expected_file.read_text()
+    cmd_str = " ".join([param if param else "''" for param in cmd])
+    assert result.stdout == expected, (
+        "Run with example files generated unexpected outputs, "
+        "if you added new features update the test with:\n"
+        f"{cmd_str} > {expected_file}"
+    )


### PR DESCRIPTION
In Schwab, when receiving RSU we're using the vesting date as the acquisition date. I believe this should be the correct treatment instead:
- Use vest date for income taxes and national insurance calculation (done automatically by employer)
- Use settlement date (i.e. the date you actually receive the shares) as the acquisition date.

# Motivation
Selling as soon as receiving the shares should trigger the same day rule. It is an strategy done by several other people to avoid using section 104. It makes sense to me to record acquisition as the day one gained control of the shares. The test case I added attempts to do this.

# HMRC justification
According to [ERSM20420](https://www.gov.uk/hmrc-internal-manuals/employment-related-securities/ersm20420), the acquisition is defined as:
> “the time when the person acquiring the securities or interest becomes beneficially entitled to those securities or that interest (and not, if different, the time when the securities are, or interest is, conveyed or transferred).”

Furthermore, there's some leeway allowed:
> We will apply common sense in allowing taxpayers and their agents to identify a reasonable date and time for acquisition in accordance with the above definitions and only query if there is evidence of avoidance or manipulation.