### PR TITLE
Upgrade to pyrate-limiter 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "Jinja2>=2.11.3,<4.0.0",
   "pandas>=2.2",
   "requests>=2.27.1",
-  "requests-ratelimiter>=0.7.0",
+  "pyrate-limiter>=3.9.0",
   "yfinance>=0.2.36",
 ]
 


### PR DESCRIPTION
Motivation: requests-ratelimiter is pinned to pyrate-limiter 2:
- https://github.com/JWCook/requests-ratelimiter/issues/78

This is blocking updating cgt-calc on NixOS, which is already on pyrate-limiter 3.9.0:
- https://search.nixos.org/packages?query=pyrate-limiter
- https://github.com/NixOS/nixpkgs/blob/e4bae1bd10c9c57b2cf517953ab70060a828ee6f/pkgs/development/python-modules/requests-ratelimiter/default.nix#L42
- https://nixpkgs-update-logs.nix-community.org/cgt-calc/2026-01-16.log

pyrate-limiter 4 will add a RateLimitedRequestsSession helper, but it isn't released yet, but we can follow its implementation with 3.9 APIs:
- https://github.com/vutran1710/PyrateLimiter/blob/master/README.md#requests
- https://github.com/vutran1710/PyrateLimiter/pull/235