### PR TITLE
Trading212: Handle "Dividend manufactured payment" (#709)

### DIFF
--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -99,6 +99,7 @@ def action_from_str(label: str, file: Path) -> ActionType:
         "Dividend (Ordinary)",
         "Dividend (Dividend)",
         "Dividend (Dividends paid by us corporations)",
+        "Dividend (Dividend manufactured payment)",
     ]:
         return ActionType.DIVIDEND
 


### PR DESCRIPTION
Per HMRC (CFM74430), a manufactured payment is a substitute paid under stock-lending / repo arrangements when the lender does not receive the real dividend or interest.

Where the payment is representative of a dividend on shares, HMRC taxes it as if the real dividend had been received. Accordingly, Trading 212 "Dividend manufactured payment" entries are handled as regular dividends.