### PR TITLE
Fix unrealized gains conversion hardcoding USD as ticker currency

### DIFF
--- a/cgt_calc/current_price_fetcher.py
+++ b/cgt_calc/current_price_fetcher.py
@@ -27,6 +27,20 @@ class CurrentPriceFetcher:
         self.historical_prices_data = historical_prices_data or {}
         self.converter = converter
 
+    def _convert_to_gbp(self, price: Decimal, currency: str | None) -> Decimal:
+        """Convert a price quoted in the given yfinance currency to GBP.
+
+        yfinance uses the non-ISO code "GBp" (lowercase p) for LSE-listed
+        instruments quoted in pence rather than pounds, so that case is
+        converted directly instead of going through CurrencyConverter, which
+        only knows real ISO currency codes and has no exchange rate for it.
+        """
+        if currency == "GBp":
+            return price / Decimal(100)
+        return self.converter.to_gbp(
+            price, currency or "USD", datetime.datetime.now().date()
+        )
+
     def get_current_market_price(self, symbol: str) -> Decimal | None:
         """Given a symbol gets the current market price."""
         if self.current_prices_data is not None and symbol in self.current_prices_data:
@@ -44,23 +58,21 @@ class CurrentPriceFetcher:
         )
         if market_price is None:
             return None
-        market_price_usd = Decimal(format(market_price, ".15g"))
-        return self.converter.to_gbp(
-            market_price_usd, "USD", datetime.datetime.now().date()
-        )
+        market_price_decimal = Decimal(format(market_price, ".15g"))
+        return self._convert_to_gbp(market_price_decimal, ticker.get("currency"))
 
     def get_closing_price(self, symbol: str, date: datetime.date) -> Decimal:
         """Get the price of the share on closing time."""
         with suppress(KeyError):
             return self.historical_prices_data[symbol][date]
 
