### PR TITLE
Vanguard parser: exclude index switching events from calcs

### DIFF
--- a/cgt_calc/const.py
+++ b/cgt_calc/const.py
@@ -76,6 +76,11 @@ TICKER_RENAMES: Final[dict[str, str]] = {
     "FB": "META",
 }
 
+# Encodes the old ticker in the RENAME transaction's description field;
+# parsed back out by main.apply_ticker_renames. Keep parser + preprocessor
+# in sync.
+RENAME_DESCRIPTION_PREFIX: Final = "renamed from "
+
 
 # =============================================================================
 # Resource files

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -20,6 +20,7 @@ from .const import (
     DIVIDEND_DOUBLE_TAXATION_RULES,
     ERI_TAX_DATE_DELTA,
     INTERNAL_START_DATE,
+    RENAME_DESCRIPTION_PREFIX,
     UK_CURRENCY,
 )
 from .currency_converter import CurrencyConverter
@@ -139,6 +140,45 @@ def _approx_equal_price_rounding(
         "acceptable range" if accptable_amount else "error",
     )
     return accptable_amount
+
+
+def apply_ticker_renames(transactions: list[BrokerTransaction]) -> None:
+    """Rewrite old-ticker symbols to the new ticker from RENAME events.
+
+    Transitive chains (A->B->C) are collapsed to A->C before rewrite.
+    """
+    rename_map: dict[str, str] = {}
+    for txn in transactions:
+        if txn.action is not ActionType.RENAME:
+            continue
+        if txn.symbol is None or not txn.description.startswith(
+            RENAME_DESCRIPTION_PREFIX
+        ):
+            continue
+        old_ticker = txn.description[len(RENAME_DESCRIPTION_PREFIX) :].strip()
+        if old_ticker:
+            rename_map[old_ticker] = txn.symbol
+
+    if not rename_map:
+        return
+
+    # Collapse transitive chains: if A->B and B->C, map A directly to C.
+    for key in list(rename_map):
+        seen = {key}
+        value = rename_map[key]
+        while value in rename_map and value not in seen:
+            seen.add(value)
+            value = rename_map[value]
+        rename_map[key] = value
+
+    for old, new in rename_map.items():
+        LOGGER.info("Applied ticker rename: %s -> %s", old, new)
+
+    for txn in transactions:
+        if txn.action is ActionType.RENAME:
+            continue
+        if txn.symbol in rename_map:
+            txn.symbol = rename_map[txn.symbol]
 
 
 class CapitalGainsCalculator:
@@ -490,6 +530,10 @@ class CapitalGainsCalculator:
         transactions: list[BrokerTransaction],
     ) -> None:
         """Convert broker transactions to HMRC transactions."""
+        # Unify tickers up-front so the per-symbol matcher (incl. B&B across
+        # a rename) sees pre- and post-rename holdings as one security.
+        apply_ticker_renames(transactions)
+
         # We keep a balance per broker,currency pair
         balance: dict[tuple[str, str], Decimal] = defaultdict(lambda: Decimal(0))
         dividends: dict[tuple[str, str], Decimal] = defaultdict(Decimal)
@@ -595,6 +639,9 @@ class CapitalGainsCalculator:
                 new_balance += amount
             elif transaction.action is ActionType.REINVEST_DIVIDENDS:
                 LOGGER.warning("Ignoring unsupported action: %s", transaction.action)
