### PR TITLE
Only add relevant ERI transactions

### DIFF
--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -132,6 +132,14 @@ class IsinConverter:
                 self._write_isin_translation_file()
         return result
 
+    def get_symbol_to_isin_map(self) -> dict[str, str]:
+        """Return a map from symbols to isin's."""
+        symbol_to_isin = {}
+        for isin, symbols in self.data.items():
+            for symbol in symbols:
+                symbol_to_isin[symbol] = isin
+        return symbol_to_isin
+
     def _read_isin_translation_data(self) -> None:
         """Read ISIN translation data from bundled and user-provided sources."""
 

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -1430,12 +1430,12 @@ def calculate_cgt(args: argparse.Namespace) -> None:
     isin_translation_file = args.isin_translation_file
 
     # Read data from input files
-    broker_transactions = BrokerRegistry.load_all_transactions(args)
+    isin_converter = IsinConverter(isin_translation_file)
+    broker_transactions = BrokerRegistry.load_all_transactions(args, isin_converter)
     currency_converter = CurrencyConverter(args.exchange_rates_file)
     price_fetcher = CurrentPriceFetcher(currency_converter)
     initial_prices = InitialPrices(args.initial_prices_file)
     spin_off_handler = SpinOffHandler(args.spin_offs_file)
-    isin_converter = IsinConverter(isin_translation_file)
 
     calculator = CapitalGainsCalculator(
         args.year,

--- a/cgt_calc/parsers/broker_registry.py
+++ b/cgt_calc/parsers/broker_registry.py
@@ -19,6 +19,7 @@ from cgt_calc.parsers.vanguard import VanguardParser
 if TYPE_CHECKING:
     import argparse
 
+    from cgt_calc.isin_converter import IsinConverter
     from cgt_calc.model import BrokerTransaction
 
     from .base_parsers import BaseParser
@@ -52,7 +53,9 @@ class BrokerRegistry:
         ERIRawParser.register_arguments(broker_group)
 
     @staticmethod
-    def load_all_transactions(args: argparse.Namespace) -> list[BrokerTransaction]:
+    def load_all_transactions(
+        args: argparse.Namespace, isin_converter: IsinConverter
+    ) -> list[BrokerTransaction]:
         """Load transactions from all brokers."""
         all_transactions: list[BrokerTransaction] = []
         for broker_class in BrokerRegistry._BROKERS:
@@ -71,7 +74,12 @@ class BrokerRegistry:
             print(f"Found {len(all_transactions)} broker transactions")
 
         # ERI Raw is not a broker but is close enough to one to be here
-        all_transactions += ERIRawParser.load_from_args(args)
+        # Only add ERI for funds that show up in the portfolio
+        isin_map = isin_converter.get_symbol_to_isin_map()
+        isins = {trx.isin or isin_map.get(trx.symbol or "") for trx in all_transactions}
+        all_transactions += [
+            trx for trx in ERIRawParser.load_from_args(args) if trx.isin in isins
+        ]
 
         all_transactions.sort(key=lambda k: k.date)
         return all_transactions


### PR DESCRIPTION
# Issue
When we add new ERI data, it generates new transactions that get added to all runs of the tool. This triggers new currency conversions on virtually all tests which are unnecessary.

# Solution
The proposed fix is only add ERI's whose fund was actually held by the current portfolio.

# Advantages:
- Prevent test flakiness
- Makes debugging easier as we won't have hundreds of never actually held offshore funds ERI in the transaction list.

# Caveats
Right now we only check the symbol but we don't validate the dates, so this check could be further improved later by removing ERI transactions for dates that the funds were never held.