-        prices = yf.Ticker(symbol).history(
+        yf_ticker = yf.Ticker(symbol)
+        prices = yf_ticker.history(
             interval="1d",
             start=date.strftime("%Y-%m-%d"),
             end=(date + datetime.timedelta(days=1)).strftime("%Y-%m-%d"),
         )
         closing_price = prices.iloc[0]["Close"]
-        market_price_usd = Decimal(format(closing_price, ".15g"))
-        return self.converter.to_gbp(
-            market_price_usd, "USD", datetime.datetime.now().date()
-        )
+        closing_price_decimal = Decimal(format(closing_price, ".15g"))
+        currency = yf_ticker.info.get("currency") if yf_ticker.info else None
+        return self._convert_to_gbp(closing_price_decimal, currency)

--- a/tests/general/test_current_price_fetcher.py
+++ b/tests/general/test_current_price_fetcher.py
@@ -16,14 +16,16 @@ if TYPE_CHECKING:
 class FakeTicker:
     """Stand-in for yf.Ticker that returns a canned info dict."""
 
-    def __init__(self, info: dict[str, float]) -> None:
+    def __init__(self, info: dict[str, float | str]) -> None:
         """Store the info dict to return."""
         self.info = info
 
 
 def _fetcher() -> CurrentPriceFetcher:
     today = datetime.datetime.now().date()
-    converter = CurrencyConverter(None, {today: {"USD": Decimal("1.25")}})
+    converter = CurrencyConverter(
+        None, {today: {"USD": Decimal("1.25"), "EUR": Decimal("1.15")}}
+    )
     return CurrentPriceFetcher(converter)
 
 
@@ -80,3 +82,43 @@ def test_returns_none_when_ticker_info_is_empty(
         lambda symbol: FakeTicker({}),
     )
     assert _fetcher().get_current_market_price("UNKNOWN") is None
+
+
+def test_gbp_pence_quoted_ticker_is_divided_by_100(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LSE-listed tickers are quoted in pence ("GBp"), not pounds or USD.
+
+    yfinance's "GBp" is not a real ISO currency code, so it must be
+    converted directly to GBP rather than looked up via CurrencyConverter.
+    """
+    monkeypatch.setattr(
+        "cgt_calc.current_price_fetcher.yf.Ticker",
+        lambda symbol: FakeTicker({"currentPrice": 100.0, "currency": "GBp"}),
+    )
+    price = _fetcher().get_current_market_price("VOD.L")
+    assert price == Decimal("1.0")
+
+
+def test_eur_quoted_ticker_uses_eur_rate_not_usd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A EUR-quoted ticker should be converted using the EUR rate, not USD."""
+    monkeypatch.setattr(
+        "cgt_calc.current_price_fetcher.yf.Ticker",
+        lambda symbol: FakeTicker({"currentPrice": 100.0, "currency": "EUR"}),
+    )
+    price = _fetcher().get_current_market_price("MC.PA")
+    assert price == Decimal("100.0") / Decimal("1.15")
+
+
+def test_defaults_to_usd_when_currency_field_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When "currency" is missing from ticker info, fall back to USD."""
+    monkeypatch.setattr(
+        "cgt_calc.current_price_fetcher.yf.Ticker",
+        lambda symbol: FakeTicker({"currentPrice": 100.0}),
+    )
+    price = _fetcher().get_current_market_price("AAPL")
+    assert price == Decimal("100.0") / Decimal("1.25")


### PR DESCRIPTION
## Summary

`CurrentPriceFetcher.get_current_market_price()` (used by `--calc-unrealized-gains`) fetched the price from `yf.Ticker(symbol).info` but always converted it to GBP as if it were quoted in USD:

```python
market_price_usd = Decimal(format(market_price, ".15g"))
return self.converter.to_gbp(
    market_price_usd, "USD", datetime.datetime.now().date()
)
```

`yfinance`'s `ticker.info` actually exposes a `"currency"` field describing what currency the price is quoted in (e.g. `"USD"`, `"EUR"`, or `"GBp"` for LSE-listed stocks quoted in pence). Ignoring it means:

- A **EUR-quoted** ticker gets converted using the USD/GBP rate instead of the EUR/GBP rate — wrong conversion factor.
- A **GBp-quoted** (LSE) ticker, e.g. `regularMarketPrice = 100` meaning 100 pence = £1, gets divided by the USD/GBP rate instead of simply divided by 100 — off by roughly 100x. Note `"GBp"` is a yfinance-specific quirk, not a real ISO 4217 code, so `CurrencyConverter` (which only knows real ISO currency codes/HMRC rates) can't and shouldn't be asked to look up a rate for it.

This silently corrupts the `--calc-unrealized-gains` report for any non-USD symbol, which is plausible for HL/Freetrade users holding LSE tickers.

## Fix

- Added a `_convert_to_gbp` helper on `CurrentPriceFetcher` that:
  - Special-cases `currency == "GBp"` by dividing by 100 directly (no FX lookup, since it's already GBP-equivalent pence).
  - Otherwise passes the ticker's real `currency` field through to `CurrencyConverter.to_gbp(...)`.
  - Falls back to `"USD"` only when the `currency` field is genuinely absent, preserving prior behavior for USD tickers.
- `get_current_market_price()` now reads `ticker.get("currency")` from `.info` and uses the helper instead of hardcoding `"USD"`.
- `get_closing_price()` had the identical hardcoded-`"USD"` bug for historical closing prices. Fixed it too: `yf.Ticker(symbol).history(...)` doesn't carry a currency column, but the same `Ticker` object's `.info["currency"]` does, so the method now fetches `.info` once alongside `.history(...)` and reuses the same helper.

## Test plan

- Added tests in `tests/general/test_current_price_fetcher.py` (following the existing `FakeTicker`/`monkeypatch` pattern):
  - `test_gbp_pence_quoted_ticker_is_divided_by_100` — GBp price of 100 converts to £1.00, no FX lookup.
  - `test_eur_quoted_ticker_uses_eur_rate_not_usd` — EUR-quoted ticker converts using the EUR rate, not USD.
  - `test_defaults_to_usd_when_currency_field_absent` — existing USD-default fallback behavior still works when `currency` is missing.
- [x] `CGT_TEST_MODE_STRICT=1 uv run pytest` — all pass (one pre-existing, unrelated failure in `tests/hl/test_hl.py::test_hl_parser` reproduces identically on unmodified `main`, likely an environment/PDF-tooling issue).
- [x] `uv run mypy cgt_calc tests`
- [x] `uv run ruff format --check` / `uv run ruff check`
- [x] `uv run pylint cgt_calc tests` (10.00/10)
- [x] pre-commit hooks pass on the commit