### PR TITLE
Warnings are not scoped to the tax year being computed

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -894,7 +894,9 @@ class CapitalGainsCalculator:
                             search_index,
                         )
                         continue
-                    LOGGER.warning(
+                    # Bed and breakfasting is a record of how the disposal was
+                    # matched rather than a problem, so it is logged at INFO.
+                    LOGGER.info(
                         "Bed and breakfasting for %s. "
                         "Disposed on %s and acquired again on %s",
                         symbol,
@@ -1166,6 +1168,11 @@ class CapitalGainsCalculator:
         It updates the interest total for the year if needed.
         """
         for (symbol, date), foreign_amount in self.dividend_list.items():
+            # Dividends outside the computed tax year are not reported, so
+            # neither are the warnings raised while resolving their treaty.
+            if not self.date_in_tax_year(date):
+                continue
+
             tax = self.dividend_tax_list[(symbol, date)]
 
             treaty = None
@@ -1212,30 +1219,29 @@ class CapitalGainsCalculator:
                 tax.amount, foreign_amount.currency, date
             )
 
-            if self.date_in_tax_year(date):
-                dividend = Dividend(
-                    date=date,
-                    symbol=symbol,
+            dividend = Dividend(
+                date=date,
+                symbol=symbol,
+                amount=amount,
+                tax_at_source=tax_amount,
+                is_interest=is_interest_fund,
+                tax_treaty=treaty,
+            )
+
+            self.calculation_log_yields[date][f"dividend${symbol}"] = [
+                CalculationEntry(
+                    rule_type=RuleType.DIVIDEND,
+                    quantity=Decimal(1),
                     amount=amount,
-                    tax_at_source=tax_amount,
-                    is_interest=is_interest_fund,
-                    tax_treaty=treaty,
+                    new_quantity=Decimal(1),
+                    new_pool_cost=Decimal(0),
+                    fees=Decimal(0),
+                    dividend=dividend,
                 )
+            ]
 
-                self.calculation_log_yields[date][f"dividend${symbol}"] = [
-                    CalculationEntry(
-                        rule_type=RuleType.DIVIDEND,
-                        quantity=Decimal(1),
-                        amount=amount,
-                        new_quantity=Decimal(1),
-                        new_pool_cost=Decimal(0),
-                        fees=Decimal(0),
-                        dividend=dividend,
-                    )
-                ]
-
-                if is_interest_fund:
-                    self.total_foreign_interest += amount
+            if is_interest_fund:
+                self.total_foreign_interest += amount
 
     def calculate_capital_gain(
         self,

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -256,6 +256,10 @@ class SchwabTransaction(BrokerTransaction):
             symbol = transaction.symbol
             if symbol is None:
                 raise SymbolMissingError(transaction)
+            if not awards_prices:
+                # Only rows priced from the awards file need it, and this is the
+                # first of them: an account without equity awards never gets here.
+                LOGGER.warning("No Schwab Award file provided")
             # Schwab transaction list contains sometimes incorrect date
             # for awards which don't match the PDF statements.
             # We want to make sure to match date and price form the awards
@@ -653,8 +657,6 @@ class SchwabParser(BaseSingleFileParser):
             raise ParsingError(
                 file_path, "Charles Schwab transactions CSV file is empty"
             )
-        if not cls.awards_prices:
-            LOGGER.warning("No Schwab Award file provided")
         headers = lines[0]
 
         required_headers = set(

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -504,13 +504,7 @@ def test_run_with_example_files() -> None:
             f"stderr:\n{result.stderr}"
         )
 
-    stderr_lines = result.stderr.strip().split("\n")
-    expected_lines = 2
-    assert len(stderr_lines) == expected_lines
-    assert stderr_lines[0] == "WARNING: No Schwab Award file provided"
-    assert stderr_lines[1].startswith("WARNING: Bed and breakfasting for VUAG"), (
-        "Unexpected stderr message"
-    )
+    assert result.stderr.strip() == "", "Unexpected stderr message"
     expected_file = (
         Path("tests") / "general" / "data" / "test_run_with_example_files_output.txt"
     )

--- a/tests/general/test_warning_scope.py
+++ b/tests/general/test_warning_scope.py
@@ -1,0 +1,114 @@
+"""Tests for which warnings a run is allowed to emit."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cgt_calc.currency_converter import CurrencyConverter
+from cgt_calc.current_price_fetcher import CurrentPriceFetcher
+from cgt_calc.initial_prices import InitialPrices
+from cgt_calc.isin_converter import IsinConverter
+from cgt_calc.main import CapitalGainsCalculator
+from cgt_calc.spin_off_handler import SpinOffHandler
+
+from .calc_test_data import (
+    buy_transaction,
+    dividend_tax_transaction,
+    dividend_transaction,
+    sell_transaction,
+)
+
+if TYPE_CHECKING:
+    from cgt_calc.model import BrokerTransaction
+
+# Both the tax year computed by the tests below and an earlier one, so that a
+# transaction can be placed inside or outside the reported year.
+TAX_YEAR = 2024
+IN_YEAR_DATE = datetime.date(2024, 6, 3)
+EARLIER_DATE = datetime.date(2022, 6, 3)
+
+
+def _calculator(
+    transactions: list[BrokerTransaction],
+) -> CapitalGainsCalculator:
+    """Create a calculator with a flat 1:1 USD rate for the dates in use."""
+    gbp_prices = {t.date: {"USD": Decimal(1)} for t in transactions}
+    currency_converter = CurrencyConverter(None, gbp_prices)
+    return CapitalGainsCalculator(
+        TAX_YEAR,
+        currency_converter,
+        IsinConverter(),
+        CurrentPriceFetcher(currency_converter, {}, {}),
+        SpinOffHandler(),
+        InitialPrices(),
+        interest_fund_tickers=[],
+        balance_check=False,
+    )
+
+
+def _dividend_with_unexpected_withholding(
+    date: datetime.date,
+) -> list[BrokerTransaction]:
+    """Dividend taxed at 30% at source, twice the USA treaty rate."""
+    return [
+        dividend_transaction(date, "FOO", 100),
+        dividend_tax_transaction(date, "FOO", 30),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("date", "expected_warnings"),
+    [
+        pytest.param(IN_YEAR_DATE, 1, id="in-year"),
+        pytest.param(EARLIER_DATE, 0, id="earlier-year"),
+    ],
+)
+def test_treaty_mismatch_warning_scoped_to_tax_year(
+    date: datetime.date,
+    expected_warnings: int,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Only dividends of the computed year may warn about the treaty."""
+    transactions = _dividend_with_unexpected_withholding(date)
+    calculator = _calculator(transactions)
+
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
+        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.calculate_capital_gain()
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "double taxation treaty does not match" in record.message
+    ]
+    assert len(warnings) == expected_warnings
+
+
+def test_bed_and_breakfast_is_logged_at_info(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Matching a disposal to a repurchase is a record, not a problem."""
+    transactions = [
+        buy_transaction(datetime.date(2024, 5, 1), "FOO", 10, 10, 0, -100),
+        sell_transaction(datetime.date(2024, 6, 3), "FOO", 10, 12, 0, 120),
+        buy_transaction(datetime.date(2024, 6, 10), "FOO", 10, 11, 0, -110),
+    ]
+    calculator = _calculator(transactions)
+
+    with caplog.at_level(logging.INFO, logger="cgt_calc.main"):
+        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.calculate_capital_gain()
+
+    bed_and_breakfast = [
+        record for record in caplog.records if "Bed and breakfasting" in record.message
+    ]
+    assert len(bed_and_breakfast) == 1
+    assert bed_and_breakfast[0].levelno == logging.INFO
+    assert not [
+        record for record in caplog.records if record.levelno >= logging.WARNING
+    ]

--- a/tests/raw/test_raw.py
+++ b/tests/raw/test_raw.py
@@ -40,11 +40,7 @@ def test_run_with_raw_files_no_balance_check() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    stderr_lines = result.stderr.strip().split("\n")
-    assert len(stderr_lines) == 1
-    assert stderr_lines[0].startswith("WARNING: Bed and breakfasting for META"), (
-        "Unexpected stderr message"
-    )
+    assert result.stderr.strip() == "", "Unexpected stderr message"
     expected_file = Path("tests") / "raw" / "data" / "expected_output.txt"
     expected = expected_file.read_text()
     cmd_str = " ".join([param or "''" for param in cmd])
@@ -70,11 +66,7 @@ def test_run_with_raw_files() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    stderr_lines = result.stderr.strip().split("\n")
-    assert len(stderr_lines) == 1
-    assert stderr_lines[0].startswith("WARNING: Bed and breakfasting for META"), (
-        "Unexpected stderr message"
-    )
+    assert result.stderr.strip() == "", "Unexpected stderr message"
     expected_file = Path("tests") / "raw" / "data" / "expected_output_2.txt"
     expected = expected_file.read_text()
     cmd_str = " ".join([param or "''" for param in cmd])

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -1,11 +1,34 @@
 """Test Schwab parser."""
 
+import logging
 from pathlib import Path
 import subprocess
 
 import pytest
 
+from cgt_calc.parsers.schwab import AwardPrices, SchwabParser
 from tests.utils import build_cmd
+
+
+def test_missing_award_file_warns_on_the_first_row_that_needs_a_price(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A vest without a price is the only thing the award file is needed for.
+
+    The runs above parse files that never need it and stay silent; this one
+    reaches a Stock Plan Activity row, so the warning is still raised.
+    """
+    path = Path("tests") / "schwab" / "data" / "rsu_settlement" / "transactions.csv"
+    SchwabParser.awards_prices = AwardPrices(award_prices={})
+
+    with (
+        caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.schwab"),
+        path.open(encoding="utf-8") as csv_file,
+        pytest.raises(KeyError),
+    ):
+        SchwabParser.read_transactions(csv_file, path)
+
+    assert "No Schwab Award file provided" in caplog.text
 
 
 def test_run_with_schwab_example_2023_files() -> None:
@@ -23,9 +46,7 @@ def test_run_with_schwab_example_2023_files() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    stderr_lines = result.stderr.strip().split("\n")
-    assert len(stderr_lines) == 1
-    assert stderr_lines[0] == "WARNING: No Schwab Award file provided"
+    assert result.stderr.strip() == "", "Unexpected stderr message"
     expected_file = Path("tests") / "schwab" / "data" / "2023" / "expected_output.txt"
     expected = expected_file.read_text()
     cmd_str = " ".join([param or "''" for param in cmd])
@@ -52,10 +73,8 @@ def test_run_with_schwab_cash_merger_files() -> None:
             f"stderr:\n{result.stderr}"
         )
     stderr_lines = result.stderr.strip().split("\n")
-    expected_lines = 2
-    assert len(stderr_lines) == expected_lines
-    assert stderr_lines[0] == "WARNING: No Schwab Award file provided"
-    assert stderr_lines[1].startswith("WARNING: Cash Merger support is not complete")
+    assert len(stderr_lines) == 1
+    assert stderr_lines[0].startswith("WARNING: Cash Merger support is not complete")
     expected_file = (
         Path("tests") / "schwab" / "data" / "cash_merger" / "expected_output.txt"
     )
@@ -114,9 +133,7 @@ def test_run_with_schwab_bond_interest_files() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    stderr_lines = result.stderr.strip().split("\n")
-    assert len(stderr_lines) == 1
-    assert stderr_lines[0] == "WARNING: No Schwab Award file provided"
+    assert result.stderr.strip() == "", "Unexpected stderr message"
     expected_file = (
         Path("tests") / "schwab" / "data" / "bond_interest" / "expected_output.txt"
     )


### PR DESCRIPTION
## Problem

`--year 2025` emits 15 warnings, fewer than half about 2025. The calculator must walk the whole history, but it warns as if every year were in scope. Users learn to scroll past the block, so warnings that matter get missed.

## Change

Gate the treaty-mismatch warning on the computed tax year. Dividends outside it are skipped entirely — they were never reported either, since `treaty` and the `Dividend` entry are already built under a `date_in_tax_year` check.

Two tidy-ups in the same area:

- Bed and breakfasting is a record of how a disposal was matched, not a problem → `WARNING` to `INFO`.
- `No Schwab Award file provided` now fires on the first row that needs a price, not before any row is parsed. Today a cash-only Schwab account triggers it with nothing to price. It still fires at most once, since the following `AwardPrices.get` raises.

## Verification

Real 2025/26 run across Schwab equity award JSON, Schwab CSV, and IB CSV: stdout byte-identical, stderr 16 warnings → 0.

Six tests asserted warnings that are now silent. None of those fixtures has a `Stock Plan Activity` row, so `No Schwab Award file provided` was spurious in all six.

## Open questions

- Warnings about other years could go behind an opt-in flag; left out to keep this small.
- When the award file is genuinely needed and absent, the warning is followed by an unhandled `KeyError` from `AwardPrices.get`. A `ParsingError` naming `--schwab-award-file` would read better — here or in a separate PR?