### PR TITLE
Fix decimal rounding errors by reordering operations.

### DIFF
--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from .util import approx_equal, round_decimal
+from .util import approx_equal, normalize_amount, round_decimal
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -294,14 +294,14 @@ class Position:
         """Add two positions."""
         return Position(
             self.quantity + other.quantity,
-            self.amount + other.amount,
+            normalize_amount(self.amount + other.amount),
         )
 
     def __sub__(self, other: Position) -> Position:
         """Subtract two positions."""
         return Position(
             self.quantity - other.quantity,
-            self.amount - other.amount,
+            normalize_amount(self.amount - other.amount),
         )
 
     def __str__(self) -> str:

--- a/cgt_calc/util.py
+++ b/cgt_calc/util.py
@@ -14,6 +14,20 @@ def round_decimal(value: Decimal, digits: int = 0) -> Decimal:
         return Decimal(round(value, digits))
 
 
+def normalize_amount(amount: Decimal) -> Decimal:
+    """Normalize amount to prevent unbounded precision growth.
+
+    Financial amounts are rounded to 10 decimal places, which is far more
+    precision than needed for real-world financial calculations, while preventing
+    precision from growing unbounded through currency conversions with repeating
+    decimals (e.g., GBP/USD conversions).
+
+    This allows using Python's default 28-digit Decimal precision instead of
+    requiring 50+ digits.
+    """
+    return round_decimal(amount, 10)
+
+
 def strip_zeros(value: Decimal) -> str:
     """Strip trailing zeros from Decimal."""
     return f"{value:.10f}".rstrip("0").rstrip(".")


### PR DESCRIPTION
## Problem

Sequential disposal calculations can accumulate decimal rounding errors, causing assertions like `AssertionError: current amount -1E-23` to fail.

**Real life error:**
```python
WARNING: Bed and breakfasting for TEST. Disposed on 2024-02-15 and acquired again on 2024-02-16
CRITICAL: Unexpected error!
ERROR: Details:
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/cgt_calc/main.py", line 1478, in main
    calculate_cgt(args)
  File "/usr/local/lib/python3.12/dist-packages/cgt_calc/main.py", line 1444, in calculate_cgt
    report = calculator.calculate_capital_gain()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/cgt_calc/main.py", line 1253, in calculate_capital_gain
    ) = self.process_disposal(
        ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/cgt_calc/main.py", line 808, in process_disposal
    assert round_decimal(current_amount, 23) == 0, (
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: current amount -1E-23
```

## Reproduction

The issue occurs with the divide-then-multiply pattern:

```python
from decimal import Decimal

# Buy 3 shares for £10, sell all 3
qty = Decimal('3')
amt = Decimal('10')

price = amt / qty          # 3.333...
cost = qty * price         # Should be 10, but isn't exactly
remaining = amt - cost

assert remaining == 0, f"Expected 0, got {remaining}"
# AssertionError: Expected 0, got 1E-27
```

When division produces repeating decimals (10/3 = 3.333...), multiplying back doesn't recover the exact original value. With multiple sequential disposals (same-day, bed & breakfast, section 104), these tiny errors accumulate.

```
10 / 3 = 3.333333333333333333333333333  (28 digits, truncated)
3 × 3.333333333333333333333333333 = 9.999999999999999999999999999
10 - 9.999999999999999999999999999 = 0.000000000000000000000000001 (1E-27)
```

## Solution

This PR implements a two-part fix:

### 1. Reorder Operations (Multiply Before Divide)

```python
# OLD (buggy):  Divide first, multiply second
cost = quantity * (amount / total)

# NEW (fixed):  Multiply first, divide second
cost = (quantity * amount) / total
```

When disposing all shares, the operations cancel exactly:
```python
(total * amount) / total = amount  # Exact algebraic cancellation
```

### 2. Strategic Normalization

Added `normalize_amount()` function that rounds financial amounts to 10 decimal places. This prevents unbounded precision growth from currency conversions while maintaining more than sufficient precision for financial calculations.

```python
def normalize_amount(amount: Decimal) -> Decimal:
    """Round to 10 decimal places to prevent unbounded precision growth."""
    return round_decimal(amount, 10)
```

Applied normalization at:
- All proportional disposal calculations (same-day, bed & breakfast, section 104)
- Position arithmetic operations (`__add__`, `__sub__`)
- Portfolio position updates

## Testing

The added tests pass on this branch but fails on `main` with the expected rounding errors:
`test_proportional_disposal_no_rounding_error` with `AssertionError: current amount 1E-27`
`test_high_precision_amount_no_rounding_error` with `AssertionError: current amount 2E-23`
