### PR TITLE
[Vanguard] Deprioritize debits (e.g. fee charged) 

### DIFF
--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -146,12 +146,16 @@ class VanguardTransaction(BrokerTransaction):
 
 def by_date_and_action(
     transaction: VanguardTransaction,
-) -> tuple[datetime.date, bool, bool]:
+) -> tuple[datetime.date, bool, bool, bool]:
     """Sort by date and action type."""
     # Deprioritize BUY and reversal transaction to prevent balance errors
+    # Deprioritize debits (e.g. fee charged) so credits (e.g. fee cleared)
+    # are processed first, preventing temporary negative balances.
+    is_debit = transaction.amount is not None and transaction.amount < 0
     return (
         transaction.date,
         transaction.action == ActionType.BUY,
+        is_debit,
         transaction.is_reversal,
     )
 

--- a/tests/vanguard/data/expected_output.txt
+++ b/tests/vanguard/data/expected_output.txt
@@ -1,5 +1,5 @@
 Parsing tests/vanguard/data/report.csv...
-Found 17 broker transactions
+Found 19 broker transactions
 First pass completed
 Final portfolio:
   FOO: 1550.00

--- a/tests/vanguard/data/report.csv
+++ b/tests/vanguard/data/report.csv
@@ -16,3 +16,5 @@ Date,Details,Amount,Balance
 26/09/2022,Deposit via direct credit,1000,1423.59
 01/10/2022,Bought 6.7700 Emerging Markets Stock Index Fund - Accumulation,-1000,423.59
 02/10/2022,Bought .9232 U.S. Equity Index Fund - Accumulation,-400,23.59
+15/10/2022,Account fee charged,-25.0,-1.41
+15/10/2022,Account fee cleared,25.0,23.59


### PR DESCRIPTION
Deprioritize debits (e.g. fee charged)  so credits (e.g. fee cleared) are processed first, preventing temporary negative balances.
see https://github.com/KapJI/capital-gains-calculator/issues/756