### PR TITLE
Withholding written before its dividend fails the balance check

### DIFF
--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -224,13 +224,18 @@ class InteractiveBrokersParser(StandardCSVParser):
 
         # If there's a deposit in the same second as a buy
         # (happens with the referral award at least)
-        # we want to put the buy last to avoid negative balance errors
-        return (transaction.date, transaction.action == ActionType.BUY)
+        # we want to put the buy last to avoid negative balance errors.
+        # Tax withheld at source goes last for the same reason: IBKR lists it
+        # before the dividend it was taken from.
+        return (
+            transaction.date,
+            transaction.action in (ActionType.BUY, ActionType.DIVIDEND_TAX),
+        )
 
     @classmethod
     def post_process_transactions(
         cls, transactions: list[BrokerTransaction]
     ) -> list[BrokerTransaction]:
-        """Sort transactions by date, buys last."""
+        """Sort transactions by date, buys and withheld tax last."""
         transactions.sort(key=cls._by_date_and_action)
         return transactions

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -264,3 +264,39 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
             )
         assert stderr_alerts(result.stderr) == []
         assert "Final balance\n  Interactive Brokers: 0.00 (GBP)" in result.stdout
+
+    def test_withholding_before_its_dividend_does_not_go_negative(
+        self, tmp_path: Path
+    ) -> None:
+        """IBKR lists tax withheld at source before the dividend it came from.
+
+        A statement that does not reach back to the opening of the account
+        starts at a zero balance, so in file order the withholding is the first
+        row and takes the balance negative before the dividend that covers it
+        arrives on the same day.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header + "Transaction History,Data,2025-06-24,U***00000,"
+            "VT(US9220427424) Cash Dividend - US Tax,Foreign Tax Withholding,"
+            "VT,-,-,-15.0,-,-15.0\n" + "Transaction History,Data,2025-06-24,U***00000,"
+            "VT(US9220427424) Cash Dividend USD 0.5 per Share,Dividend,"
+            "VT,-,-,100.0,-,100.0\n"
+        )
+
+        cmd = build_cmd(
+            "--year",
+            "2025",
+            "--interactive-brokers-file",
+            str(csv_file),
+            "--output",
+            str(tmp_path / "out"),
+        )
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode:
+            pytest.fail(
+                "Integration test failed\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+        assert stderr_alerts(result.stderr) == []


### PR DESCRIPTION
## Problem

IBKR lists tax withheld at source before the dividend it came from. A statement that does not reach back to the opening of the account starts at zero, so the withholding is the first row processed:

```
ERROR: Reached a negative balance(-8.5861881) for broker Interactive Brokers (GBP)
```

The dividend covering it is the next row, same date. #845 does not reach this: both rows sort to the same key.

## Change

`DIVIDEND_TAX` joins `BUY` at the end of the day in `_by_date_and_action`, for the same reason buys are there.

## Verification

`pytest`, `ruff`, `mypy` clean. New regression test fails without the change.

A real 2025/26 run over Schwab equity award JSON, Schwab CSV and IB CSV now completes without `--no-balance-check`, which it could not before. Output with and without the flag is byte-identical.
