### PR TITLE
fix: parse ordinary dividends and FX adjustments from Interactive Brokers

### DIFF
--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -56,7 +56,10 @@ def _action_from_str(action_type: str, file_path: Path) -> ActionType:
     """Infer action type."""
     if action_type == "Credit Interest":
         return ActionType.INTEREST
-    if action_type == "Payment in Lieu":
+    # A payment in lieu arrives instead of a dividend when the holding is out on
+    # loan. It is the rarer of the two, so a parser that knows it and not the
+    # ordinary dividend fails for most holders on their first real statement.
+    if action_type in ["Dividend", "Payment in Lieu"]:
         return ActionType.DIVIDEND
     if action_type in ["Deposit", "Withdrawal"]:
         return ActionType.TRANSFER
@@ -68,8 +71,26 @@ def _action_from_str(action_type: str, file_path: Path) -> ActionType:
         return ActionType.DIVIDEND_TAX
     if action_type in ["Forex Trade Component", "Other Fee"]:
         return ActionType.FEE
+    # "FX Translations P&L": the revaluation of a foreign currency balance, not
+    # a trade. It moves the cash balance and creates no taxable event, which is
+    # what ADJUSTMENT means here and how the Schwab parser treats its own.
+    if action_type == "Adjustment":
+        return ActionType.ADJUSTMENT
 
     raise ParsingError(file_path, f"Unknown type: '{action_type}'")
+
+
+def _parse_str(row: dict[str, str], column: str) -> str | None:
+    """Read a text column, treating IBKR's "-" placeholder as absent.
+
+    IBKR writes "-" wherever a column does not apply to a row, in text columns
+    as well as numeric ones. Taking it at face value puts a currency called "-"
+    on the transaction.
+    """
+    value = row.get(column)
+    if not value or value == "-":
+        return None
+    return value
 
 
 def _parse_decimal(row: dict[str, str], column: str) -> Decimal | None:
@@ -109,7 +130,9 @@ class InteractiveBrokersTransaction(BrokerTransaction):
         price = _parse_decimal(row, InteractiveBrokersColumn.PRICE)
         amount = _parse_decimal(row, InteractiveBrokersColumn.NET_AMOUNT)
         fees = _parse_decimal(row, InteractiveBrokersColumn.COMMISSION) or Decimal(0)
-        price_currency = row.get(InteractiveBrokersColumn.PRICE_CURRENCY) or "GBP"
+        price_currency = (
+            _parse_str(row, InteractiveBrokersColumn.PRICE_CURRENCY) or "GBP"
+        )
         exchange_rate = (
             _parse_decimal(row, InteractiveBrokersColumn.EXCHANGE_RATE)
             if InteractiveBrokersColumn.EXCHANGE_RATE in row

--- a/tests/interactive_brokers/data/expected_output.txt
+++ b/tests/interactive_brokers/data/expected_output.txt
@@ -1,12 +1,13 @@
 Parsing tests/interactive_brokers/data/test_basic.csv...
-Found 9 broker transactions
+Found 12 broker transactions
 First pass completed
 Final portfolio:
   CNX1: 2.00
 Final balance:
-  Interactive Brokers: 3009.80 (GBP)
+  Interactive Brokers: 3027.35 (GBP)
 Dividends:
   IBKR: 1.00, excluding 0.2 taxed at source (GBP)
+  VT: 20.00, excluding 3.0 taxed at source (GBP)
 Disposal proceeds: £2002.00
 
 Second pass completed
@@ -20,7 +21,7 @@ Capital gain: £0.00
 Capital loss: £2.50
 Total capital gain: £-2.50
 Taxable capital gain: £0
-Total dividends proceeds: £1.00
+Total dividends proceeds: £21.00
 Total amount of dividends tax yearly allowance: £500.00
 Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00

--- a/tests/interactive_brokers/data/test_basic.csv
+++ b/tests/interactive_brokers/data/test_basic.csv
@@ -8,6 +8,9 @@ Summary,Data,Starting Cash,0.0
 Summary,Data,Change,200.00
 Summary,Data,Ending Cash,200.00
 Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quantity,Price,Gross Amount ,Commission,Net Amount
+Transaction History,Data,2025-11-03,U***00000,VT(US9220427424) Cash Dividend USD 0.50 per Share,Dividend,VT,-,-,20.0,-,20.0
+Transaction History,Data,2025-11-03,U***00000,VT(US9220427424) Cash Dividend - US Tax,Foreign Tax Withholding,VT,-,-,-3.0,-,-3.0
+Transaction History,Data,2025-11-30,U***00000,FX Translations P&L,Adjustment,-,-,-,0.55,-,0.55
 Transaction History,Data,2025-10-01,U***00000,IBKR(US45841N1072) Payment in Lieu of Dividend (Ordinary Dividend),Payment in Lieu,IBKR,-,-,1.0,-,1.0
 Transaction History,Data,2025-10-01,U***00000,IBKR(US45841N1072) Payment in Lieu of Dividend - US Tax,Foreign Tax Withholding,IBKR,-,-,-0.2,-,-0.2
 Transaction History,Data,2025-10-01,U***00000,Net Amount in Base from Forex Trade: 0.8 GBP.USD,Forex Trade Component,GBP.USD,0.8,1.32,-2.637591265E-4,-,-2.637591265E-4

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -143,3 +143,52 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
             "if you added new features update the test with:\n"
             f"{cmd_str} > {expected_file}"
         )
