### PR TITLE
Fall back to regularMarketPrice/navPrice for unrealized gains

### DIFF
--- a/cgt_calc/current_price_fetcher.py
+++ b/cgt_calc/current_price_fetcher.py
@@ -33,10 +33,18 @@ class CurrentPriceFetcher:
             return self.current_prices_data[symbol]
 
         ticker = yf.Ticker(symbol).info
-        if not ticker or "currentPrice" not in ticker:
+        if not ticker:
             return None
-        market_price_str = ticker["currentPrice"]
-        market_price_usd = Decimal(format(market_price_str, ".15g"))
+        # ETFs often lack currentPrice, e.g. VTI only has regularMarketPrice
+        # and navPrice.
+        market_price = (
+            ticker.get("currentPrice")
+            or ticker.get("regularMarketPrice")
+            or ticker.get("navPrice")
+        )
+        if market_price is None:
+            return None
+        market_price_usd = Decimal(format(market_price, ".15g"))
         return self.converter.to_gbp(
             market_price_usd, "USD", datetime.datetime.now().date()
         )

--- a/tests/general/test_current_price_fetcher.py
+++ b/tests/general/test_current_price_fetcher.py
@@ -1,0 +1,82 @@
+"""Test CurrentPriceFetcher."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from cgt_calc.currency_converter import CurrencyConverter
+from cgt_calc.current_price_fetcher import CurrentPriceFetcher
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class FakeTicker:
+    """Stand-in for yf.Ticker that returns a canned info dict."""
+
+    def __init__(self, info: dict[str, float]) -> None:
+        """Store the info dict to return."""
+        self.info = info
+
+
+def _fetcher() -> CurrentPriceFetcher:
+    today = datetime.datetime.now().date()
+    converter = CurrencyConverter(None, {today: {"USD": Decimal("1.25")}})
+    return CurrentPriceFetcher(converter)
+
+
+def test_uses_current_price_when_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """currentPrice, when present, is used as-is."""
+    monkeypatch.setattr(
+        "cgt_calc.current_price_fetcher.yf.Ticker",
+        lambda symbol: FakeTicker({"currentPrice": 100.0}),
+    )
+    price = _fetcher().get_current_market_price("AAPL")
+    assert price == Decimal("100.0") / Decimal("1.25")
+
+
+def test_falls_back_to_regular_market_price(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ETFs like VTI lack currentPrice but carry regularMarketPrice and navPrice.
+
+    See https://github.com/KapJI/capital-gains-calculator/issues/801.
+    """
+    monkeypatch.setattr(
+        "cgt_calc.current_price_fetcher.yf.Ticker",
+        lambda symbol: FakeTicker({"regularMarketPrice": 366.79, "navPrice": 366.74}),
+    )
+    price = _fetcher().get_current_market_price("VTI")
+    assert price == Decimal("366.79") / Decimal("1.25")
+
+
+def test_falls_back_to_nav_price(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Some tickers only carry navPrice, with no currentPrice or regularMarketPrice."""
+    monkeypatch.setattr(
+        "cgt_calc.current_price_fetcher.yf.Ticker",
+        lambda symbol: FakeTicker({"navPrice": 42.5}),
+    )
+    price = _fetcher().get_current_market_price("BND")
+    assert price == Decimal("42.5") / Decimal("1.25")
+
+
+def test_returns_none_when_no_price_field_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No known price field means the price is genuinely unavailable."""
+    monkeypatch.setattr(
+        "cgt_calc.current_price_fetcher.yf.Ticker",
+        lambda symbol: FakeTicker({"someOtherField": 1}),
+    )
+    assert _fetcher().get_current_market_price("XYZ") is None
+
+
+def test_returns_none_when_ticker_info_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty info dict (e.g. an unknown symbol) yields no price."""
+    monkeypatch.setattr(
+        "cgt_calc.current_price_fetcher.yf.Ticker",
+        lambda symbol: FakeTicker({}),
+    )
+    assert _fetcher().get_current_market_price("UNKNOWN") is None


### PR DESCRIPTION
## Summary
- `CurrentPriceFetcher.get_current_market_price` only checked `currentPrice` in the yfinance ticker info. Several ETFs (VTI, VXUS, BND, BNDX, EWU, ...) don't populate that field, only `regularMarketPrice` and/or `navPrice`, so `--unrealized-gains` reported "unknown" for them.
- Falls back to `regularMarketPrice`, then `navPrice`, when `currentPrice` is absent.

Fixes #801

## Test plan
- [x] Added `tests/general/test_current_price_fetcher.py`, mocking `yf.Ticker` to cover: `currentPrice` present, fallback to `regularMarketPrice`, fallback to `navPrice`, and the "no known field" / "empty info" cases returning `None`.
- [x] `CGT_TEST_MODE_STRICT=1 uv run pytest` — 243 passed.
- [x] `mypy`, `ruff format`/`check`, `pylint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)