### PR TITLE
Fix approx_equal() ignoring its approx_quantity tolerance

### DIFF
--- a/cgt_calc/util.py
+++ b/cgt_calc/util.py
@@ -83,7 +83,7 @@ def approx_equal(
     so assume the values are equal if they are within approx_quantity input.
     Defaults to 0.01
     """
-    return abs(val_a - val_b) < Decimal("0.01")
+    return abs(val_a - val_b) < approx_quantity
 
 
 def open_with_parents(path: Path, clear_content: bool = True) -> TextIO:

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -14,10 +14,12 @@ import pytest
 from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.currency_converter import CurrencyConverter
 from cgt_calc.current_price_fetcher import CurrentPriceFetcher
+from cgt_calc.exceptions import InvalidTransactionError
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.main import CapitalGainsCalculator
 from cgt_calc.model import ActionType, BrokerTransaction, RuleType
+from cgt_calc.parsers.eri.model import ERITransaction
 from cgt_calc.spin_off_handler import SpinOffHandler
 from cgt_calc.util import round_decimal
 from tests.utils import build_cmd
@@ -153,6 +155,68 @@ def test_interest_tax_reversals_cancel_across_months() -> None:
     ]
     report = get_report(calculator, broker_transactions)
     assert report.total_interest_tax == Decimal(0)
+
+
+ERI_ISIN = "US5949181045"
+
+
+def test_eri_duplicate_report_within_tolerance_is_skipped(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A second ERI report within the 0.0001 tolerance is a harmless duplicate.
+
+    ``add_eri`` compares consecutive reports for the same symbol/date with
+    ``approx_equal(previous_price, price, Decimal("0.0001"))``. Prices this
+    close should be treated as the same report arriving twice (e.g. from
+    overlapping input files) and simply skipped with a warning.
+    """
+    date = datetime.date(2024, 6, 30)
+    calculator = create_calculator()
+    calculator.isin_converter.data[ERI_ISIN] = {"VWRL"}
+
+    transactions: list[BrokerTransaction] = [
+        ERITransaction(
+            date=date, isin=ERI_ISIN, price=Decimal("1.00000"), currency="GBP"
+        ),
+        ERITransaction(
+            date=date, isin=ERI_ISIN, price=Decimal("1.00005"), currency="GBP"
+        ),
+    ]
+
+    calculator.convert_to_hmrc_transactions(transactions)
+
+    assert "Skipping duplicated ERI transaction" in caplog.text
+    assert calculator.eris[date]["VWRL"].price == Decimal("1.00000")
+
+
+def test_eri_conflicting_report_raises_invalid_transaction_error() -> None:
+    """A second ERI report that materially differs must raise, not be accepted.
+
+    Regression test: ``approx_equal`` used to ignore its ``approx_quantity``
+    argument and always compare against a hardcoded ``Decimal("0.01")``. Since
+    ``add_eri`` calls it with a much tighter ``Decimal("0.0001")`` tolerance to
+    tell apart a duplicate report from a genuinely conflicting one, that bug
+    made any two ERI prices within 0.01 GBP of each other silently accepted as
+    duplicates (first-seen price wins), even though they should have raised
+    ``InvalidTransactionError``. Here the prices differ by 0.005, which is
+    more than the intended 0.0001 tolerance but less than the old, buggy 0.01
+    one.
+    """
+    date = datetime.date(2024, 6, 30)
+    calculator = create_calculator()
+    calculator.isin_converter.data[ERI_ISIN] = {"VWRL"}
+
+    transactions: list[BrokerTransaction] = [
+        ERITransaction(
+            date=date, isin=ERI_ISIN, price=Decimal("1.0000"), currency="GBP"
+        ),
+        ERITransaction(
+            date=date, isin=ERI_ISIN, price=Decimal("1.0050"), currency="GBP"
+        ),
+    ]
+
+    with pytest.raises(InvalidTransactionError, match="conflicting ERI report"):
+        calculator.convert_to_hmrc_transactions(transactions)
 
 
 @pytest.mark.parametrize(

--- a/tests/general/test_util.py
+++ b/tests/general/test_util.py
@@ -1,0 +1,40 @@
+"""Tests for cgt_calc.util helpers."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from cgt_calc.util import approx_equal
+
+
+@pytest.mark.parametrize(
+    ("val_a", "val_b", "approx_quantity", "expected"),
+    [
+        # Default tolerance (0.01): values within/outside of it.
+        (Decimal("1.00"), Decimal("1.005"), Decimal("0.01"), True),
+        (Decimal("1.00"), Decimal("1.02"), Decimal("0.01"), False),
+        # A tight explicit tolerance (0.0001) must actually be honoured:
+        # a difference of 0.005 is well within the old hardcoded 0.01
+        # default but must fail a tighter 0.0001 tolerance.
+        (Decimal("1.0000"), Decimal("1.0050"), Decimal("0.0001"), False),
+        (Decimal("1.0000"), Decimal("1.00005"), Decimal("0.0001"), True),
+        # A looser explicit tolerance (1) must also be honoured: a
+        # difference that would fail the hardcoded 0.01 default should
+        # pass here.
+        (Decimal("1.00"), Decimal("1.50"), Decimal(1), True),
+        (Decimal("1.00"), Decimal("3.00"), Decimal(1), False),
+    ],
+)
+def test_approx_equal_respects_approx_quantity(
+    val_a: Decimal, val_b: Decimal, approx_quantity: Decimal, expected: bool
+) -> None:
+    """approx_equal must compare against the given tolerance, not a hardcoded one."""
+    assert approx_equal(val_a, val_b, approx_quantity) is expected
+
+
+def test_approx_equal_default_tolerance() -> None:
+    """approx_equal defaults to a tolerance of 0.01 when none is given."""
+    assert approx_equal(Decimal("1.00"), Decimal("1.005")) is True
+    assert approx_equal(Decimal("1.00"), Decimal("1.02")) is False


### PR DESCRIPTION
## Summary

`approx_equal()` in `cgt_calc/util.py` takes an `approx_quantity` parameter but its body ignores it and always compares against a hardcoded `Decimal("0.01")`:

```python
def approx_equal(
    val_a: Decimal, val_b: Decimal, approx_quantity: Decimal = Decimal("0.01")
) -> bool:
    ...
    return abs(val_a - val_b) < Decimal("0.01")  # should use approx_quantity
```

### Impact on ERI conflict detection

`add_eri()` in `cgt_calc/main.py` calls `approx_equal(previous_price, price, Decimal("0.0001"))` when a second ERI (excess reportable income) report arrives for the same symbol/date, to distinguish a harmless duplicate report (skip with a warning) from a genuine conflict (raise `InvalidTransactionError`).

Because of the bug, the intended `0.0001` tolerance was silently replaced with `0.01` — 100x looser. Any two ERI prices within 0.01 GBP of each other were treated as duplicates, so genuinely conflicting reports (e.g. two different providers reporting different figures for the same fund/date) were silently accepted, with the first-seen price winning. This produces a wrong cost-basis uplift with no error raised — exactly the case `add_eri()`'s conflict check is meant to catch.

Other call sites of `approx_equal()` (`cgt_calc/model.py`, and the other calls in `main.py`) all use the default `Decimal("0.01")` tolerance, so this fix doesn't change their behavior — only calls passing an explicit non-default `approx_quantity` (i.e. this one) are affected.

## Changes

- `cgt_calc/util.py`: `approx_equal()` now compares against `approx_quantity` instead of the hardcoded `0.01`.
- `tests/general/test_util.py` (new): direct unit tests for `approx_equal()` covering the tolerance parameter, including cases that pass under the buggy hardcoded `0.01` but should fail a tighter explicit tolerance (and vice versa for a looser one).
- `tests/general/test_calc.py`: two new tests exercising `add_eri()`'s duplicate-vs-conflict detection:
  - `test_eri_duplicate_report_within_tolerance_is_skipped` — prices within `0.0001` are still correctly treated as a harmless duplicate.
  - `test_eri_conflicting_report_raises_invalid_transaction_error` — prices differing by `0.005` (more than the intended `0.0001` tolerance, but less than the old buggy `0.01` one) now correctly raise `InvalidTransactionError` instead of being silently accepted. This test fails against the pre-fix code, confirming it reproduces the bug.

## Test plan

- [x] `CGT_TEST_MODE_STRICT=1 uv run pytest` — all 252 tests pass
- [x] `uv run mypy cgt_calc tests` — clean
- [x] `uv run ruff format --check .` / `uv run ruff check .` — clean
- [x] `uv run pylint` on changed files — 10.00/10
- [x] Verified the new tests fail against the pre-fix `approx_equal()` implementation, confirming they reproduce the bug
- [x] `pre-commit run` (all hooks) — passing