### PR TITLE
Add support for processing file descriptors and standard input

### DIFF
--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 
 from .const import INTERNAL_START_DATE
 
+STDIN_PATH = Path("-")
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any
@@ -73,9 +75,11 @@ def optional_file_type(value: str) -> Path | None:
     """Convert non-empty value to Path and ensure file semantics."""
     if value.strip() == "":
         return None
+    if value == "-":
+        return STDIN_PATH
     path = Path(value)
     if path.exists():
-        if not path.is_file():
+        if not (path.is_file() or path.is_fifo()):
             raise argparse.ArgumentTypeError(
                 f"expected file path, got directory: '{value}'"
             )
@@ -90,7 +94,7 @@ def _existing_path_type(value: str, *, require_dir: bool) -> Path:
         raise argparse.ArgumentTypeError(f"path does not exist: '{value}'")
     if require_dir and not path.is_dir():
         raise argparse.ArgumentTypeError(f"expected directory path, got: '{value}'")
-    if not require_dir and not path.is_file():
+    if not require_dir and not (path.is_file() or path.is_fifo()):
         raise argparse.ArgumentTypeError(f"expected file path, got: '{value}'")
     if require_dir:
         _ensure_readable_directory(path, value)
@@ -100,7 +104,9 @@ def _existing_path_type(value: str, *, require_dir: bool) -> Path:
 
 
 def existing_file_type(value: str) -> Path:
-    """Validate that provided value points to an existing file."""
+    """Validate that provided value points to an existing file, or '-' for stdin."""
+    if value == "-":
+        return STDIN_PATH
     return _existing_path_type(value, require_dir=False)
 
 

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -6,9 +6,11 @@ from collections.abc import Iterable, Sequence
 import csv
 import logging
 from pathlib import Path
+import sys
 from typing import ClassVar, TextIO
 
 from cgt_calc.args_validators import (
+    STDIN_PATH,
     DeprecatedAction,
     existing_directory_type,
     existing_file_type,
@@ -82,13 +84,18 @@ class BaseSingleFileParser(BaseParser):
         cls, file_path: Path, warn_on_empty: bool = True, show_parsing_msg: bool = True
     ) -> list[BrokerTransaction]:
         """Load broker data from file path."""
-        with file_path.open(encoding=cls.encoding) as file:
+        if file_path == STDIN_PATH:
             if show_parsing_msg:
-                print(f"Parsing {file_path}...")
-            transactions = cls.read_transactions(file, file_path)
-            if not transactions and warn_on_empty:
-                LOGGER.warning("No transactions detected in file %s", file_path)
-            return cls.post_process_transactions(transactions)
+                print("Parsing stdin...")
+            transactions = cls.read_transactions(sys.stdin, STDIN_PATH)
+        else:
+            with file_path.open(encoding=cls.encoding) as file:
+                if show_parsing_msg:
+                    print(f"Parsing {file_path}...")
+                transactions = cls.read_transactions(file, file_path)
+        if not transactions and warn_on_empty:
+            LOGGER.warning("No transactions detected in file %s", file_path)
+        return cls.post_process_transactions(transactions)
 
     @classmethod
     @abstractmethod

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -12,6 +12,7 @@ import pytest
 
 from cgt_calc.args_parser import create_parser
 from cgt_calc.args_validators import (
+    STDIN_PATH,
     existing_directory_type,
     existing_file_type,
     optional_file_type,
@@ -494,3 +495,15 @@ def test_interest_fund_tickers_empty_items_filtered() -> None:
     args = parser.parse_args(["--interest-fund-tickers", "VGOV,,VBMFX,"])
 
     assert args.interest_fund_tickers == ["VGOV", "VBMFX"]
+
+
+def test_existing_file_type_stdin() -> None:
+    """Ensure existing_file_type returns STDIN_PATH when passed '-'."""
+    assert existing_file_type("-") == STDIN_PATH
+
+
+def test_raw_file_stdin() -> None:
+    """Ensure --raw-file - correctly returns STDIN_PATH."""
+    parser = create_parser()
+    args = parser.parse_args(["--raw-file", "-"])
+    assert args.raw_file == STDIN_PATH

--- a/tests/raw/data/expected_output_stdin.txt
+++ b/tests/raw/data/expected_output_stdin.txt
@@ -1,0 +1,38 @@
+Parsing stdin...
+Found 16 broker transactions
+First pass completed
+Final portfolio:
+  AMZN: 210.00
+  OPRA: 120.00
+  BABA: 30.00
+  META: 119.00
+Final balance:
+  Unknown: -28486.60 (USD)
+Dividends:
+  OTGLY: 9.68 (USD)
+  OPRA: 3360.00 (USD)
+Disposal proceeds: £11422.10
+
+Second pass completed
+Portfolio at the end of 2022/2023 tax year:
+  AMZN: 210.00, £1900.67
+  OPRA: 120.00, £492.03
+  BABA: 30.00, £1942.83
+  META: 119.00, £18042.21
+For tax year 2022/2023:
+Number of disposals: 3
+Disposal proceeds: £11422.10
+Allowable costs: £13588.22
+Capital gain: £0.00
+Capital loss: £2166.12
+Total capital gain: £-2166.12
+Taxable capital gain: £0
+Total dividends proceeds: £2719.29
+Total amount of dividends tax yearly allowance: £2000.00
+Total taxable dividends proceeds: £719.29
+Total UK interest proceeds: £0.00
+Total foreign interest proceeds: £0.00
+Total interest tax paid: £0.00
+
+Generating PDF report...
+All done!

--- a/tests/raw/test_raw.py
+++ b/tests/raw/test_raw.py
@@ -81,6 +81,56 @@ def test_run_with_raw_files() -> None:
     )
 
 
+def test_run_with_raw_files_stdin() -> None:
+    """Runs the script with stdin and verifies it works identically."""
+    csv_file = Path("tests") / "raw" / "data" / "test_data.csv"
+    csv_content = csv_file.read_text(encoding="utf-8")
+
+    cmd = build_cmd(
+        "--year",
+        "2022",
+        "--raw-file",
+        "-",
+        "--no-balance-check",
+        "--output",
+        "out/test-raw-stdin/",
+    )
+    result = subprocess.run(
+        cmd, input=csv_content, capture_output=True, text=True, check=False
+    )
+    if result.returncode:
+        pytest.fail(
+            "Integration test failed\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    assert result.stderr.strip() == "", "Unexpected stderr message"
+    expected_file = Path("tests") / "raw" / "data" / "expected_output_stdin.txt"
+    expected = expected_file.read_text()
+
+    cmd_str = " ".join([param or "''" for param in cmd])
+    assert result.stdout == expected, (
+        "Run with stdin generated unexpected outputs, "
+        "if you added new features update the test with:\n"
+        f"cat {csv_file} | {cmd_str} > {expected_file}"
+    )
+
+
+def test_run_with_nonexistent_file() -> None:
+    """Runs the script with a nonexistent file and verifies it fails with an error."""
+    missing_file = "tests/raw/data/does_not_exist.csv"
+    cmd = build_cmd(
+        "--year",
+        "2022",
+        "--raw-file",
+        missing_file,
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    assert result.returncode != 0
+    assert "path does not exist" in result.stderr
+    assert missing_file in result.stderr
+
+
 def test_read_raw_transactions_with_header(tmp_path: Path) -> None:
     """Parse a RAW file including a header row."""
 


### PR DESCRIPTION
E.g. `cgt-calc --raw-file <(my-command ...)` or `my-command ... | cgt-calc --raw-file -`

Fixes https://github.com/KapJI/capital-gains-calculator/issues/788