### PR TITLE
ci: send a User-Agent to the Trade Tariff site in the link check

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -4,5 +4,15 @@
             "pattern": "^#%EF%B8%8F-",
             "replacement": "#-"
         }
+    ],
+    "httpHeaders": [
+        {
+            "urls": [
+                "https://www.trade-tariff.service.gov.uk"
+            ],
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (compatible; markdown-link-check)"
+            }
+        }
     ]
 }


### PR DESCRIPTION
The link check reports https://www.trade-tariff.service.gov.uk/exchange_rates as dead. It is not: the site answers 403 to requests without a browser-like User-Agent and 200 with one, so the failure is bot filtering rather than a broken link.

Verified:

    curl -o /dev/null -w '%{http_code}' <url>              403
    curl -o /dev/null -w '%{http_code}' -A 'Mozilla/5.0…'  200

markdown-link-check takes per-host headers, so the fix is configuration rather than changing or removing the link. The URL is referenced twice in README.md and is where the exchange rates actually come from, so it is worth keeping.