### PR TITLE
Improve parser error context and Schwab parser quality

### DIFF
--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -118,10 +118,14 @@ class QuantityNotPositiveError(InvalidTransactionError):
 class UnexpectedColumnCountError(ParsingError):
     """Unexpected column error."""
 
-    def __init__(self, row: list[str], count: int, file: Path):
+    def __init__(
+        self, row: list[str], count: int, file: Path, *, row_index: int | None = None
+    ):
         """Initialise."""
         super().__init__(
-            file, f"The following row doesn't have {count} columns:\n{row}"
+            file,
+            f"The following row doesn't have {count} columns:\n{row}",
+            row_index=row_index,
         )
 
 

--- a/cgt_calc/initial_prices.py
+++ b/cgt_calc/initial_prices.py
@@ -12,7 +12,11 @@ from typing import Final
 
 from .const import INITIAL_PRICES_RESOURCE
 from .dates import is_date
-from .exceptions import ExchangeRateMissingError, UnexpectedColumnCountError
+from .exceptions import (
+    ExchangeRateMissingError,
+    ParsingError,
+    UnexpectedColumnCountError,
+)
 from .resources import RESOURCES_PACKAGE
 
 INITIAL_PRICES_COLUMNS_NUM: Final = 3
@@ -74,11 +78,16 @@ class InitialPrices:
             with self.initial_prices_file.open(encoding="utf-8") as csv_file:
                 lines = list(csv.reader(csv_file))
         lines = lines[1:]
-        for row in lines:
-            entry = InitialPricesEntry(
-                row,
-                self.initial_prices_file or Path("resources") / INITIAL_PRICES_RESOURCE,
-            )
+        for index, row in enumerate(lines, start=2):
+            try:
+                entry = InitialPricesEntry(
+                    row,
+                    self.initial_prices_file
+                    or Path("resources") / INITIAL_PRICES_RESOURCE,
+                )
+            except ParsingError as err:
+                err.add_row_context(index)
+                raise
             date_index = entry.date
             if date_index not in initial_prices:
                 initial_prices[date_index] = {}

--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Final
 from pyrate_limiter import limiter_factory
 from pyrate_limiter.abstracts.rate import Duration
 from pyrate_limiter.extras.requests_limiter import RateLimitedRequestsSession
+from requests import exceptions as requests_exceptions
 
 from .const import CGT_TEST_MODE, INITIAL_ISIN_TRANSLATION_RESOURCE
 from .exceptions import (
@@ -158,10 +159,15 @@ class IsinConverter:
                     file_label,
                     "Unexpected header in ISIN translation data: "
                     f"expected {ISIN_TRANSLATION_HEADER}, found {header}",
+                    row_index=1,
                 )
             entries: dict[str, set[str]] = {}
-            for row in lines[1:]:
-                entry = IsinTranslationEntry(row, file_label)
+            for index, row in enumerate(lines[1:], start=2):
+                try:
+                    entry = IsinTranslationEntry(row, file_label)
+                except ParsingError as err:
+                    err.add_row_context(index)
+                    raise
                 entries[entry.isin] = entry.symbols
             return entries
 
@@ -197,7 +203,7 @@ class IsinConverter:
             response = self.session.post(url, json=data, headers=headers, timeout=10)
             response_text = response.text
             json_response = response.json()
-        except Exception as err:
+        except (requests_exceptions.RequestException, ValueError) as err:
             msg = f"Failed to fetch ISIN information for {isin}. "
             if response_text:
                 msg += f"Server response: {response_text}. "

--- a/cgt_calc/parsers/eri/raw.py
+++ b/cgt_calc/parsers/eri/raw.py
@@ -79,10 +79,13 @@ class ERIRawParser(BaseSingleFileParser):
     @staticmethod
     def _validate_header(header: list[str], file: Path, columns: list[str]) -> None:
         """Check if header is valid."""
-        for actual in header:
-            if actual not in columns:
-                msg = f"Unknown column {actual}"
-                raise ParsingError(file, msg)
+        unknown_columns = sorted(set(header) - set(columns))
+        if unknown_columns:
+            raise ParsingError(
+                file,
+                f"Unknown columns: {', '.join(unknown_columns)}",
+                row_index=1,
+            )
 
     @classmethod
     def load_from_args(cls, args: argparse.Namespace) -> list[BrokerTransaction]:
@@ -112,5 +115,11 @@ class ERIRawParser(BaseSingleFileParser):
 
         ERIRawParser._validate_header(header, file_path, COLUMNS)
 
-        lines = lines[1:]
-        return [ERIRaw(header, row, file_path) for row in lines]
+        transactions: list[BrokerTransaction] = []
+        for index, row in enumerate(lines[1:], start=2):
+            try:
+                transactions.append(ERIRaw(header, row, file_path))
+            except ParsingError as err:
+                err.add_row_context(index)
+                raise
+        return transactions

--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -210,9 +210,9 @@ class FreetradeParser(BaseSingleFileParser):
         missing = REQUIRED_COLUMNS - provided
         if missing:
             missing_columns = ", ".join(sorted(missing))
-            raise ParsingError(file, f"Missing columns: {missing_columns}")
+            raise ParsingError(file, f"Missing columns: {missing_columns}", row_index=1)
 
         unknown = provided - REQUIRED_COLUMNS
         if unknown:
             unknown_columns = ", ".join(sorted(unknown))
-            raise ParsingError(file, f"Unknown columns: {unknown_columns}")
+            raise ParsingError(file, f"Unknown columns: {unknown_columns}", row_index=1)

--- a/cgt_calc/parsers/raw.py
+++ b/cgt_calc/parsers/raw.py
@@ -179,7 +179,7 @@ class RawParser(BaseSingleFileParser):
         """Validate optional header row."""
 
         if len(header) != CSV_COLUMNS_NUM:
-            raise UnexpectedColumnCountError(header, CSV_COLUMNS_NUM, file)
+            raise UnexpectedColumnCountError(header, CSV_COLUMNS_NUM, file, row_index=1)
 
         normalized = [value.strip().lower() for value in header]
         for index, (exp, act) in enumerate(
@@ -189,6 +189,7 @@ class RawParser(BaseSingleFileParser):
                 raise ParsingError(
                     file,
                     f"Expected column {index} to be '{exp}' but found '{header[index - 1]}'",
+                    row_index=1,
                 )
 
     @staticmethod

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -7,7 +7,7 @@ from collections import OrderedDict, defaultdict
 import csv
 from dataclasses import dataclass
 import datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from enum import StrEnum
 import logging
 from typing import TYPE_CHECKING, ClassVar, Final, TextIO
@@ -38,8 +38,8 @@ LOGGER = logging.getLogger(__name__)
 CANCEL_BUY_SEARCH_DAYS: Final = 5
 
 
-class SchwabTransactionsFileRequiredHeaders(StrEnum):
-    """Enum to list the headers in Schwab transactions file that we will use."""
+class RequiredTransactionsColumn(StrEnum):
+    """Column names for Schwab transactions file."""
 
     DATE = "Date"
     ACTION = "Action"
@@ -51,8 +51,8 @@ class SchwabTransactionsFileRequiredHeaders(StrEnum):
     AMOUNT = "Amount"
 
 
-class AwardsTransactionsFileRequiredHeaders(StrEnum):
-    """Enum to list the headers in Awards transactions file that we will use."""
+class RequiredAwardColumn(StrEnum):
+    """Column names for Awards transactions file."""
 
     DATE = "Date"
     SYMBOL = "Symbol"
@@ -162,6 +162,26 @@ def action_from_str(label: str, file: Path) -> ActionType:
     raise ParsingError(file, f"Unknown action: '{label}'")
 
 
+def parse_decimal(
+    row: OrderedDict[str, str],
+    column: RequiredTransactionsColumn,
+) -> Decimal | None:
+    """Convert Schwab CSV column into Decimal, allowing optional blanks."""
+
+    raw_value = row[column]
+
+    normalized = raw_value.replace("$", "").replace(",", "").strip()
+    if normalized == "":
+        return None
+
+    try:
+        return Decimal(normalized)
+    except InvalidOperation as err:
+        raise ValueError(
+            f"Invalid decimal in column '{column.value}': {raw_value!r}"
+        ) from err
+
+
 class SchwabTransaction(BrokerTransaction):
     """Represent single Schwab transaction."""
 
@@ -179,7 +199,7 @@ class SchwabTransaction(BrokerTransaction):
         if len(row_dict) == OLD_COLUMNS_NUM and list(row_dict.values())[-1] != "":
             raise ParsingError(file, f"Column {OLD_COLUMNS_NUM} should be empty")
         as_of_str = " as of "
-        date_header = SchwabTransactionsFileRequiredHeaders.DATE.value
+        date_header = RequiredTransactionsColumn.DATE.value
         if as_of_str in row_dict[date_header]:
             index = row_dict[date_header].find(as_of_str)
             date_str = row_dict[date_header][:index]
@@ -191,39 +211,20 @@ class SchwabTransaction(BrokerTransaction):
             raise ParsingError(
                 file, f"Invalid date format: {date_str} from row: {row_dict}"
             ) from exc
-        action_header = SchwabTransactionsFileRequiredHeaders.ACTION.value
+        action_header = RequiredTransactionsColumn.ACTION.value
         self.raw_action = row_dict[action_header]
         action = action_from_str(self.raw_action, file)
-        symbol_header = SchwabTransactionsFileRequiredHeaders.SYMBOL.value
+        symbol_header = RequiredTransactionsColumn.SYMBOL.value
         symbol = row_dict[symbol_header] if row_dict[symbol_header] != "" else None
         if symbol is not None:
             symbol = TICKER_RENAMES.get(symbol, symbol)
-        description_header = SchwabTransactionsFileRequiredHeaders.DESCRIPTION.value
-        description = row_dict[description_header]
-        price_header = SchwabTransactionsFileRequiredHeaders.PRICE.value
-        price = (
-            Decimal(row_dict[price_header].replace("$", "").replace(",", ""))
-            if row_dict[price_header] != ""
-            else None
-        )
-        quantity_header = SchwabTransactionsFileRequiredHeaders.QUANTITY.value
-        quantity = (
-            Decimal(row_dict[quantity_header].replace(",", ""))
-            if row_dict[quantity_header] != ""
-            else None
-        )
-        fees_header = SchwabTransactionsFileRequiredHeaders.FEES_AND_COMM.value
-        fees = (
-            Decimal(row_dict[fees_header].replace("$", ""))
-            if row_dict[fees_header] != ""
-            else Decimal(0)
-        )
-        amount_header = SchwabTransactionsFileRequiredHeaders.AMOUNT.value
-        amount = (
-            Decimal(row_dict[amount_header].replace("$", ""))
-            if row_dict[amount_header] != ""
-            else None
-        )
+        description = row_dict[RequiredTransactionsColumn.DESCRIPTION.value]
+        price = parse_decimal(row_dict, RequiredTransactionsColumn.PRICE)
+        quantity = parse_decimal(row_dict, RequiredTransactionsColumn.QUANTITY)
+        fees = parse_decimal(
+            row_dict, RequiredTransactionsColumn.FEES_AND_COMM
+        ) or Decimal(0)
+        amount = parse_decimal(row_dict, RequiredTransactionsColumn.AMOUNT)
 
         # Handle bonds/notes: CUSIP symbols have price per $100 face value
         price, fees = adjust_cusip_bond_price(symbol, price, quantity, amount, fees)
@@ -416,9 +417,11 @@ def _unify_schwab_paired_transactions(
 
         if transaction.raw_action == "Cash Merger Adj":
             # Cash Merger Adj comes AFTER Cash Merger
-            assert len(filtered) > 0, (
-                "Cash Merger Adj must be preceded by a Cash Merger transaction"
-            )
+            if len(filtered) == 0:
+                raise ParsingError(
+                    transactions_file,
+                    "Cash Merger Adj must be preceded by a Cash Merger transaction",
+                )
             main_transaction = filtered[-1]
             adj_transaction = transaction
 
@@ -560,8 +563,6 @@ def _read_schwab_awards(
         return AwardPrices(award_prices={})
 
     initial_prices: dict[datetime.date, dict[str, Decimal]] = defaultdict(dict)
-    headers = []
-    lines = []
 
     with schwab_award_transactions_file.open(encoding="utf-8") as csv_file:
         print(f"Parsing {schwab_award_transactions_file}...")
@@ -570,17 +571,17 @@ def _read_schwab_awards(
         raise ParsingError(
             schwab_award_transactions_file, "Charles Schwab Award CSV file is empty"
         )
-    headers = lines[0]
-    required_headers = set(
-        {header.value for header in AwardsTransactionsFileRequiredHeaders}
-    )
-    if not required_headers.issubset(headers):
+    header = lines[0]
+    required_columns = set({column.value for column in RequiredAwardColumn})
+    if not required_columns.issubset(header):
         raise ParsingError(
             schwab_award_transactions_file,
-            f"Missing columns in awards file: {required_headers.difference(headers)}",
+            "Missing columns in Schwab Award file: "
+            f"{required_columns.difference(header)}",
+            row_index=1,
         )
 
-    # Remove headers
+    # Remove header
     lines = lines[1:]
 
     modulo = len(lines) % 2
@@ -589,30 +590,36 @@ def _read_schwab_awards(
             len(lines) - modulo + 2, schwab_award_transactions_file
         )
 
-    for upper_row, lower_row in zip(lines[::2], lines[1::2], strict=True):
-        # in this format each row is split into two rows,
+    for offset in range(0, len(lines), 2):
+        upper_row = lines[offset]
+        lower_row = lines[offset + 1]
+        row_index = offset + 2
+
+        # in this format each logical row is split into two rows,
         # so we combine them safely below
         row = []
         for upper_col, lower_col in zip(upper_row, lower_row, strict=True):
             assert upper_col == "" or lower_col == ""
             row.append(upper_col + lower_col)
 
-        if len(row) != len(headers):
+        if len(row) != len(header):
             raise UnexpectedColumnCountError(
-                row, len(headers), schwab_award_transactions_file
+                row,
+                len(header),
+                schwab_award_transactions_file,
+                row_index=row_index,
             )
 
-        row_dict = OrderedDict(zip(headers, row, strict=True))
-        date_header = AwardsTransactionsFileRequiredHeaders.DATE.value
-        date_str = row_dict[date_header]
+        row_dict = OrderedDict(zip(header, row, strict=True))
+        date_str = row_dict[RequiredAwardColumn.DATE.value]
         try:
             date = datetime.datetime.strptime(date_str, "%Y/%m/%d").date()
         except ValueError:
             date = datetime.datetime.strptime(date_str, "%m/%d/%Y").date()
-        symbol_header = AwardsTransactionsFileRequiredHeaders.SYMBOL.value
+        symbol_header = RequiredAwardColumn.SYMBOL.value
         symbol = row_dict[symbol_header] if row_dict[symbol_header] != "" else None
         fair_market_value_price_header = (
-            AwardsTransactionsFileRequiredHeaders.FAIR_MARKET_VALUE_PRICE.value
+            RequiredAwardColumn.FAIR_MARKET_VALUE_PRICE.value
         )
         price = (
             Decimal(row_dict[fair_market_value_price_header].replace("$", ""))
@@ -672,29 +679,40 @@ class SchwabParser(BaseSingleFileParser):
             raise ParsingError(
                 file_path, "Charles Schwab transactions CSV file is empty"
             )
-        headers = lines[0]
+        header = lines[0]
 
-        required_headers = set(
-            {header.value for header in SchwabTransactionsFileRequiredHeaders}
-        )
-        if not required_headers.issubset(headers):
+        required_headers = set({column.value for column in RequiredTransactionsColumn})
+        if not required_headers.issubset(header):
             raise ParsingError(
                 file_path,
                 "Missing columns in Schwab transaction file: "
-                f"{required_headers.difference(headers)}",
+                f"{required_headers.difference(header)}",
+                row_index=1,
             )
 
-        # Remove header
-        lines = lines[1:]
-        transactions = [
-            SchwabTransaction.create(
-                OrderedDict(zip(headers, row, strict=True)),
-                file_path,
-                cls.awards_prices,
-            )
-            for row in lines
-            if any(row)
-        ]
+        transactions: list[SchwabTransaction] = []
+        for index, row in enumerate(lines[1:], start=2):
+            if not any(row):
+                continue
+
+            if len(row) != len(header):
+                raise UnexpectedColumnCountError(
+                    row, len(header), file_path, row_index=index
+                )
+
+            try:
+                transaction = SchwabTransaction.create(
+                    OrderedDict(zip(header, row, strict=True)),
+                    file_path,
+                    cls.awards_prices,
+                )
+            except ParsingError as err:
+                err.add_row_context(index)
+                raise
+            except ValueError as err:
+                raise ParsingError(file_path, str(err), row_index=index) from err
+
+            transactions.append(transaction)
         transactions = _unify_schwab_paired_transactions(transactions, file_path)
         transactions = _filter_cancelled_buy_transactions(transactions)
         transactions.reverse()

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -595,20 +595,30 @@ def _read_schwab_awards(
         lower_row = lines[offset + 1]
         row_index = offset + 2
 
+        if len(upper_row) != len(header):
+            raise UnexpectedColumnCountError(
+                upper_row,
+                len(header),
+                schwab_award_transactions_file,
+                row_index=row_index,
+            )
+        # Some exports append an extra empty column to the lower row.
+        if len(lower_row) == len(header) + 1 and lower_row[-1] == "":
+            lower_row.pop()
+        if len(lower_row) != len(header):
+            raise UnexpectedColumnCountError(
+                lower_row,
+                len(header),
+                schwab_award_transactions_file,
+                row_index=row_index + 1,
+            )
+
         # in this format each logical row is split into two rows,
         # so we combine them safely below
         row = []
         for upper_col, lower_col in zip(upper_row, lower_row, strict=True):
             assert upper_col == "" or lower_col == ""
             row.append(upper_col + lower_col)
-
-        if len(row) != len(header):
-            raise UnexpectedColumnCountError(
-                row,
-                len(header),
-                schwab_award_transactions_file,
-                row_index=row_index,
-            )
 
         row_dict = OrderedDict(zip(header, row, strict=True))
         date_str = row_dict[RequiredAwardColumn.DATE.value]

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -332,8 +332,9 @@ class Trading212Parser(BaseDirParser):
         """Check if header is valid. Not all columns exist in every export."""
         unknown = set(header) - COLUMN_SET
         if unknown:
-            msg = f"Unknown column(s) {', '.join(sorted(unknown))}"
-            raise ParsingError(file, msg)
+            raise ParsingError(
+                file, f"Unknown column(s) {', '.join(sorted(unknown))}", row_index=1
+            )
 
     @staticmethod
     def _by_date_and_action(

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -392,12 +392,13 @@ class VanguardParser(BaseSingleFileParser):
         """Check if header matches the cash transactions columns."""
         expected = [c.value for c in CashColumn]
         if len(header) != len(expected):
-            raise UnexpectedColumnCountError(header, len(expected), file)
+            raise UnexpectedColumnCountError(header, len(expected), file, row_index=1)
         for index, (exp, act) in enumerate(zip(expected, header, strict=True), start=1):
             if exp != act:
                 raise ParsingError(
                     file,
                     f"Expected column {index} to be '{exp}' but found '{act}'",
+                    row_index=1,
                 )
 
     @classmethod

--- a/tests/general/test_eri_raw.py
+++ b/tests/general/test_eri_raw.py
@@ -82,3 +82,19 @@ def test_read_eri_raw_raises_on_invalid_isin(tmp_path: Path) -> None:
 
     with pytest.raises(ParsingError, match=f"Invalid ISIN value '{INVALID_ISIN}'"):
         ERIRawParser.load_from_file(file_path)
+
+
+def test_read_eri_raw_reports_sorted_unknown_columns(tmp_path: Path) -> None:
+    """Raise ParsingError listing unknown header columns alphabetically."""
+    file_path = tmp_path / "eri.csv"
+    file_path.write_text(
+        (
+            "Foo,ISIN,Bar,Fund Reporting Period End Date,Currency,"
+            "Excess of reporting income over distribution\n"
+            "foo-value,US5949181045,bar-value,01/02/2024,USD,1.23\n"
+        ),
+        encoding="utf8",
+    )
+
+    with pytest.raises(ParsingError, match=r"Unknown columns: Bar, Foo"):
+        ERIRawParser.load_from_file(file_path)


### PR DESCRIPTION
- Add row numbers to header and row errors in more parsers (Freetrade, RAW, Trading212, Vanguard, ERI, ISIN translation, initial prices, Schwab).
- Schwab parser cleanups: shorter column enum names, `parse_decimal` with clear errors for invalid values, `ParsingError` instead of assert for misplaced Cash Merger Adj.
- Validate both rows of each Schwab Award file pair before combining, tolerating a trailing empty column.