### PR TITLE
Fix Vanguard parsing for funds without symbols and fractional share quantities

### DIFF
--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -30,11 +30,11 @@ class VanguardColumn(StrEnum):
 
 COLUMNS: Final[list[str]] = [column.value for column in VanguardColumn]
 
-BOUGHT_RE = re.compile(r"^Bought (\d*[,]?\d*) .*\((.*)\)$")
-SOLD_RE = re.compile(r"^Sold (\d*[,]?\d*) .*\((.*)\)$")
+BOUGHT_RE = re.compile(r"^Bought ([\d,]*\.?\d+) (.+?)(?:\s*\(([^()]+)\))?$")
+SOLD_RE = re.compile(r"^Sold ([\d,]*\.?\d+) (.+?)(?:\s*\(([^()]+)\))?$")
 DIV_RE = re.compile(r"^DIV: ([^\.]+)\.[^ ]+ @ ([A-Z]+) (\d*[,\.]?\d*)")
 TRANSFER_RE = re.compile(
-    r".*(Regular Deposit|Deposit via|Deposit for|Payment by|Account Fee).*"
+    r".*(Regular Deposit|Cash transfer|Deposit via|Deposit for|Payment by|Account [Ff]ee).*"
 )
 
 INTEREST_STR = "Cash Account Interest"
@@ -114,13 +114,13 @@ class VanguardTransaction(BrokerTransaction):
             match = BOUGHT_RE.match(details)
             assert match
             quantity = _parse_decimal(match.group(1), "Details quantity")
-            symbol = match.group(2)
+            symbol = match.group(3) or match.group(2).strip()
             price = abs(amount) / quantity
         elif action == ActionType.SELL:
             match = SOLD_RE.match(details)
             assert match
             quantity = _parse_decimal(match.group(1), "Details quantity")
-            symbol = match.group(2)
+            symbol = match.group(3) or match.group(2).strip()
             price = amount / quantity
         elif action == ActionType.DIVIDEND:
             match = DIV_RE.match(details)

--- a/tests/vanguard/data/expected_output.txt
+++ b/tests/vanguard/data/expected_output.txt
@@ -1,11 +1,13 @@
 Parsing tests/vanguard/data/report.csv...
-Found 15 broker transactions
+Found 17 broker transactions
 First pass completed
 Final portfolio:
   FOO: 1550.00
   BAR: 293.00
+  Emerging Markets Stock Index Fund - Accumulation: 6.77
+  U.S. Equity Index Fund - Accumulation: 0.92
 Final balance:
-  Vanguard: 1423.59 (GBP)
+  Vanguard: 23.59 (GBP)
 Dividends:
   FOO: 396.66 (GBP)
 Disposal proceeds: £104.06
@@ -14,6 +16,8 @@ Second pass completed
 Portfolio at the end of 2022/2023 tax year:
   FOO: 1550.00, £14982.06
   BAR: 293.00, £29845.42
+  Emerging Markets Stock Index Fund - Accumulation: 6.77, £1000.00
+  U.S. Equity Index Fund - Accumulation: 0.92, £400.00
 For tax year 2022/2023:
 Number of disposals: 1
 Disposal proceeds: £104.06

--- a/tests/vanguard/data/report.csv
+++ b/tests/vanguard/data/report.csv
@@ -14,3 +14,5 @@ Date,Details,Amount,Balance
 29/07/2022,DIV: FOO.XLON.GB @ GBP 0.3106,170.83,693.83
 23/08/2022,Payment by Faster - One-off withdrawal Faster,-270.24,423.59
 26/09/2022,Deposit via direct credit,1000,1423.59
+01/10/2022,Bought 6.7700 Emerging Markets Stock Index Fund - Accumulation,-1000,423.59
+02/10/2022,Bought .9232 U.S. Equity Index Fund - Accumulation,-400,23.59

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -73,6 +73,61 @@ def test_read_vanguard_transactions_buy(tmp_path: Path) -> None:
     assert transaction.currency == "GBP"
 
 
+def test_read_vanguard_missing_symbol(tmp_path: Path) -> None:
+    """Use the full string investment name if no symbol within ( ) is matched."""
+
+    vanguard_file = tmp_path / "buy.csv"
+    rows = [
+        COLUMNS,
+        [
+            "09/03/2022",
+            "Bought 10 Foo Fund",
+            "-100.00",
+            "0",
+        ],
+    ]
+    _write_csv(vanguard_file, rows)
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert transaction.action is ActionType.BUY
+    assert transaction.symbol == "Foo Fund"
+    assert transaction.quantity == Decimal(10)
+    assert transaction.price == Decimal(10)
+    assert transaction.amount == Decimal(-100)
+    assert transaction.currency == "GBP"
+
+
+def test_read_vanguard_fractional_share(tmp_path: Path) -> None:
+    """Make sure it handles fractional share."""
+
+    vanguard_file = tmp_path / "buy.csv"
+    rows = [
+        COLUMNS,
+        [
+            "09/03/2022",
+            "Bought .2 Foo Fund (GBP) (FOO)",
+            "-100.00",
+            "0",
+        ],
+    ]
+    _write_csv(vanguard_file, rows)
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert transaction.action is ActionType.BUY
+    assert transaction.symbol == "FOO"
+    assert transaction.quantity is not None
+    assert transaction.quantity - Decimal("0.2") < Decimal("0.000001")
+    assert transaction.price == Decimal(500)
+    assert transaction.amount == Decimal(-100)
+    assert transaction.currency == "GBP"
+
+
 def test_read_vanguard_transactions_invalid_decimal(tmp_path: Path) -> None:
     """Raise ParsingError when amount cannot be parsed as Decimal."""
 


### PR DESCRIPTION
Vanguard parser improvements (cgt_calc/parsers/vanguard.py):
- Updated BOUGHT_RE and SOLD_RE regexes to handle funds that don't have a ticker symbol in parentheses (e.g. "Bought 6.77 Emerging Markets Stock Index Fund - Accumulation"). Previously, a parenthesized symbol like (FOO) was required. Now the full fund name is used as a fallback when no (SYMBOL) is present.
- Added support for fractional shares starting with a decimal point (e.g. .9232).
- Added "Cash transfer" and case-insensitive "Account fee" to the transfer regex.

Tests (tests/vanguard/test_vanguard.py):
- Added test_read_vanguard_missing_symbol — verifies the full fund name is used when no parenthesized symbol exists.
- Added test_read_vanguard_fractional_share — verifies parsing of quantities like .2.

Test data (tests/vanguard/data/):
- Added two new rows to report.csv for funds without ticker symbols.
- Updated expected_output.txt to reflect the new transactions and adjusted balance.