### PR TITLE
Fix Interactive Brokers transaction ordering

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -637,6 +637,7 @@ class CapitalGainsCalculator:
                             )
                             # filter out ERI transactions, they don't affect the balance
                             if trx.action != ActionType.EXCESS_REPORTED_INCOME
+                            and trx.broker == transaction.broker
                         ]
                     )
                     + "\n"

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -87,7 +87,7 @@ class BaseSingleFileParser(BaseParser):
             transactions = cls.read_transactions(file, file_path)
             if not transactions and warn_on_empty:
                 LOGGER.warning("No transactions detected in file %s", file_path)
-            return transactions
+            return cls.post_process_transactions(transactions)
 
     @classmethod
     @abstractmethod
@@ -95,6 +95,13 @@ class BaseSingleFileParser(BaseParser):
         cls, file: TextIO, file_path: Path
     ) -> list[BrokerTransaction]:
         """Parse broker transactions from open file."""
+
+    @classmethod
+    def post_process_transactions(
+        cls, transactions: list[BrokerTransaction]
+    ) -> list[BrokerTransaction]:
+        """Do any required post processing after loading all the transactions in the dir."""
+        return transactions
 
 
 class StandardCSVParser(BaseSingleFileParser):

--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -219,7 +219,7 @@ class InteractiveBrokersParser(StandardCSVParser):
     @staticmethod
     def _by_date_and_action(
         transaction: BrokerTransaction,
-    ) -> tuple[datetime, bool]:
+    ) -> tuple[datetime.date, bool]:
         """Sort by date and action type."""
 
         # If there's a deposit in the same second as a buy
@@ -231,6 +231,6 @@ class InteractiveBrokersParser(StandardCSVParser):
     def post_process_transactions(
         cls, transactions: list[BrokerTransaction]
     ) -> list[BrokerTransaction]:
-        """Remove duplicates and sort."""
+        """Sort transactions by date, buys last."""
         transactions.sort(key=cls._by_date_and_action)
         return transactions

--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -215,3 +215,22 @@ class InteractiveBrokersParser(StandardCSVParser):
             file_path,
             "Couldn't find Transaction History header, is this the right file?",
         )
+
+    @staticmethod
+    def _by_date_and_action(
+        transaction: BrokerTransaction,
+    ) -> tuple[datetime, bool]:
+        """Sort by date and action type."""
+
+        # If there's a deposit in the same second as a buy
+        # (happens with the referral award at least)
+        # we want to put the buy last to avoid negative balance errors
+        return (transaction.date, transaction.action == ActionType.BUY)
+
+    @classmethod
+    def post_process_transactions(
+        cls, transactions: list[BrokerTransaction]
+    ) -> list[BrokerTransaction]:
+        """Remove duplicates and sort."""
+        transactions.sort(key=cls._by_date_and_action)
+        return transactions

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -223,3 +223,44 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
         # disposal however it is grouped downstream.
         assert transactions[0].quantity is None
         assert transactions[0].price is None
+
+    def test_buy_before_same_day_sell_does_not_go_negative(
+        self, tmp_path: Path
+    ) -> None:
+        """A same-day buy listed before the sell funding it must not go negative.
+
+        The file lists the buy of AAA before the sell of BBB on the same day,
+        even though the cash to pay for the buy only exists once the sell is
+        accounted for. If the transactions were processed in file order the
+        cash balance would briefly go negative and trip the balance check.
+        Sorting sells before buys on the same day (post_process_transactions)
+        avoids that, and the amounts are chosen so the buy exactly consumes
+        the sell's proceeds, leaving a final cash balance of zero.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header
+            + "Transaction History,Data,2025-01-01,U***00000,Electronic Fund Transfer,Deposit,-,-,-,1000.0,-,1000.0\n"
+            + "Transaction History,Data,2025-01-01,U***00000,BBB STOCK,Buy,BBB,10.0,100.0,-1000.0,-,-1000.0\n"
+            # Same day, buy listed before the sell that funds it.
+            + "Transaction History,Data,2025-06-02,U***00000,AAA STOCK,Buy,AAA,10.0,100.0,-1000.0,-,-1000.0\n"
+            + "Transaction History,Data,2025-06-02,U***00000,BBB STOCK,Sell,BBB,-10.0,100.0,1000.0,-,1000.0\n"
+        )
+
+        cmd = build_cmd(
+            "--year",
+            "2025",
+            "--interactive-brokers-file",
+            str(csv_file),
+            "--output",
+            str(tmp_path / "out"),
+        )
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode:
+            pytest.fail(
+                "Integration test failed\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+        assert result.stderr == ""
+        assert "Final balance:\n  Interactive Brokers: 0.00 (GBP)" in result.stdout


### PR DESCRIPTION
## Summary
- Sort Interactive Brokers transactions by date, placing buys after other same-second actions (e.g. a referral-award deposit landing in the same second as a buy) to avoid spurious negative balance errors.
- Add a `post_process_transactions` hook to `BaseSingleFileParser` so parsers can reorder/dedupe after all rows are read, and wire it up for the IB parser.
- When filtering ERI transactions out of the balance display, also scope by broker so multi-broker runs don't cross-contaminate.

## Test plan
- [ ] Existing Interactive Brokers test suite passes