### PR TITLE
Tax treaty selected by transaction currency instead of the income's source country

### DIFF
--- a/cgt_calc/const.py
+++ b/cgt_calc/const.py
@@ -50,12 +50,25 @@ DIVIDEND_ALLOWANCES: Final[dict[int, int]] = {
 # Double taxation
 # =============================================================================
 
-# Country and treaty rates per country
+# Country and treaty rates per country of the income's source, keyed by the
+# ISO 3166-1 alpha-2 code that an ISIN is prefixed with.
 # https://www.gov.uk/hmrc-internal-manuals/double-taxation-relief
 DIVIDEND_DOUBLE_TAXATION_RULES: Final[dict[str, TaxTreaty]] = {
-    "USD": TaxTreaty("USA", Decimal("0.15"), Decimal("0.15")),
-    "PLN": TaxTreaty("Poland", Decimal("0.19"), Decimal("0.1")),
+    "US": TaxTreaty("USA", Decimal("0.15"), Decimal("0.15")),
+    "PL": TaxTreaty("Poland", Decimal("0.19"), Decimal("0.1")),
 }
+
+# Fallback for transactions with no ISIN: guess the source country from the
+# currency the dividend was paid in. This is only a guess — a broker reporting
+# in the account's base currency breaks it — so it is used only as a last
+# resort, and it keeps the behaviour brokers relied on before ISINs were used.
+DIVIDEND_CURRENCY_TO_COUNTRY: Final[dict[str, str]] = {
+    "USD": "US",
+    "PLN": "PL",
+}
+
+# ISIN is prefixed with the ISO 3166-1 alpha-2 code of the issuing country.
+ISIN_COUNTRY_CODE_LENGTH: Final = 2
 
 
 # =============================================================================

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -17,9 +17,11 @@ from .const import (
     BED_AND_BREAKFAST_DAYS,
     CAPITAL_GAIN_ALLOWANCES,
     DIVIDEND_ALLOWANCES,
+    DIVIDEND_CURRENCY_TO_COUNTRY,
     DIVIDEND_DOUBLE_TAXATION_RULES,
     ERI_TAX_DATE_DELTA,
     INTERNAL_START_DATE,
+    ISIN_COUNTRY_CODE_LENGTH,
     RENAME_DESCRIPTION_PREFIX,
     UK_CURRENCY,
 )
@@ -1189,6 +1191,18 @@ class CapitalGainsCalculator:
                 )
             ]
 