+            elif transaction.action is ActionType.RENAME:
+                # Consumed upfront by apply_ticker_renames; kept for audit.
+                pass
             else:
                 raise InvalidTransactionError(
                     transaction, f"Action not processed({transaction.action})"

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -155,6 +155,7 @@ class ActionType(Enum):
     CASH_MERGER = 16
     EXCESS_REPORTED_INCOME = 17
     FULL_REDEMPTION = 18
+    RENAME = 19
 
 
 class CalculationType(Enum):

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -63,6 +63,10 @@ DIV_RE = re.compile(r"^DIV: ([^\.]+)\.[^ ]+ @ ([A-Z]+) (\d*[,\.]?\d*)")
 TRANSFER_RE = re.compile(
     r".*(Regular Deposit|Cash transfer|Deposit via|Deposit for|Payment by|Account [Ff]ee).*"
 )
+NAMECHANGE_RE = re.compile(
+    r"^NameChange:\s*([A-Z0-9]+)(?:\.\S+)?"
+    r"(?:\s+replaced with\s+([A-Z0-9]+)(?:\.\S+)?)?\s*$"
+)
 
 INTEREST_STR = "Cash Account Interest"
 REVERSAL_STR = "Reversal of "
@@ -239,10 +243,16 @@ class VanguardTransaction(BrokerTransaction):
 def _make_transaction_from_investment(
     row: dict[str, str],
     file: Path,
-) -> VanguardTransaction:
-    """Create a VanguardTransaction from an Investment Transactions row."""
-    date = datetime.datetime.strptime(row[InvestmentColumn.DATE], "%d/%m/%Y").date()
+) -> VanguardTransaction | None:
+    """Create a VanguardTransaction from an Investment Transactions row.
+
+    Returns None for NameChange annotation rows — these mark a ticker rename,
+    not a real trade, and are handled via a rename map applied post-parsing.
+    """
     details, is_reversal = _strip_reversal(row[InvestmentColumn.TRANSACTION_DETAILS])
+    if NAMECHANGE_RE.match(details):
+        return None
+    date = datetime.datetime.strptime(row[InvestmentColumn.DATE], "%d/%m/%Y").date()
     action = action_from_str(details, file)
     symbol = _symbol_from_details(details)
 
@@ -397,6 +407,10 @@ class VanguardParser(BaseSingleFileParser):
         # If "Investment Transaction" table exists, build investment lookup keyed by TransactionDetails
         # This will be merged with "Cash Transaction" table
         investment_lookup: dict[str, list[dict[str, str]]] = {}
+        # Ticker renames sourced from "NameChange: OLD replaced with NEW" annotation
+        # rows in the investment table. Applied to all parsed transactions below so
+        # pre-rename holdings carry through as a single continuous position.
+        rename_map: dict[str, str] = {}
         if investment_lines is not None:
             investment_header = investment_lines[0]
             for row in investment_lines[1:]:
@@ -404,8 +418,15 @@ class VanguardParser(BaseSingleFileParser):
                     continue
                 investment_row = dict(zip(investment_header, row, strict=False))
                 key = investment_row.get(InvestmentColumn.TRANSACTION_DETAILS, "")
-                if key:
-                    investment_lookup.setdefault(key, []).append(investment_row)
+                if not key:
+                    continue
+                namechange = NAMECHANGE_RE.match(key)
+                if namechange:
+                    new_ticker = namechange.group(2)
+                    if new_ticker:
+                        rename_map[namechange.group(1)] = new_ticker
+                    continue
+                investment_lookup.setdefault(key, []).append(investment_row)
 
         transactions: list[VanguardTransaction] = []
 
@@ -438,13 +459,21 @@ class VanguardParser(BaseSingleFileParser):
                     continue
                 investment_row = dict(zip(investment_header, row, strict=False))
                 try:
-                    txn = _make_transaction_from_investment(investment_row, file_path)
-                    transactions.append(txn)
+                    inv_txn = _make_transaction_from_investment(
+                        investment_row, file_path
+                    )
                 except ParsingError as err:
                     err.add_row_context(index)
                     raise
                 except ValueError as err:
                     raise ParsingError(file_path, str(err), row_index=index) from err
