### PR TITLE
ci: ignore UK Trade Tariff link

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -4,5 +4,8 @@
             "pattern": "^#%EF%B8%8F-",
             "replacement": "#-"
         }
+    ],
+    "ignorePatterns": [
+        "^https://www\\.trade-tariff\\.service\\.gov\\.uk/exchange_rates$"
     ]
 }


### PR DESCRIPTION
CI pipeline is receiving 403 status when trying to fetch this link, but the page is loading fine. Ignoring this error to unblock, probably they have some bot detection mechanism.