### PR TITLE
Upload latex artifacts for debugging & fix latex race condition issues while testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,15 @@ jobs:
 
       - name: Run pytest inside container
         run: |
-          docker run --rm -e ENABLE_PDFLATEX=1 local/cgt-calc:test -lc "cd /build && uv run pytest -q"
+          docker run --rm \
+            -e ENABLE_PDFLATEX=1 \
+            -v "${{ github.workspace }}:/build" \
+            local/cgt-calc:test \
+            -lc "cd /build && uv run pytest -q"
+
+      - name: Upload e2e tests outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-outputs
+          path: out/test-*

--- a/tests/freetrade/test_freetrade.py
+++ b/tests/freetrade/test_freetrade.py
@@ -82,6 +82,8 @@ def test_run_with_freetrade_file() -> None:
         "2023",
         "--freetrade-file",
         "tests/freetrade/data/transactions.csv",
+        "--output",
+        "out/test-freetrade/",
     )
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode:

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -495,6 +495,8 @@ def test_run_with_example_files() -> None:
         "tests/trading212/data/2020/",
         "--mssb-dir",
         "tests/morgan_stanley/data/",
+        "--output",
+        "out/test-general/",
     )
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode:

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -124,6 +124,8 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
             "2025",
             "--interactive-brokers-file",
             "tests/interactive_brokers/data/test_basic.csv",
+            "--output",
+            "out/test-interactive_brokers/",
         )
         result = subprocess.run(cmd, capture_output=True, text=True, check=False)
         if result.returncode:

--- a/tests/raw/test_raw.py
+++ b/tests/raw/test_raw.py
@@ -32,6 +32,8 @@ def test_run_with_raw_files_no_balance_check() -> None:
         "--raw-file",
         "tests/raw/data/test_data.csv",
         "--no-balance-check",
+        "--output",
+        "out/test-raw/",
     )
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode:
@@ -62,6 +64,8 @@ def test_run_with_raw_files() -> None:
         "2022",
         "--raw-file",
         "tests/raw/data/test_data_2.csv",
+        "--output",
+        "out/test-raw-2/",
     )
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode:

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -15,6 +15,8 @@ def test_run_with_schwab_example_2023_files() -> None:
         "2023",
         "--schwab-file",
         "tests/schwab/data/2023/transactions.csv",
+        "--output",
+        "out/test-schwab-2023/",
     )
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode:
@@ -43,6 +45,8 @@ def test_run_with_schwab_cash_merger_files() -> None:
         "2020",
         "--schwab-file",
         "tests/schwab/data/cash_merger/transactions.csv",
+        "--output",
+        "out/test-schwab-cash-merger/",
     )
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode:
@@ -77,6 +81,8 @@ def test_run_with_schwab_rsu_settlement_files() -> None:
         "tests/schwab/data/rsu_settlement/transactions.csv",
         "--schwab-award-file",
         "tests/schwab/data/rsu_settlement/awards.csv",
+        "--output",
+        "out/test-schwab-rsu_settlement/",
     )
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode:
@@ -106,6 +112,8 @@ def test_run_with_schwab_bond_interest_files() -> None:
         "2023",
         "--schwab-file",
         "tests/schwab/data/bond_interest/transactions.csv",
+        "--output",
+        "out/test-schwab-bond_interest/",
     )
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode:

--- a/tests/sharesight/test_sharesight.py
+++ b/tests/sharesight/test_sharesight.py
@@ -32,6 +32,8 @@ def test_run_with_sharesight_files_no_balance_check() -> None:
         "--sharesight-dir",
         "tests/sharesight/data/inputs/",
         "--no-balance-check",
+        "--output",
+        "out/test-sharesight/",
     )
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode:

--- a/tests/trading212/test_trading212.py
+++ b/tests/trading212/test_trading212.py
@@ -505,6 +505,8 @@ def test_run_with_trading212_2024_files() -> None:
         "2024",
         "--trading212-dir",
         "tests/trading212/data/2024/inputs/",
+        "--output",
+        "out/test-trading212/",
     )
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode:

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -27,6 +27,8 @@ def test_run_with_vanguard_files() -> None:
         "tests/vanguard/data/cash_investment_report.csv",
         "--interest-fund-tickers",
         "FOO",
+        "--output",
+        "out/test-vanguard/",
     )
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode:


### PR DESCRIPTION
There are transient issues in the CI, I believe this is because all our e2e integration tests attempt to write into the same out/ folder. I have now:
- Added isolated output dirs for each of these tests
- Added a CI step to upload these outputs so is easier to debug CI e2e issues in the future

If you go to the "View details" in the added step, the logs provide the download URL. The outputs are only 667KB.