+    def dividend_source_country(self, symbol: str, currency: str) -> str | None:
+        """Return the country a dividend was paid from, or None if unknown.
+
+        The ISIN a security is registered under is the authority. Where no
+        parser supplied one, fall back to guessing from the currency, which is
+        what the calculator did before ISINs were consulted.
+        """
+        isin = self.isin_converter.get_symbol_to_isin_map().get(symbol)
+        if isin is not None:
+            return isin[:ISIN_COUNTRY_CODE_LENGTH]
+        return DIVIDEND_CURRENCY_TO_COUNTRY.get(currency)
+
     def process_dividends(self) -> None:
         """Process all dividends events and taxes.
 
@@ -1204,23 +1218,30 @@ class CapitalGainsCalculator:
                     LOGGER.warning(
                         "Cannot apply taxation treaty for bond fund %s", symbol
                     )
-                elif foreign_amount.currency != UK_CURRENCY:
+                else:
                     assert tax.currency == foreign_amount.currency, (
                         f"Not matching currency for dividend {foreign_amount.currency} "
                         f"and its tax {tax.currency}"
                     )
-                    try:
-                        treaty = DIVIDEND_DOUBLE_TAXATION_RULES[foreign_amount.currency]
-                    except KeyError:
+                    country = self.dividend_source_country(
+                        symbol, foreign_amount.currency
+                    )
+                    if country is None:
                         LOGGER.warning(
-                            "Taxation treaty for %s country is missing (ticker: %s), "
+                            "Source country of the %s dividend is unknown (ticker: %s), "
                             "double taxation rules cannot be determined!",
                             foreign_amount.currency,
                             symbol,
                         )
-                        treaty = None
+                    elif country not in DIVIDEND_DOUBLE_TAXATION_RULES:
+                        LOGGER.warning(
+                            "Taxation treaty for %s country is missing (ticker: %s), "
+                            "double taxation rules cannot be determined!",
+                            country,
+                            symbol,
+                        )
                     else:
-                        assert treaty is not None
+                        treaty = DIVIDEND_DOUBLE_TAXATION_RULES[country]
                         expected_tax = treaty.country_rate * -foreign_amount.amount
                         if not approx_equal(expected_tax, tax.amount):
                             LOGGER.warning(

--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -7,11 +7,13 @@ from decimal import Decimal, InvalidOperation
 from enum import StrEnum
 from itertools import chain
 import logging
+import re
 from typing import TYPE_CHECKING, ClassVar, Final
 
 from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType, BrokerTransaction
+from cgt_calc.util import is_isin
 
 from .base_parsers import StandardCSVParser
 
@@ -23,6 +25,19 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 EXPECTED_COLS_IN_SUMMARY_SECTION: Final[int] = 4
+
+# Dividend and withholding rows name the security as "VT(US9220427424) Cash
+# Dividend ...". Trade rows carry a plain description, so this is best effort.
+_ISIN_IN_DESCRIPTION_RE: Final = re.compile(r"^[^\s(]+\((?P<isin>[A-Z0-9]{12})\)")
+
+
+def _isin_from_description(description: str) -> str | None:
+    """Return the ISIN the description is prefixed with, if it has one."""
+    match = _ISIN_IN_DESCRIPTION_RE.match(description)
+    if match is None:
+        return None
+    isin = match.group("isin")
+    return isin if is_isin(isin) else None
 
 
 class InteractiveBrokersColumn(StrEnum):
@@ -157,6 +172,7 @@ class InteractiveBrokersTransaction(BrokerTransaction):
             amount=amount,
             currency=price_currency,
             broker="Interactive Brokers",
+            isin=_isin_from_description(row[InteractiveBrokersColumn.DESCRIPTION]),
         )
 
 

--- a/tests/general/test_dividend_source_country.py
+++ b/tests/general/test_dividend_source_country.py
@@ -1,0 +1,119 @@
+"""Tests for resolving the country a dividend was paid from."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+import logging
+from typing import TYPE_CHECKING
+
+from cgt_calc.currency_converter import CurrencyConverter
+from cgt_calc.current_price_fetcher import CurrentPriceFetcher
+from cgt_calc.initial_prices import InitialPrices
+from cgt_calc.isin_converter import IsinConverter
+from cgt_calc.main import CapitalGainsCalculator
+from cgt_calc.model import ActionType, BrokerTransaction, RuleType
+from cgt_calc.spin_off_handler import SpinOffHandler
+
+if TYPE_CHECKING:
+    import pytest
+
+TAX_YEAR = 2024
+DATE = datetime.date(2024, 6, 3)
+
+# A US-domiciled security. Interactive Brokers reports its dividends in the
+# account's base currency, GBP for a UK account, while Schwab reports in USD.
+US_ISIN = "US9220427424"
+US_WITHHOLDING_RATE = Decimal("0.15")
+
+
+def _dividend_pair(
+    currency: str,
+    isin: str | None,
+    withholding_rate: Decimal = US_WITHHOLDING_RATE,
+) -> list[BrokerTransaction]:
+    """Build a dividend of 100 and the tax withheld at source on it."""
+    amount = Decimal(100)
+
+    def make(action: ActionType, value: Decimal) -> BrokerTransaction:
+        return BrokerTransaction(
+            date=DATE,
+            action=action,
+            symbol="FOO",
+            description="dividend",
+            quantity=None,
+            price=None,
+            fees=Decimal(0),
+            amount=value,
+            currency=currency,
+            broker="Test Broker",
+            isin=isin,
+        )
+
+    return [
+        make(ActionType.DIVIDEND, amount),
+        make(ActionType.DIVIDEND_TAX, -amount * withholding_rate),
+    ]
+
+
+def _treaty_country(transactions: list[BrokerTransaction]) -> str | None:
+    """Run the calculation and return the treaty applied to the dividend."""
+    gbp_prices = {DATE: {t.currency: Decimal(1) for t in transactions}}
+    currency_converter = CurrencyConverter(None, gbp_prices)
+    calculator = CapitalGainsCalculator(
+        TAX_YEAR,
+        currency_converter,
+        IsinConverter(),
+        CurrentPriceFetcher(currency_converter, {}, {}),
+        SpinOffHandler(),
+        InitialPrices(),
+        interest_fund_tickers=[],
+        balance_check=False,
+    )
+    calculator.convert_to_hmrc_transactions(transactions)
+    report = calculator.calculate_capital_gain()
+
+    entries = [
+        entry
+        for entries in report.calculation_log_yields.values()
+        for entry_list in entries.values()
+        for entry in entry_list
+        if entry.rule_type == RuleType.DIVIDEND
+    ]
+    assert len(entries) == 1
+    dividend = entries[0].dividend
+    assert dividend is not None
+    return dividend.tax_treaty.country if dividend.tax_treaty else None
+
+
+def test_treaty_from_isin_when_currency_is_not_the_source_country() -> None:
+    """A US dividend converted to GBP by the broker still gets treaty relief."""
+    assert _treaty_country(_dividend_pair("GBP", US_ISIN)) == "USA"
+
+
+def test_treaty_from_currency_when_no_isin_is_available() -> None:
+    """Brokers that supply no ISIN keep the behaviour they had before."""
+    assert _treaty_country(_dividend_pair("USD", None)) == "USA"
+
+
+def test_isin_wins_over_the_currency_guess() -> None:
+    """A US security paying in USD resolves the same way through either path."""
+    assert _treaty_country(_dividend_pair("USD", US_ISIN)) == "USA"
+
+
+def test_no_treaty_when_the_source_country_cannot_be_determined(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Without an ISIN, GBP says nothing about where the income came from."""
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
+        assert _treaty_country(_dividend_pair("GBP", None)) is None
+    assert "Source country of the GBP dividend is unknown" in caplog.text
+
+
+def test_no_treaty_when_withholding_does_not_match_the_treaty_rate(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Relief is refused when the rate deducted is not the treaty rate."""
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
+        assert _treaty_country(_dividend_pair("GBP", US_ISIN, Decimal("0.30"))) is None
+    assert "does not match the base taxation rules" in caplog.text

--- a/tests/interactive_brokers/data/expected_output.txt
+++ b/tests/interactive_brokers/data/expected_output.txt
@@ -4,9 +4,9 @@ First pass completed
 Final portfolio:
   CNX1: 2.00
 Final balance:
-  Interactive Brokers: 3027.35 (GBP)
+  Interactive Brokers: 3027.40 (GBP)
 Dividends:
-  IBKR: 1.00, excluding 0.2 taxed at source (GBP)
+  IBKR: 1.00, excluding 0.15 taxed at source (GBP)
   VT: 20.00, excluding 3.0 taxed at source (GBP)
 Disposal proceeds: £2002.00
 

--- a/tests/interactive_brokers/data/test_basic.csv
+++ b/tests/interactive_brokers/data/test_basic.csv
@@ -12,7 +12,7 @@ Transaction History,Data,2025-11-03,U***00000,VT(US9220427424) Cash Dividend USD
 Transaction History,Data,2025-11-03,U***00000,VT(US9220427424) Cash Dividend - US Tax,Foreign Tax Withholding,VT,-,-,-3.0,-,-3.0
 Transaction History,Data,2025-11-30,U***00000,FX Translations P&L,Adjustment,-,-,-,0.55,-,0.55
 Transaction History,Data,2025-10-01,U***00000,IBKR(US45841N1072) Payment in Lieu of Dividend (Ordinary Dividend),Payment in Lieu,IBKR,-,-,1.0,-,1.0
-Transaction History,Data,2025-10-01,U***00000,IBKR(US45841N1072) Payment in Lieu of Dividend - US Tax,Foreign Tax Withholding,IBKR,-,-,-0.2,-,-0.2
+Transaction History,Data,2025-10-01,U***00000,IBKR(US45841N1072) Payment in Lieu of Dividend - US Tax,Foreign Tax Withholding,IBKR,-,-,-0.15,-,-0.15
 Transaction History,Data,2025-10-01,U***00000,Net Amount in Base from Forex Trade: 0.8 GBP.USD,Forex Trade Component,GBP.USD,0.8,1.32,-2.637591265E-4,-,-2.637591265E-4
 Transaction History,Data,2025-08-15,U***00000,ISHARES NASDAQ 100 USD ACC,Sell,CNX1,-2.0,1001.00,2002.0,-3.0,1999.0
 Transaction History,Data,2025-03-15,U***00000,ISHARES NASDAQ 100 USD ACC,Buy,CNX1,4.0,1000.0,-4000.0,-3.0,-4003.0

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -84,6 +84,35 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
         assert txn.currency == expected.currency
         assert txn.broker == expected.broker
 
+    def test_isin_is_read_from_the_description(self, tmp_path: Path) -> None:
+        """Dividend rows name the security as TICKER(ISIN); trades do not."""
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header + "Transaction History,Data,2025-10-01,U***08040,"
+            "VT(US9220427424) Cash Dividend USD 0.3272 per Share (Ordinary Dividend),"
+            "Payment in Lieu,VT,-,-,1.0,-,1.0\n"
+            + "Transaction History,Data,2025-10-13,U***08040,"
+            "ISHARES NASDAQ 100 USD ACC,Buy,CNX1,1.0,1060.3,-1060.3,-3.0,-1063.3\n"
+        )
+
+        dividend, trade = InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert dividend.isin == "US9220427424"
+        assert trade.isin is None
+
+    def test_invalid_isin_in_the_description_is_ignored(self, tmp_path: Path) -> None:
+        """A malformed code must not be passed off as an ISIN."""
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header + "Transaction History,Data,2025-10-01,U***08040,"
+            "VT(US9220427429) Cash Dividend USD 0.3272 per Share (Ordinary Dividend),"
+            "Payment in Lieu,VT,-,-,1.0,-,1.0\n"
+        )
+
+        transactions = InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert transactions[0].isin is None
+
     def test_buy_foreign_currency_price(self, tmp_path: Path) -> None:
         """Test that a buy with a foreign-currency price is converted to GBP correctly.
 


### PR DESCRIPTION
## Problem

Two US-domiciled securities with identical 15% US withholding are treated differently in one run: `NVDA` gets treaty relief, `VT` does not. The reported taxable dividend total is wrong as a result.

Currency is a property of the broker, not of the income. Schwab reports US dividends in USD; Interactive Brokers converts them to the account's base currency, GBP for a UK account. Two things go wrong:

- `DIVIDEND_DOUBLE_TAXATION_RULES` is keyed by currency and `main.py` looks up `foreign_amount.currency`.
- For a GBP-denominated foreign dividend the lookup is never reached at all, because the block sits under `elif foreign_amount.currency != UK_CURRENCY`. That guard is also why `Taxation treaty for %s country is missing` never fires for such a dividend.

The guard looks redundant: the enclosing `if tax.amount < 0` already requires withholding at source, which a genuine UK dividend does not have.

## Change

The source country now comes from the ISIN, which is what the codebase already uses to identify a security — `BrokerTransaction` has the field and `IsinConverter.add_from_transaction` collects the mapping from every transaction. No broker parser populated it, so the IBKR parser starts reading it from the description it is prefixed with (`VT(US9220427424) Cash Dividend ...`), validated with `is_isin`.

- `DIVIDEND_DOUBLE_TAXATION_RULES` is re-keyed by country code. `TaxTreaty` already carried the country, so the currency key was the odd one out. It is a module constant with one call site and no CLI surface, so nothing user-facing changes shape.
- Brokers that supply no ISIN fall back to guessing the country from the currency, keeping today's behaviour for them.
- The `!= UK_CURRENCY` guard is removed.

I avoided adding a ticker → country mapping: it would duplicate what ISIN already models, and a hardcoded one does not scale, since every user holds different tickers.

## Verification

`pytest`, `ruff`, `mypy` clean. Seven new tests: five covering each way the country is resolved — three of which fail without this change, two pinning the currency fallback — and two on the parser.

On a real 2025/26 run across Schwab equity award JSON, Schwab CSV and IB CSV, `VT` now gets relief alongside `NVDA`, and the reported taxable dividend total moves from £29.99 to £0.00: `max(0, 580.54 − 500.00 − (50.55 + 36.53))`.

Two behaviour changes worth calling out:

- The fixture's withholding on a US ISIN was 20%, which the calculator now rightly reports as not matching the 15% treaty rate. I changed the synthetic figure to 15% so the fixture exercises relief being granted; no logic depends on it.
- `Source country of the %s dividend is unknown` is a new warning for anyone whose broker gives no ISIN and pays in GBP with tax withheld. Those cases were silent before.

## Open questions

- Is the currency fallback worth keeping at all, or would you rather every parser be taught to supply an ISIN first? I kept it so no existing setup regresses.
- Only `US` and `PL` exist in the table today. If you would like more treaties added while the keys are being rewritten anyway, say which.
