### PR TITLE
Fix dead empty-file check and unhandled crash on short CSV rows in StandardCSVParser

### DIFF
--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -154,15 +154,24 @@ class StandardCSVParser(BaseSingleFileParser):
         cls._validate_header(reader.fieldnames, file_path)
         expected_col_count = len(reader.fieldnames)
 
-        if not reader:
-            raise ParsingError(
-                file_path, f"{cls.pretty_name} {cls.format_name} file is empty"
-            )
-
         transactions: list[BrokerTransaction] = []
+        saw_row = False
         # Row numbers are 1-based file lines; the header is line 1.
         for index, row in enumerate(reader, start=2):
+            saw_row = True
             try:
+                # A row with MORE fields than the header collects the extras
+                # under DictReader's `None` key (`restkey`), which changes
+                # `len(row)`. A row with FEWER fields is instead padded with
+                # `None` values for the missing trailing keys (`restval`), so
+                # `len(row)` alone can't detect it here. We deliberately don't
+                # reject those on `None` values alone: some parsers (e.g.
+                # Morgan Stanley's withdrawal report) legitimately rely on
+                # DictReader padding a short trailing row to recognise and
+                # skip it in `read_row`. Instead, a short/malformed row that
+                # a parser doesn't expect is caught below when it blows up
+                # trying to parse a `None` field, and reported with row
+                # context rather than as an unhandled traceback.
                 if len(row) != expected_col_count:
                     raise UnexpectedColumnCountError(
                         list(row.values()), expected_col_count, file_path
@@ -173,8 +182,13 @@ class StandardCSVParser(BaseSingleFileParser):
             except ParsingError as err:
                 err.add_row_context(index)
                 raise
-            except ValueError as err:
+            except (ValueError, TypeError, AttributeError) as err:
                 raise ParsingError(file_path, str(err), row_index=index) from err
+
+        if not saw_row:
+            raise ParsingError(
+                file_path, f"{cls.pretty_name} {cls.format_name} file is empty"
+            )
         return transactions
 
 

--- a/tests/morgan_stanley/test_mssb.py
+++ b/tests/morgan_stanley/test_mssb.py
@@ -148,3 +148,49 @@ def test_read_mssb_release_invalid_header(tmp_path: Path) -> None:
         MSSBParser().load_from_dir(tmp_path)
 
     assert "CSV header mismatch" in str(exc.value)
+
+
+def test_read_mssb_release_header_only_file(tmp_path: Path) -> None:
+    """Raise a clean 'file is empty' error for a header with zero data rows.
+
+    Regression test: `csv.DictReader` has no `__bool__`/`__len__`, so
+    `bool(reader)` is always truthy even when the file has no data rows,
+    which used to make the "file is empty" check dead code.
+    """
+
+    release_file = tmp_path / RELEASES_REPORT_FILENAME
+    _write_csv(release_file, [COLUMNS_RELEASE])
+
+    with pytest.raises(ParsingError) as exc:
+        MSSBParser().load_from_dir(tmp_path)
+
+    assert "file is empty" in str(exc.value)
+
+
+def test_read_mssb_withdrawal_short_row(tmp_path: Path) -> None:
+    """Raise a clean ParsingError for a row with fewer fields than the header.
+
+    Regression test: a row with fewer fields than the header gets padded by
+    `csv.DictReader` with `None` values for the missing trailing columns
+    (rather than being rejected outright). Before the fix, this crashed deep
+    in `_parse_decimal` with an unhandled `AttributeError` ('NoneType' object
+    has no attribute 'replace') instead of raising a clean ParsingError with
+    row/file context.
+    """
+
+    withdrawal_file = tmp_path / WITHDRAWALS_REPORT_FILENAME
+    rows = [
+        COLUMNS_WITHDRAWAL,
+        # Only the first 6 columns are provided; Quantity, Net Amount,
+        # Net Share Proceeds and Tax Payment Method are missing entirely.
+        ["02-Apr-2021", "ORDER-2", "Cash", "Sale", "Complete", "$10.00"],
+    ]
+    _write_csv(withdrawal_file, rows)
+
+    with pytest.raises(ParsingError) as exc:
+        MSSBParser().load_from_dir(tmp_path)
+
+    # It must be a *clean* ParsingError with row/file context, not an
+    # unhandled AttributeError/TypeError bubbling out of the parser.
+    assert exc.type is ParsingError
+    assert "row 2" in str(exc.value)


### PR DESCRIPTION
## Summary

`StandardCSVParser.read_transactions()` in `cgt_calc/parsers/base_parsers.py` (used by `hl.py`, `mssb.py`, `interactive_brokers.py`) had two related bugs.

### Bug A: dead "file is empty" check

```python
if not reader:
    raise ParsingError(...)
```

`csv.DictReader` implements neither `__bool__` nor `__len__`, so `bool(reader)` is always `True`:

```python
>>> import csv, io
>>> bool(csv.DictReader(io.StringIO("a,b,c\n")))
True
```

A header-only CSV therefore silently produced an empty transaction list instead of raising `ParsingError(..., "... file is empty")`. Fixed with a `saw_row` flag set inside the existing row loop; if the loop never runs, `read_transactions` raises the "file is empty" error after it. This keeps the row processing fully streaming (no need to materialize the whole file into a list just to check for emptiness).

### Bug B: short rows silently pass the column-count check

```python
if len(row) != expected_col_count:
    raise UnexpectedColumnCountError(...)
```

`DictReader` handles malformed rows asymmetrically:
- **Extra** fields are collected into a list under a `None` key (`restkey`), which *does* change `len(row)` — this case was already caught.
- **Fewer** fields than the header get the missing trailing keys padded with `None` (`restval`) — `len(row)` stays equal to the header length, so this case slipped through untouched.

A truncated row (e.g. only `date,action` values supplied against a wider header) would then reach `read_row()` with `None` for the missing trailing fields, and crash deep in parser-specific code with an unhandled exception, e.g. in `mssb.py`'s `_parse_decimal`:

```
AttributeError: 'NoneType' object has no attribute 'replace'
```

**Why the obvious fix doesn't work:** the natural fix is a pre-check like `if len(row) != expected_col_count or None in row.values():` before calling `read_row`. This works for most cases but **breaks `mssb.py`'s withdrawal report parser**, which intentionally relies on `DictReader` padding a short trailing row so it can recognise and skip Morgan Stanley's "Please note that any Alphabet share sales..." notice line (see `test_read_mssb_withdrawal_skips_notice`) — that notice line only has 1 field against a 10-column header, and is structurally indistinguishable from a genuinely malformed short row at this generic layer.

Instead, the fix broadens the exception handling around the `read_row()` call to also catch `AttributeError`/`TypeError` (in addition to the existing `ValueError`) and convert them into a clean `ParsingError` with row/file context. This fixes the actual reported symptom (unhandled crash) while leaving subclasses free to handle intentionally short/malformed rows themselves (as MSSB already does).

## Test plan

- [x] Added `test_read_mssb_release_header_only_file`: a release report with only the header row now raises `ParsingError` containing "file is empty" (previously silently returned zero transactions).
- [x] Added `test_read_mssb_withdrawal_short_row`: a withdrawal row missing its trailing columns now raises a clean `ParsingError` with row context instead of an unhandled `AttributeError`.
- [x] Verified both new tests fail against the pre-fix code and pass after the fix.
- [x] Confirmed `test_read_mssb_withdrawal_skips_notice` (existing test relying on short-row tolerance) still passes.
- [x] `CGT_TEST_MODE_STRICT=1 uv run pytest` — 245 passed.
- [x] `uv run mypy .` — clean (pre-existing unrelated errors in `scripts/import_eri_reports.py` only).
- [x] `uv run ruff format --check` / `uv run ruff check` — clean.
- [x] `uv run pylint` — 10.00/10.
- [x] pre-commit hooks ran and passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
