### PR TITLE
Update README.md to reference new Schwab params in Cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ apt install texlive-latex-base
   tax year 2020/21:
 
 ```shell
-cgt-calc --year 2020 --schwab-file schwab_transactions.csv --trading212-dir trading212/ --mssb-dir mmsb_report/
+cgt-calc --year 2020 --schwab schwab_transactions.csv --trading212-dir trading212/ --mssb-dir mmsb_report/
 ```
 
 - Run `cgt-calc --help` for all available options.
@@ -120,7 +120,7 @@ You will need:
 Example usage for the tax year 2020/21:
 
 ```shell
-cgt-calc --year 2020 --schwab-file schwab_transactions.csv --schwab-award-file schwab_awards.csv
+cgt-calc --year 2020 --schwab schwab_transactions.csv --schwab-award schwab_awards.csv
 ```
 
 _Note: For historic reasons, it is possible to provide the Equity Awards history in JSON format with


### PR DESCRIPTION
Rename Schwab param in Readme file, see currently available options below

```
~ % cgt-calc --help
usage: cgt-calc [-h] [--year [YEAR]] [--raw [RAW]] [--schwab [SCHWAB]] [--schwab-award [SCHWAB_AWARD]]
                [--schwab_equity_award_json [SCHWAB_EQUITY_AWARD_JSON]] [--trading212 [TRADING212]] [--mssb [MSSB]]
                [--sharesight [SHARESIGHT]] [--vanguard [VANGUARD]] [--eri-raw-file [ERI_RAW_FILE]]
                [--exchange-rates-file [EXCHANGE_RATES_FILE]] [--spin-offs-file [SPIN_OFFS_FILE]] [--initial-prices [INITIAL_PRICES]]
                [--report [REPORT]] [--no-report] [--no-balance-check] [--unrealized-gains]
                [--interest-fund-tickers INTEREST_FUND_TICKERS] [--isin-translation-file [ISIN_TRANSLATION_FILE]] [--verbose]
                [--version]

options:
  --schwab [SCHWAB]     file containing the exported transactions from Charles Schwab
  --schwab-award [SCHWAB_AWARD]
                        file containing schwab award data for stock prices
  --schwab_equity_award_json [SCHWAB_EQUITY_AWARD_JSON]
                        file containing schwab equity award transactions data in JSON format
```