### PR TITLE
Make dependabot scan composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,11 @@ updates:
     labels:
       - "dependencies"
   - package-ecosystem: github-actions
-    directory: "/"
+    directories:
+      # Workflows in .github/workflows
+      - "/"
+      # Composite actions are not covered by "/" and must be listed explicitly
+      - "/.github/actions/*"
     schedule:
       interval: weekly
     labels:


### PR DESCRIPTION
Dependabot only scans `.github/workflows/` by default, so action pins inside `.github/actions/*` (e.g. `astral-sh/setup-uv`) were never updated. Add composite action directories to the config.