### PR TITLE
Adapt to rules stabilized in ruff 0.16

### DIFF
--- a/cgt_calc/parsers/eri/importer/blackrock.py
+++ b/cgt_calc/parsers/eri/importer/blackrock.py
@@ -137,7 +137,7 @@ class BlackrockImporter(ERIImporter):
                 amount = (
                     Decimal(0)
                     if isinstance(amount_raw, str) and amount_raw.lower() == "nil"
-                    else round_decimal(Decimal.from_float(amount_raw), 5)
+                    else round_decimal(Decimal(amount_raw), 5)
                 )
             except Exception as e:
                 raise ParsingError(file, f"Not valid ERI amount {amount_raw}") from e

--- a/cgt_calc/parsers/eri/importer/vanguard.py
+++ b/cgt_calc/parsers/eri/importer/vanguard.py
@@ -131,7 +131,7 @@ class VanguardImporter(ERIImporter):
                 amount = (
                     Decimal(0)
                     if isinstance(amount_raw, str) and amount_raw.lower() == "nil"
-                    else round_decimal(Decimal.from_float(amount_raw), 5)
+                    else round_decimal(Decimal(amount_raw), 5)
                 )
             except Exception as e:
                 raise ParsingError(file, f"Not valid ERI amount {amount_raw}") from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -422,6 +422,7 @@ ignore = [
   "PLR0911", # Too many return statements ({returns} > {max_returns})
   "PLR0912", # Too many branches ({branches} > {max_branches})
   "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
+  "PLR0917", # Too many positional arguments ({c_pos} > {max_pos})
   "PLR0915", # Too many statements ({statements} > {max_statements})
   "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
   "TRY003", # Avoid specifying long messages outside the exception class


### PR DESCRIPTION
Unblocks #829.

- Ignore `PLR0917` (too many positional arguments): positional-only sibling of the already-ignored `PLR0913`.
- Fix the two `FURB164` hits: `Decimal.from_float(x)` → `Decimal(x)`.