+                if inv_txn is not None:
+                    transactions.append(inv_txn)
+
+        if rename_map:
+            for txn in transactions:
+                if txn.symbol in rename_map:
+                    txn.symbol = rename_map[txn.symbol]
 
         transactions.sort(key=by_date_and_action)
         return cast("list[BrokerTransaction]", transactions)

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -11,6 +11,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, ClassVar, Final, TextIO, cast
 
+from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
 from cgt_calc.model import ActionType, BrokerTransaction
 
@@ -218,6 +219,7 @@ class VanguardTransaction(BrokerTransaction):
         amount: Decimal | None,
         currency: str,
         is_reversal: bool,
+        description: str = "",
     ) -> VanguardTransaction:
         """Create a VanguardTransaction from pre-parsed fields."""
         txn = object.__new__(cls)
@@ -229,7 +231,7 @@ class VanguardTransaction(BrokerTransaction):
             date,
             action,
             symbol,
-            "",
+            description,
             quantity,
             price,
             Decimal(0),
@@ -240,14 +242,35 @@ class VanguardTransaction(BrokerTransaction):
         return txn
 
 
+def _make_rename_transaction(
+    date: datetime.date,
+    old_ticker: str,
+    new_ticker: str,
+    quantity: Decimal,
+    price: Decimal,
+) -> VanguardTransaction:
+    """Build a RENAME transaction representing a ticker rename event."""
+    return VanguardTransaction.from_fields(
+        date=date,
+        action=ActionType.RENAME,
+        symbol=new_ticker,
+        quantity=abs(quantity),
+        price=price,
+        amount=Decimal(0),
+        currency="GBP",
+        is_reversal=False,
+        description=f"{RENAME_DESCRIPTION_PREFIX}{old_ticker}",
+    )
+
+
 def _make_transaction_from_investment(
     row: dict[str, str],
     file: Path,
 ) -> VanguardTransaction | None:
     """Create a VanguardTransaction from an Investment Transactions row.
 
-    Returns None for NameChange annotation rows — these mark a ticker rename,
-    not a real trade, and are handled via a rename map applied post-parsing.
+    Returns None for NameChange rows; RENAME transactions are emitted by the
+    caller's investment_lookup pass instead.
     """
     details, is_reversal = _strip_reversal(row[InvestmentColumn.TRANSACTION_DETAILS])
     if NAMECHANGE_RE.match(details):
@@ -407,10 +430,9 @@ class VanguardParser(BaseSingleFileParser):
         # If "Investment Transaction" table exists, build investment lookup keyed by TransactionDetails
         # This will be merged with "Cash Transaction" table
         investment_lookup: dict[str, list[dict[str, str]]] = {}
-        # Ticker renames sourced from "NameChange: OLD replaced with NEW" annotation
-        # rows in the investment table. Applied to all parsed transactions below so
-        # pre-rename holdings carry through as a single continuous position.
-        rename_map: dict[str, str] = {}
+        # RENAME transactions from "NameChange: OLD replaced with NEW" rows;
+        # the calculator unifies old/new tickers centrally from these.
+        rename_transactions: list[VanguardTransaction] = []
         if investment_lines is not None:
             investment_header = investment_lines[0]
             for row in investment_lines[1:]:
@@ -423,8 +445,25 @@ class VanguardParser(BaseSingleFileParser):
                 namechange = NAMECHANGE_RE.match(key)
                 if namechange:
                     new_ticker = namechange.group(2)
-                    if new_ticker:
-                        rename_map[namechange.group(1)] = new_ticker
+                    if new_ticker is not None:
+                        rename_transactions.append(
+                            _make_rename_transaction(
+                                date=datetime.datetime.strptime(
+                                    investment_row[InvestmentColumn.DATE],
+                                    "%d/%m/%Y",
+                                ).date(),
+                                old_ticker=namechange.group(1),
+                                new_ticker=new_ticker,
+                                quantity=_parse_decimal(
+                                    investment_row[InvestmentColumn.QUANTITY],
+                                    InvestmentColumn.QUANTITY.value,
+                                ),
+                                price=_parse_decimal(
+                                    investment_row[InvestmentColumn.PRICE],
+                                    InvestmentColumn.PRICE.value,
+                                ),
+                            )
+                        )
                     continue
                 investment_lookup.setdefault(key, []).append(investment_row)
 
