### PR TITLE
Raise ParsingError for unrecognized HL reference codes

### DIFF
--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -148,7 +148,10 @@ class HargreavesLansdownParser(StandardCSVParser, BaseDirParser):
         description = row.get("Description", "")
         action_type = cls._determine_action_type(reference, description)
         if not action_type:
-            return None
+            raise ParsingError(
+                file_path,
+                f"Unknown reference: '{reference}' (description: '{description}')",
+            )
 
         date_str = row.get("Trade date", "")
         try:

--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -150,7 +150,8 @@ class HargreavesLansdownParser(StandardCSVParser, BaseDirParser):
         if not action_type:
             raise ParsingError(
                 file_path,
-                f"Unknown reference: '{reference}' (description: '{description}')",
+                f"Unknown transaction type for reference '{reference}' "
+                f"(description: '{description}')",
             )
 
         date_str = row.get("Trade date", "")

--- a/tests/hl/test_hl.py
+++ b/tests/hl/test_hl.py
@@ -172,7 +172,7 @@ def test_hl_unknown_reference_raises(tmp_path: Path) -> None:
         HargreavesLansdownParser().load_from_file(csv_file)
 
     message = str(exc.value)
-    assert "Unknown reference" in message
+    assert "Unknown transaction type" in message
     assert "D302087099" in message
 
 

--- a/tests/hl/test_hl.py
+++ b/tests/hl/test_hl.py
@@ -9,7 +9,18 @@ import pytest
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
+from cgt_calc.exceptions import ParsingError
+from cgt_calc.parsers.hl import HargreavesLansdownParser
 from tests.utils import build_cmd
+
+HL_CSV_HEADER = (
+    "Transaction Summary, , , ,\n"
+    "Client Name:,Anonymous User, , ,\n"
+    "Client Number:,1234567, , ,\n"
+    "Valuation as at,09-08-2026 16:40, , ,\n"
+    "\n"
+    "Trade date,Settle date,Reference,Description,Unit cost (p),Quantity,Value (£),\n"
+)
 
 
 def _create_buy_pdf(filename: str) -> None:
@@ -138,3 +149,43 @@ def test_hl_parser_missing_pdf() -> None:
     assert "Cannot find contract note pdf" in result.stderr, (
         "Test failed with unexpected error"
     )
+
+
+def test_hl_unknown_reference_raises(tmp_path: Path) -> None:
+    """Raise ParsingError instead of silently dropping unrecognized rows.
+
+    HL statements routinely contain rows such as dividends or corporate
+    actions whose "Reference" code isn't a Buy/Sell reference, INTEREST,
+    FPC or MANAGE FEE. Previously these rows were silently skipped, which
+    meant real dividend income could vanish from a user's report without
+    any indication anything was wrong.
+    """
+    csv_file = tmp_path / "hl-transaction-summary.csv"
+    csv_file.write_text(
+        HL_CSV_HEADER
+        + '"04/04/2026","04/04/2026","D302087099","Vanguard FTSE Developed World '
+        'UCITS ETF Dividend","n/a","n/a","12.34"\n',
+        encoding="windows-1252",
+    )
+
+    with pytest.raises(ParsingError) as exc:
+        HargreavesLansdownParser().load_from_file(csv_file)
+
+    message = str(exc.value)
+    assert "Unknown reference" in message
+    assert "D302087099" in message
+
+
+def test_hl_blank_reference_skipped(tmp_path: Path) -> None:
+    """Rows with a blank reference (e.g. subtotal/summary lines) are skipped."""
+    csv_file = tmp_path / "hl-transaction-summary.csv"
+    csv_file.write_text(
+        HL_CSV_HEADER + '"","","","Balance carried forward","","","0.00"\n',
+        encoding="windows-1252",
+    )
+
+    transactions = HargreavesLansdownParser().load_from_file(
+        csv_file, warn_on_empty=False
+    )
+
+    assert transactions == []


### PR DESCRIPTION
## Bug

`HargreavesLansdownParser.read_row()` (in `cgt_calc/parsers/hl.py`) silently returned `None` whenever `_determine_action_type()` could not map a CSV row's `Reference` code to a known `ActionType` — i.e. any reference that isn't a Buy (`B...`) or Sell (`S...`) reference, `INTEREST`, `FPC`, or `MANAGE FEE`.

`StandardCSVParser.read_transactions()` (in `base_parsers.py`) only appends the result of `read_row()` when it's truthy:

```python
transaction = cls.read_row(row, file_path)
if transaction:
    transactions.append(transaction)
```

So any unrecognized row was dropped with **no warning, no error, nothing** — there isn't even a single `LOGGER`/`logging` call anywhere in `hl.py`. HL statements routinely contain dividend rows (and other rows like corporate actions or stamp duty) whose reference code doesn't match any of the recognized patterns, so real dividend income could silently vanish from a user's tax report without any indication anything was wrong.

This is inconsistent with every other parser in the codebase, all of which raise a `ParsingError` for an unrecognized transaction type rather than silently dropping it:
- `interactive_brokers.py`: `raise ParsingError(file_path, f"Unknown type: '{action_type}'")`
- `schwab.py`: `raise ParsingError(file, f"Unknown action: '{label}'")`
- `vanguard.py`: `raise ParsingError(file, f"Unknown action: {label}")`
- `trading212.py`: `raise ParsingError(file, f"Unknown action: {label}")`

## Fix

- `read_row()` now raises `ParsingError(file_path, f"Unknown reference: '{reference}' (description: '{description}')")` when `_determine_action_type()` returns `None` for a *non-empty* reference, matching the convention used by every other parser.
- The pre-existing `if not reference: return None` branch is left untouched — a blank `Reference` corresponds to subtotal/summary lines in real HL exports, which are legitimately not transactions and should keep being skipped silently rather than erroring.

## Testing

Added two regression tests in `tests/hl/test_hl.py`:
- `test_hl_unknown_reference_raises`: a CSV row with a realistic-looking but unrecognized reference (a dividend row) now raises `ParsingError` mentioning the unknown reference, instead of being silently dropped.
- `test_hl_blank_reference_skipped`: confirms a blank-reference row (e.g. a subtotal line) is still safely skipped without error.

Full suite (`CGT_TEST_MODE_STRICT=1 uv run pytest`), `mypy`, `ruff format --check`, `ruff check`, and `pylint` all pass. Pre-commit hooks ran normally on the commit.