### PR TITLE
Improve release labeling automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,6 @@ updates:
       interval: weekly
     labels:
       - "dependencies"
+      # Kodiak automerges any PR with this label. GitHub Actions major bumps
+      # are safe to automerge; uv (Python) majors stay manual.
+      - "automerge"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,3 +9,7 @@ documentation:
 github structure:
   - any: [".github/**/*"]
     all: ["!**/*.py"]
+
+testing:
+  - any: ["tests/**"]
+    all: ["!cgt_calc/**"]

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -7,6 +7,10 @@
   description: Automatically merge by Kodiak
   color: d4c5f9
 
+- name: breaking
+  description: Breaking change. Used for major release bump
+  color: b60205
+
 - name: bug
   description: Something isn't working
   color: d73a4a
@@ -47,16 +51,19 @@
   description: This doesn't seem right
   color: e4e669
 
+# major/minor/patch describe the dependency's version jump on Dependabot PRs.
+# They do not affect this project's version: release bumps are driven by the
+# "breaking" and "feature" labels, see release-drafter.yml.
 - name: major
-  description: Major changes. Used for release bump
+  description: Semver-major dependency update
   color: 16970B
 
 - name: minor
-  description: Minor changes. Used for release bump
+  description: Semver-minor dependency update
   color: 16970B
 
 - name: patch
-  description: Patch changes. Used for release bump
+  description: Semver-patch dependency update
   color: 16970B
 
 - name: performance

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,6 +14,9 @@ categories:
   - title: "🏅 Code Quality Improvements"
     labels:
       - "code quality"
+  - title: "🧪 Testing"
+    labels:
+      - "testing"
   - title: "🧱 Dependency Updates"
     labels:
       - "dependencies"
@@ -23,18 +26,36 @@ categories:
       - "removal"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+# major/minor/patch labels are intentionally not used here: Dependabot applies
+# them to describe the dependency's own version jump, which says nothing about
+# this project's API.
 version-resolver:
   major:
     labels:
-      - "major"
+      - "breaking"
   minor:
     labels:
-      - "minor"
       - "feature"
-  patch:
-    labels:
-      - "patch"
   default: patch
+autolabeler:
+  - label: "bug"
+    title:
+      - "/^fix[:(]/i"
+  - label: "feature"
+    title:
+      - "/^feat[:(]/i"
+  - label: "documentation"
+    title:
+      - "/^docs[:(]/i"
+  - label: "testing"
+    title:
+      - "/^test[:(]/i"
+  - label: "github structure"
+    title:
+      - "/^ci[:(]/i"
+  - label: "code quality"
+    title:
+      - "/^refactor[:(]/i"
 template: |
   ## Changes
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,6 +24,9 @@ categories:
     labels:
       - "github structure"
       - "removal"
+# PRs with this label are left out of the release notes entirely.
+exclude-labels:
+  - "skip-release"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 # major/minor/patch labels are intentionally not used here: Dependabot applies

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,13 +4,36 @@ on:
   push:
     branches:
       - main
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
 
 jobs:
   draft_release:
     name: Release Drafter
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Run release-drafter
         uses: release-drafter/release-drafter@v7.7.0
+        with:
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  autolabel:
+    name: Autolabeler
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run release-drafter autolabeler
+        uses: release-drafter/release-drafter@v7.7.0
+        with:
+          disable-releaser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add Testing category to release notes.
- Decouple version resolution from Dependabot's `major`/`minor`/`patch` labels: releases bump major only on `breaking`, minor on `feature`, patch otherwise.
- Autolabel PRs from conventional title prefixes (release-drafter autolabeler) and label tests-only PRs via path (labeler).
- Automerge GitHub Actions major bumps: Dependabot now adds the `automerge` label, which Kodiak honors.
- Exclude `skip-release` PRs from release notes.