### PR TITLE
Missing Schwab award file ends in a traceback instead of a message

### DIFF
--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -256,21 +256,30 @@ class SchwabTransaction(BrokerTransaction):
             symbol = transaction.symbol
             if symbol is None:
                 raise SymbolMissingError(transaction)
-            if not awards_prices:
-                # Only rows priced from the awards file need it, and this is the
-                # first of them: an account without equity awards never gets here.
-                LOGGER.warning(
-                    "No Schwab Award file provided, needed to price the %s "
-                    "stock activity of %s on %s",
-                    symbol,
-                    transaction.quantity,
-                    transaction.date,
-                )
             # Schwab transaction list contains sometimes incorrect date
             # for awards which don't match the PDF statements.
             # We want to make sure to match date and price form the awards
             # spreadsheet.
-            _vest_date, transaction.price = awards_prices.get(transaction.date, symbol)
+            try:
+                _vest_date, transaction.price = awards_prices.get(
+                    transaction.date, symbol
+                )
+            except KeyError as err:
+                context = (
+                    f"the {symbol} stock activity of {transaction.quantity} "
+                    f"on {transaction.date} has no price of its own"
+                )
+                reason = (
+                    "no Schwab Award file was provided"
+                    if not awards_prices
+                    else "the Schwab Award file has no award price for it"
+                )
+                raise ParsingError(
+                    file,
+                    f"Cannot price a vest: {context}, and {reason}. "
+                    "Pass the Equity Awards transaction history with "
+                    "--schwab-award-file.",
+                ) from err
         return transaction
 
 

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -1,37 +1,54 @@
 """Test Schwab parser."""
 
-import logging
+import datetime
+from decimal import Decimal
 from pathlib import Path
 import subprocess
 
 import pytest
 
+from cgt_calc.exceptions import ParsingError
 from cgt_calc.parsers.schwab import AwardPrices, SchwabParser
 from tests.utils import build_cmd
 
 
-def test_missing_award_file_warns_on_the_first_row_that_needs_a_price(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_missing_award_file_reports_the_vest_it_cannot_price() -> None:
     """A vest without a price is the only thing the award file is needed for.
 
-    The runs above parse files that never need it and stay silent; this one
-    reaches a Stock Plan Activity row, so the warning is still raised.
+    The runs below parse files that never need it and stay silent; this one
+    reaches a Stock Plan Activity row and has nothing to price it with.
     """
     path = Path("tests") / "schwab" / "data" / "rsu_settlement" / "transactions.csv"
     SchwabParser.awards_prices = AwardPrices(award_prices={})
 
     with (
-        caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.schwab"),
         path.open(encoding="utf-8") as csv_file,
-        pytest.raises(KeyError),
+        pytest.raises(ParsingError) as exc_info,
     ):
         SchwabParser.read_transactions(csv_file, path)
 
-    assert "No Schwab Award file provided" in caplog.text
+    message = str(exc_info.value)
+    assert "no Schwab Award file was provided" in message
+    assert "--schwab-award-file" in message
     # The row that needs the file is named, so it can be found in the statement.
-    assert "BAR" in caplog.text
-    assert "2023-08-18" in caplog.text
+    assert "BAR" in message
+    assert "2023-08-18" in message
+
+
+def test_award_file_without_the_award_says_so() -> None:
+    """A file that lacks this particular award is a different mistake."""
+    path = Path("tests") / "schwab" / "data" / "rsu_settlement" / "transactions.csv"
+    SchwabParser.awards_prices = AwardPrices(
+        award_prices={datetime.date(2020, 1, 1): {"FOO": Decimal(1)}}
+    )
+
+    with (
+        path.open(encoding="utf-8") as csv_file,
+        pytest.raises(ParsingError) as exc_info,
+    ):
+        SchwabParser.read_transactions(csv_file, path)
+
+    assert "has no award price for it" in str(exc_info.value)
 
 
 def test_run_with_schwab_example_2023_files() -> None:


### PR DESCRIPTION
Follow-up to #814, as suggested there.

## Problem

A Stock Plan Activity row with no price of its own is priced from the Equity Awards file. When that lookup fails, the `KeyError` from `AwardPrices.get` was never caught, so the run ended in a traceback:

```
CRITICAL: Unexpected error!
ERROR: Details:
Traceback (most recent call last):
  ...
KeyError: 'Award price is not found for symbol BAR for date 2023-08-18'
```

Nothing in that says the user simply forgot `--schwab-award-file`.

## Change

`ParsingError` instead, naming the vest and what to do about it:

```
ERROR: While parsing .../transactions.csv: Cannot price a vest: the BAR stock
activity of 200 on 2023-08-18 has no price of its own, and no Schwab Award file
was provided. Pass the Equity Awards transaction history with --schwab-award-file.
```

A file that was provided but does not cover this award reads `the Schwab Award file has no award price for it` instead, since that is a different mistake.

The `No Schwab Award file provided` warning is removed. Since #814 it fired only on a row that needs the file, and the very next statement is the lookup that now fails — so it only ever appeared immediately before this error, and everything it reported is in the message.

## Verification

`pytest`, `ruff`, `mypy` clean. Two tests, one per reason the lookup can fail; both assert the vest is named.
