### PR TITLE
Fix GOOG stock split date in mssb parser (June 15 -> July 15, 2022)

### DIFF
--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -77,7 +77,7 @@ class StockSplit:
 
 
 STOCK_SPLIT_INFO = [
-    StockSplit(symbol="GOOG", date=datetime.datetime(2022, 6, 15).date(), factor=20),
+    StockSplit(symbol="GOOG", date=datetime.datetime(2022, 7, 15).date(), factor=20),
 ]
 
 

--- a/tests/morgan_stanley/test_mssb.py
+++ b/tests/morgan_stanley/test_mssb.py
@@ -108,6 +108,79 @@ def test_read_mssb_withdrawal_skips_notice(tmp_path: Path) -> None:
     assert transaction.fees == Decimal(0)
 
 
+def test_read_mssb_withdrawal_goog_sale_before_split_window(tmp_path: Path) -> None:
+    """Ensure a GOOG sale shortly before the July 15, 2022 split is adjusted.
+
+    Morgan Stanley's own notice states that sales occurring "on or prior to
+    the July 15, 2022 stock split are reflected in pre-split" values. This
+    covers the previously mishandled window (2022-06-15 to 2022-07-14) where
+    a bug in STOCK_SPLIT_INFO used June 15 instead of July 15, causing these
+    sales to be skipped for the 20x split adjustment.
+    """
+
+    withdrawal_file = tmp_path / WITHDRAWALS_REPORT_FILENAME
+    rows = [
+        COLUMNS_WITHDRAWAL,
+        [
+            "01-Jul-2022",
+            "ORDER-4",
+            "GSU Class C",
+            "Sale",
+            "Complete",
+            "$2,240.00",
+            "-2.00",
+            "$4,479.90",
+            "0",
+            "N/A",
+        ],
+    ]
+    _write_csv(withdrawal_file, rows)
+
+    transactions = MSSBParser().load_from_dir(tmp_path)
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert transaction.action == ActionType.SELL
+    expected_symbol = TICKER_RENAMES.get("GOOG", "GOOG")
+    assert transaction.symbol == expected_symbol
+    # Pre-split values reported by Morgan Stanley get multiplied by the
+    # split factor (20) for quantity and divided by it for price.
+    assert transaction.quantity == Decimal("40.00")
+    assert transaction.price == Decimal("112.00")
+
+
+def test_read_mssb_withdrawal_goog_sale_after_split_not_adjusted(
+    tmp_path: Path,
+) -> None:
+    """Ensure a GOOG sale on the split date itself is treated as post-split."""
+
+    withdrawal_file = tmp_path / WITHDRAWALS_REPORT_FILENAME
+    rows = [
+        COLUMNS_WITHDRAWAL,
+        [
+            "15-Jul-2022",
+            "ORDER-5",
+            "GSU Class C",
+            "Sale",
+            "Complete",
+            "$112.00",
+            "-40.00",
+            "$4,479.90",
+            "0",
+            "N/A",
+        ],
+    ]
+    _write_csv(withdrawal_file, rows)
+
+    transactions = MSSBParser().load_from_dir(tmp_path)
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    # No adjustment should be applied on/after the split date.
+    assert transaction.quantity == Decimal("40.00")
+    assert transaction.price == Decimal("112.00")
+
+
 def test_read_mssb_withdrawal_invalid_decimal(tmp_path: Path) -> None:
     """Raise parsing error when numeric values cannot be parsed."""
 


### PR DESCRIPTION
## Summary

`STOCK_SPLIT_INFO` in `cgt_calc/parsers/mssb.py` recorded the GOOG (Alphabet) 20-for-1 stock split date as `datetime.datetime(2022, 6, 15)`. The actual split date was **July 15, 2022**, not June 15.

Evidence:
- The parser's own comment (quoting Morgan Stanley's notice text embedded in the withdrawal report CSV) says: *"Please note that any Alphabet share sales, transfers, or deposits that occurred on or prior to the July 15, 2022 stock split are reflected in pre-split. Any sales, transfers, or deposits that occurred after July 15, 2022 are in post-split values."*
- `cgt_calc/parsers/schwab_equity_award_json.py` already correctly uses `datetime.date(2022, 7, 15)` for the very same GOOG split.
- According to The Wall Street Journal: *"shareholders of record as of July 1, 2022 will receive an additional 19 shares for every share they own on Friday, July 15. The stock will then begin trading under its split-adjusted price on Monday, July 18."*

## Impact

`_handle_stock_split` only adjusts a sale's quantity/price when `transaction.date < split.date`. With the incorrect `2022-06-15` date, any GSU Class C (GOOG) sale executed between **2022-06-15 and 2022-07-14** (inclusive) was incorrectly treated as already post-split and left unadjusted, even though Morgan Stanley reports it in pre-split values. This resulted in:
- Sale quantity 20x too low
- Sale price 20x too high

for any such transaction, silently corrupting the capital gains calculation for that ~1 month window. No existing test covered this boundary (existing split-related tests use 2021/2023 dates, well outside the June-July 2022 window).

## Changes

- Fixed the split date from `datetime.datetime(2022, 6, 15)` to `datetime.datetime(2022, 7, 15)`.
- Added regression tests in `tests/morgan_stanley/test_mssb.py`:
  - A GOOG sale on `2022-07-01` (within the previously mishandled window) is now correctly adjusted by the 20x split factor. This test fails against the old `2022-06-15` date (quantity `2.00` instead of the expected `40.00`).
  - A GOOG sale on the split date itself (`2022-07-15`) is confirmed to remain unadjusted (post-split), per the `transaction.date < split.date` boundary condition.

## Test plan

- [x] `CGT_TEST_MODE_STRICT=1 uv run pytest` — 245 passed
- [x] `uv run mypy .` — no new errors (pre-existing unrelated errors in `scripts/import_eri_reports.py` only)
- [x] `uv run ruff format --check .` / `uv run ruff check .` — clean
- [x] `uv run pylint cgt_calc tests` — 10.00/10
- [x] Verified the new regression test fails under the old (buggy) `2022-06-15` date and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)