### PR TITLE
Don't crash while determining version.

### DIFF
--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -402,10 +402,14 @@ Environment variables:
         action="help",
         help="show this help message and exit",
     )
+    try:
+        version = f"cgt-calc {importlib.metadata.version(__package__)}"
+    except importlib.metadata.PackageNotFoundError:
+        version = "cgt-calc (unknown version)"
     general_group.add_argument(
         "--version",
         action="version",
-        version=f"cgt-calc {importlib.metadata.version(__package__)}",
+        version=version,
         help="show version and exit",
     )
     general_group.add_argument(


### PR DESCRIPTION
If the Distribution Package version cannot be determined, cgt-calc currently errors out with a `importlib.metadata.PackageNotFoundError`. This means that e.g. running `pytests` by hand fails, which seems unnecessarily restrictive.

This commit makes the version string fall back to "unknown version" in those cases, which should make development easier while also prompting the right questions if users raise an issue.

This contribution has been developed in my spare time.