+
+    def test_ordinary_dividend_and_its_withholding(self, tmp_path: Path) -> None:
+        """An ordinary dividend is income, and the US tax on it is withheld.
+
+        The parser knew "Payment in Lieu", which arrives instead of a dividend
+        when the holding is out on loan, but not the ordinary dividend that
+        every holder of a paying security receives. Anyone with one hit
+        "Unknown type: 'Dividend'" on their first real statement.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header
+            + "Transaction History,Data,2025-11-03,U***00000,VT(US9220427424) Cash Dividend USD 0.50 per Share,Dividend,VT,-,-,20.0,-,20.0\n"
+            + "Transaction History,Data,2025-11-03,U***00000,VT(US9220427424) Cash Dividend - US Tax,Foreign Tax Withholding,VT,-,-,-3.0,-,-3.0\n"
+        )
+
+        transactions = InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert [t.action for t in transactions] == [
+            ActionType.DIVIDEND,
+            ActionType.DIVIDEND_TAX,
+        ]
+        assert transactions[0].amount == Decimal("20.0")
+        assert transactions[0].symbol == "VT"
+        assert transactions[1].amount == Decimal("-3.0")
+
+    def test_fx_translation_adjusts_the_balance_only(self, tmp_path: Path) -> None:
+        """Revaluing a currency balance is not a disposal.
+
+        IBKR reports "FX Translations P&L" as an Adjustment. It moves the cash
+        balance and creates no taxable event: exchange movement on a personal
+        currency balance is outside CGT. The Schwab parser treats its own
+        Adjustment the same way.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header
+            + "Transaction History,Data,2025-11-30,U***00000,FX Translations P&L,Adjustment,-,-,-,0.55,-,0.55\n"
+        )
+
+        transactions = InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert len(transactions) == 1
+        assert transactions[0].action == ActionType.ADJUSTMENT
+        assert transactions[0].amount == Decimal("0.55")
+        # No quantity and no price, so it cannot become an acquisition or a
+        # disposal however it is grouped downstream.
+        assert transactions[0].quantity is None
+        assert transactions[0].price is None


### PR DESCRIPTION
A real IBKR Transaction History statement failed on unsupported `Adjustment` and `Dividend` rows.
The parser now:

- Supports ordinary dividends.
- Maps FX translation adjustments to `ActionType.ADJUSTMENT` as non-taxable cash movements.
- Treats `"-"` as empty in text fields, matching numeric fields.

Fixtures and tests now cover dividends, withholding tax, and FX adjustments. A real statement parses successfully, with dividend and tax totals matching IBKR’s dividend report and 1042-S.