@@ -470,10 +509,6 @@ class VanguardParser(BaseSingleFileParser):
                 if inv_txn is not None:
                     transactions.append(inv_txn)
 
-        if rename_map:
-            for txn in transactions:
-                if txn.symbol in rename_map:
-                    txn.symbol = rename_map[txn.symbol]
-
+        transactions.extend(rename_transactions)
         transactions.sort(key=by_date_and_action)
         return cast("list[BrokerTransaction]", transactions)

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -11,12 +11,13 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.currency_converter import CurrencyConverter
 from cgt_calc.current_price_fetcher import CurrentPriceFetcher
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.main import CapitalGainsCalculator
-from cgt_calc.model import ActionType, BrokerTransaction
+from cgt_calc.model import ActionType, BrokerTransaction, RuleType
 from cgt_calc.spin_off_handler import SpinOffHandler
 from cgt_calc.util import round_decimal
 from tests.utils import build_cmd
@@ -482,6 +483,197 @@ def test_same_day_rule_all_shares_disposed_no_rounding_error() -> None:
         f"Pool amount should be exactly zero after disposing all shares on same day, "
         f"got {calculator.portfolio[symbol].amount}"
     )
+
+
+def _rename_transaction(
+    date: datetime.date, old_ticker: str, new_ticker: str
+) -> BrokerTransaction:
+    """Build a minimal RENAME broker transaction for tests."""
+    return BrokerTransaction(
+        date=date,
+        action=ActionType.RENAME,
+        symbol=new_ticker,
+        description=f"{RENAME_DESCRIPTION_PREFIX}{old_ticker}",
+        quantity=Decimal(0),
+        price=None,
+        fees=Decimal(0),
+        amount=Decimal(0),
+        currency="GBP",
+        broker="Test",
+    )
+
+
+def test_rename_preprocessor_unifies_old_and_new_tickers() -> None:
+    """BUY(OLD) + RENAME(OLD->NEW) + BUY(NEW) collapse into a single holding."""
+    calculator = create_calculator()
+
+    transactions: list[BrokerTransaction] = [
+        BrokerTransaction(
+            date=datetime.date(2024, 6, 1),
+            action=ActionType.BUY,
+            symbol="OLD",
+            description="pre-rename buy",
+            quantity=Decimal(10),
+            price=Decimal(10),
+            fees=Decimal(0),
+            amount=Decimal(-100),
+            currency="GBP",
+            broker="Test",
+        ),
+        _rename_transaction(datetime.date(2024, 6, 15), "OLD", "NEW"),
+        BrokerTransaction(
+            date=datetime.date(2024, 7, 1),
+            action=ActionType.BUY,
+            symbol="NEW",
+            description="post-rename buy",
+            quantity=Decimal(5),
+            price=Decimal(12),
+            fees=Decimal(0),
+            amount=Decimal(-60),
+            currency="GBP",
+            broker="Test",
+        ),
+    ]
+
+    calculator.convert_to_hmrc_transactions(transactions)
+
+    # Acquisitions for both dates are filed under NEW after preprocessing.
+    assert "OLD" not in calculator.acquisition_list[datetime.date(2024, 6, 1)]
+    assert "NEW" in calculator.acquisition_list[datetime.date(2024, 6, 1)]
+    assert "NEW" in calculator.acquisition_list[datetime.date(2024, 7, 1)]
+
+    # Portfolio consolidated under NEW, no OLD left behind.
+    assert "OLD" not in calculator.portfolio
+    assert calculator.portfolio["NEW"].quantity == Decimal(15)
+
+
+def test_rename_preprocessor_collapses_transitive_chains() -> None:
+    """A->B->C renames map all historic tickers onto the latest one."""
+    calculator = create_calculator()
+
+    transactions: list[BrokerTransaction] = [
+        BrokerTransaction(
+            date=datetime.date(2024, 1, 10),
+            action=ActionType.BUY,
+            symbol="A",
+            description="buy A",
+            quantity=Decimal(10),
+            price=Decimal(10),
+            fees=Decimal(0),
+            amount=Decimal(-100),
+            currency="GBP",
+            broker="Test",
+        ),
+        _rename_transaction(datetime.date(2024, 2, 1), "A", "B"),
+        BrokerTransaction(
+            date=datetime.date(2024, 3, 1),
+            action=ActionType.BUY,
+            symbol="B",
+            description="buy B",
+            quantity=Decimal(5),
+            price=Decimal(10),
+            fees=Decimal(0),
+            amount=Decimal(-50),
+            currency="GBP",
+            broker="Test",
+        ),
+        _rename_transaction(datetime.date(2024, 4, 1), "B", "C"),
+        BrokerTransaction(
+            date=datetime.date(2024, 5, 1),
+            action=ActionType.BUY,
+            symbol="C",
+            description="buy C",
+            quantity=Decimal(3),
+            price=Decimal(10),
+            fees=Decimal(0),
+            amount=Decimal(-30),
+            currency="GBP",
+            broker="Test",
+        ),
+    ]
+
+    calculator.convert_to_hmrc_transactions(transactions)
+
+    # Every acquisition — including the original buy of A — sits under C.
+    for date in (
+        datetime.date(2024, 1, 10),
+        datetime.date(2024, 3, 1),
+        datetime.date(2024, 5, 1),
+    ):
+        assert "C" in calculator.acquisition_list[date]
+    assert "A" not in calculator.portfolio
+    assert "B" not in calculator.portfolio
+    assert calculator.portfolio["C"].quantity == Decimal(18)
+
+
+def test_bed_and_breakfast_across_rename() -> None:
+    """A sell->rename->buy sequence within 30 days is matched under B&B.
+
+    HMRC treats a pure ticker rename as a continuation of the same holding,
+    so a sell of OLD followed by a buy of NEW within 30 days is the same
+    security post-rename and must B&B-match.
+    """
+    calculator = create_calculator()
+
+    transactions: list[BrokerTransaction] = [
+        BrokerTransaction(
+            date=datetime.date(2024, 6, 1),
+            action=ActionType.BUY,
+            symbol="OLD",
+            description="initial buy",
+            quantity=Decimal(100),
+            price=Decimal(10),
+            fees=Decimal(0),
+            amount=Decimal(-1000),
+            currency="GBP",
+            broker="Test",
+        ),
+        BrokerTransaction(
+            date=datetime.date(2024, 6, 11),
+            action=ActionType.SELL,
+            symbol="OLD",
+            description="disposal of OLD",
+            quantity=Decimal(100),
+            price=Decimal(8),
+            fees=Decimal(0),
+            amount=Decimal(800),
+            currency="GBP",
+            broker="Test",
+        ),
+        _rename_transaction(datetime.date(2024, 6, 16), "OLD", "NEW"),
+        BrokerTransaction(
+            date=datetime.date(2024, 6, 21),
+            action=ActionType.BUY,
+            symbol="NEW",
+            description="rebuy post-rename (within 30 days)",
+            quantity=Decimal(100),
+            price=Decimal(9),
+            fees=Decimal(0),
+            amount=Decimal(-900),
+            currency="GBP",
+            broker="Test",
+        ),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    sell_date = datetime.date(2024, 6, 11)
+    sell_entries = report.calculation_log[sell_date]["sell$NEW"]
+    rule_types = {entry.rule_type for entry in sell_entries}
+    assert RuleType.BED_AND_BREAKFAST in rule_types
+
+    bnb_entry = next(
+        entry for entry in sell_entries if entry.rule_type == RuleType.BED_AND_BREAKFAST
+    )
+    assert bnb_entry.quantity == Decimal(100)
+    # 100 sold @ £8 = £800 proceeds; B&B allowable cost is the £900 rebuy.
+    assert bnb_entry.amount == Decimal(800)
+    assert bnb_entry.allowable_cost == Decimal(900)
+    assert bnb_entry.gain == Decimal(-100)
+    assert bnb_entry.bed_and_breakfast_date_index == datetime.date(2024, 6, 21)
+
+    # Confirmed a capital loss of £100 overall.
+    assert report.total_gain() == Decimal(-100)
 
 
 def test_run_with_example_files() -> None:

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -307,8 +307,13 @@ def test_investment_only_table(tmp_path: Path) -> None:
     assert transactions[1].action == ActionType.SELL
 
 
-def test_namechange_rewrites_old_ticker_to_new(tmp_path: Path) -> None:
-    """Pre-rename buys of the old ticker are rewritten to the new ticker."""
+def test_namechange_emits_rename_transaction(tmp_path: Path) -> None:
+    """Parser emits a RENAME transaction; pre-rename buys keep the old ticker.
+
+    Symbol unification happens later in the calculator preprocessor. Leaving
+    the pre-rename buys under OLD at the parser layer keeps the rename event
+    visible end-to-end for audit.
+    """
     content = (
         "Cash Transactions\n"
         "\n"
@@ -332,17 +337,26 @@ def test_namechange_rewrites_old_ticker_to_new(tmp_path: Path) -> None:
 
     transactions = VanguardParser().load_from_file(vanguard_file)
 
-    assert len(transactions) == 2
-    # Both buys should now sit under the new ticker VGER — the pre-rename VDXX
-    # buy has been rewritten, and no synthetic trade is emitted for 18/09/2020.
-    symbols = {t.symbol for t in transactions}
-    assert symbols == {"VGER"}
-    dates = {t.date.isoformat() for t in transactions}
-    assert "2020-09-18" not in dates
+    assert len(transactions) == 3
+
+    renames = [t for t in transactions if t.action is ActionType.RENAME]
+    assert len(renames) == 1
+    rename = renames[0]
+    assert rename.symbol == "VGER"
+    assert rename.date.isoformat() == "2020-09-18"
+    assert "VDXX" in rename.description
+    assert rename.amount == Decimal(0)
+
+    # Pre-rename buy of VDXX remains under VDXX at the parser layer.
+    buys = [t for t in transactions if t.action is ActionType.BUY]
+    assert len(buys) == 2
+    buy_by_date = {t.date.isoformat(): t for t in buys}
+    assert buy_by_date["2020-06-22"].symbol == "VDXX"
+    assert buy_by_date["2020-09-28"].symbol == "VGER"
 
 
-def test_namechange_in_investment_only_table_is_skipped(tmp_path: Path) -> None:
-    """NameChange rows in an investment-only CSV parse without error and emit no txn."""
+def test_namechange_in_investment_only_table_emits_rename(tmp_path: Path) -> None:
+    """NameChange rows in an investment-only CSV emit a RENAME transaction."""
     content = (
         "Investment Transactions\n"
         "\n"
@@ -361,7 +375,14 @@ def test_namechange_in_investment_only_table_is_skipped(tmp_path: Path) -> None:
 
     transactions = VanguardParser().load_from_file(vanguard_file)
 
-    assert len(transactions) == 1
-    assert transactions[0].action == ActionType.BUY
-    assert transactions[0].symbol == "VGER"
-    assert transactions[0].quantity == Decimal(50)
+    assert len(transactions) == 2
+
+    renames = [t for t in transactions if t.action is ActionType.RENAME]
+    assert len(renames) == 1
+    assert renames[0].symbol == "VGER"
+    assert "VDXX" in renames[0].description
+
+    buys = [t for t in transactions if t.action is ActionType.BUY]
+    assert len(buys) == 1
+    assert buys[0].symbol == "VGER"
+    assert buys[0].quantity == Decimal(50)

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -305,3 +305,63 @@ def test_investment_only_table(tmp_path: Path) -> None:
     assert transactions[0].quantity == Decimal(10)
     assert transactions[0].price == Decimal("9.5")
     assert transactions[1].action == ActionType.SELL
+
+
+def test_namechange_rewrites_old_ticker_to_new(tmp_path: Path) -> None:
+    """Pre-rename buys of the old ticker are rewritten to the new ticker."""
+    content = (
+        "Cash Transactions\n"
+        "\n"
+        "Date,Details,Amount,Balance\n"
+        "22/06/2020,Bought 100 DAX UCITS ETF Distributing (VDXX),-1000.00,0\n"
+        "28/09/2020,"
+        "Bought 50 Vanguard Germany All Cap UCITS ETF (EUR) Distributing (VGER),"
+        "-600.00,0\n"
+        "\n"
+        "Investment Transactions\n"
+        "\n"
+        "Date,InvestmentName,TransactionDetails,Quantity,Price,Cost\n"
+        "18/09/2020,Vanguard Germany All Cap UCITS ETF (EUR) Distributing (VGER),"
+        "NameChange: VDXX.XLON.GB replaced with VGER.XLON.GB,"
+        "100,11.00,1100.00\n"
+        "18/09/2020,DAX UCITS ETF Distributing (VDXX),NameChange: VDXX.XLON.GB,"
+        "-100,11.00,-1100.00\n"
+    )
+    vanguard_file = tmp_path / "namechange.csv"
+    vanguard_file.write_text(content, encoding="utf-8")
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert len(transactions) == 2
+    # Both buys should now sit under the new ticker VGER — the pre-rename VDXX
+    # buy has been rewritten, and no synthetic trade is emitted for 18/09/2020.
+    symbols = {t.symbol for t in transactions}
+    assert symbols == {"VGER"}
+    dates = {t.date.isoformat() for t in transactions}
+    assert "2020-09-18" not in dates
+
+
+def test_namechange_in_investment_only_table_is_skipped(tmp_path: Path) -> None:
+    """NameChange rows in an investment-only CSV parse without error and emit no txn."""
+    content = (
+        "Investment Transactions\n"
+        "\n"
+        "Date,InvestmentName,TransactionDetails,Quantity,Price,Cost\n"
+        "18/09/2020,Vanguard Germany All Cap UCITS ETF (EUR) Distributing (VGER),"
+        "NameChange: VDXX.XLON.GB replaced with VGER.XLON.GB,"
+        "100,11.00,1100.00\n"
+        "18/09/2020,DAX UCITS ETF Distributing (VDXX),NameChange: VDXX.XLON.GB,"
+        "-100,11.00,-1100.00\n"
+        "25/09/2020,Vanguard Germany All Cap UCITS ETF (EUR) Distributing (VGER),"
+        "Bought 50 Vanguard Germany All Cap UCITS ETF (EUR) Distributing (VGER),"
+        "50,12.00,600.00\n"
+    )
+    vanguard_file = tmp_path / "inv_namechange.csv"
+    vanguard_file.write_text(content, encoding="utf-8")
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert len(transactions) == 1
+    assert transactions[0].action == ActionType.BUY
+    assert transactions[0].symbol == "VGER"
+    assert transactions[0].quantity == Decimal(50)


### PR DESCRIPTION
 In 2020, a Vanguard ETF that tracked the DAX swapped to tracking a larger (in company number) German index.

If you were affected by this, then the vanguard parser currently breaks. This change attempts to fix this, by ignoring the switch event itself (which is not CGT chargeable), and correcting purchases before the swap to the new name, for correct calculation of purchase price averages.