### PR TITLE
Report 1-based file lines in base parser row errors

### DIFF
--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -145,7 +145,8 @@ class StandardCSVParser(BaseSingleFileParser):
             )
 
         transactions: list[BrokerTransaction] = []
-        for index, row in enumerate(reader):
+        # Row numbers are 1-based file lines; the header is line 1.
+        for index, row in enumerate(reader, start=2):
             try:
                 if len(row) != expected_col_count:
                     raise UnexpectedColumnCountError(

--- a/tests/morgan_stanley/test_mssb.py
+++ b/tests/morgan_stanley/test_mssb.py
@@ -133,7 +133,7 @@ def test_read_mssb_withdrawal_invalid_decimal(tmp_path: Path) -> None:
         MSSBParser().load_from_dir(tmp_path)
 
     message = str(exc.value)
-    assert "row 0" in message
+    assert "row 2" in message
     assert "Invalid decimal in column 'Quantity'" in message
 
 


### PR DESCRIPTION
The shared parser row loop numbered rows from 0, so an error on the first data row said "row 0" while every parser-specific loop reports 1-based file lines ("row 2", header being line 1). Found while auditing the superseded `better-errors-2` branch, whose Morgan Stanley error-handling work had already landed on main via the parser class refactor.