### PR TITLE
Vanguard parser: add ETF dealing fee as TRANSFER

### DIFF
--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -61,7 +61,8 @@ BOUGHT_RE = re.compile(r"^Bought ([\d,]*\.?\d+) (.+?)(?:\s*\(([^()]+)\))?$")
 SOLD_RE = re.compile(r"^Sold ([\d,]*\.?\d+) (.+?)(?:\s*\(([^()]+)\))?$")
 DIV_RE = re.compile(r"^DIV: ([^\.]+)\.[^ ]+ @ ([A-Z]+) (\d*[,\.]?\d*)")
 TRANSFER_RE = re.compile(
-    r".*(Regular Deposit|Cash transfer|Deposit via|Deposit for|Payment by|Account [Ff]ee).*"
+    r".*(Regular Deposit|Cash transfer|Deposit via|Deposit for|Payment by|"
+    r"Account [Ff]ee|ETF dealing fee).*"
 )
 
 INTEREST_STR = "Cash Account Interest"

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -128,6 +128,32 @@ def test_read_vanguard_fractional_share(tmp_path: Path) -> None:
     assert transaction.currency == "GBP"
 
 
+def test_read_vanguard_etf_dealing_fee_is_transfer(tmp_path: Path) -> None:
+    """ETF dealing fees parse as TRANSFER and affect cash without a position."""
+
+    vanguard_file = tmp_path / "etf_dealing_fee.csv"
+    rows = [
+        COLUMNS,
+        [
+            "09/03/2022",
+            "ETF dealing fee (sell) FTSE 100 UCITS ETF - Distributing (VUKE)",
+            "-7.50",
+            "0",
+        ],
+    ]
+    _write_csv(vanguard_file, rows)
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert transaction.action is ActionType.TRANSFER
+    assert transaction.symbol is None
+    assert transaction.quantity is None
+    assert transaction.price is None
+    assert transaction.amount == Decimal("-7.50")
+
+
 def test_read_vanguard_transactions_invalid_decimal(tmp_path: Path) -> None:
     """Raise ParsingError when amount cannot be parsed as Decimal."""
 


### PR DESCRIPTION
ETF dealing fees currently break parsing of the vanguard output -- this correctly treats them as a fee