### PR TITLE
Report on stdout, progress on stderr

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -505,7 +505,6 @@ class CapitalGainsCalculator:
         dividends_tax: dict[tuple[str, str], Decimal] = defaultdict(Decimal)
         interests: dict[tuple[str, str], Decimal] = defaultdict(Decimal)
         interest_taxes: dict[tuple[str, str], Decimal] = defaultdict(Decimal)
-        total_disposal_proceeds = Decimal(0)
         balance_history: list[Decimal] = []
 
         for transaction in transactions:
@@ -535,10 +534,6 @@ class CapitalGainsCalculator:
                 amount = get_amount_or_fail(transaction)
                 new_balance += amount
                 self.add_disposal(transaction)
-                if self.date_in_tax_year(transaction.date):
-                    total_disposal_proceeds += self.currency_converter.to_gbp_for(
-                        amount + transaction.fees, transaction
-                    )
             elif transaction.action is ActionType.FEE:
                 amount = get_amount_or_fail(transaction)
                 new_balance += amount
@@ -652,7 +647,6 @@ class CapitalGainsCalculator:
             dividends_tax,
             interests,
             interest_taxes,
-            total_disposal_proceeds,
         )
 
     def first_pass_report(
@@ -662,31 +656,31 @@ class CapitalGainsCalculator:
         dividends_tax: dict[tuple[str, str], Decimal],
         interests: dict[tuple[str, str], Decimal],
         interest_taxes: dict[tuple[str, str], Decimal],
-        total_disposal_proceeds: Decimal,
     ) -> None:
         """Print the results of the first pass."""
         print("First pass completed")
-        print("Final portfolio:")
+        print("Final portfolio")
+        if not self.portfolio:
+            print("  * (none)")
         for stock, position in sorted(self.portfolio.items()):
-            print(f"  {stock}: {position}")
-        print("Final balance:")
+            print(f"  * {stock}: {position}")
+        print("Final balance")
         for (broker, currency), amount in balance.items():
-            print(f"  {broker}: {round_decimal(amount, 2)} ({currency})")
+            print(f"  * {broker}: {round_decimal(amount, 2)} ({currency})")
         if dividends:
-            print("Dividends:")
+            print("Dividends")
             for (symbol, currency), amount in dividends.items():
                 tax = dividends_tax[(symbol, currency)]
                 tax_str = f", excluding {-tax} taxed at source" if tax < 0 else ""
-                print(f"  {symbol}: {round_decimal(amount, 2)}{tax_str} ({currency})")
+                print(f"  * {symbol}: {round_decimal(amount, 2)}{tax_str} ({currency})")
         if interests:
-            print("Interests:")
+            print("Interest")
             for (broker, currency), amount in interests.items():
-                print(f"  {broker}: {round_decimal(amount, 2)} ({currency})")
+                print(f"  * {broker}: {round_decimal(amount, 2)} ({currency})")
         if interest_taxes:
-            print("Interest taxes:")
+            print("Interest taxes")
             for (broker, currency), amount in interest_taxes.items():
-                print(f"  {broker}: {round_decimal(-amount, 2)} ({currency})")
-        print(f"Disposal proceeds: £{round_decimal(total_disposal_proceeds, 2)}")
+                print(f"  * {broker}: {round_decimal(-amount, 2)} ({currency})")
         print()
 
     def process_acquisition(

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -658,7 +658,7 @@ class CapitalGainsCalculator:
         interest_taxes: dict[tuple[str, str], Decimal],
     ) -> None:
         """Print the results of the first pass."""
-        print("First pass completed")
+        LOGGER.info("\nFirst pass complete\n")
         print("Final portfolio")
         if not self.portfolio:
             print("  * (none)")
@@ -929,8 +929,12 @@ class CapitalGainsCalculator:
                         )
                         continue
                     # Bed and breakfasting is a record of how the disposal was
-                    # matched rather than a problem, so it is logged at INFO.
-                    LOGGER.info(
+                    # matched rather than a problem. Surface it for the computed
+                    # tax year; the rest of the history walk logs it at DEBUG.
+                    LOGGER.log(
+                        logging.INFO
+                        if self.date_in_tax_year(date_index)
+                        else logging.DEBUG,
                         "Bed & breakfast match: %s disposed %s, re-acquired %s",
                         symbol,
                         date_index,
@@ -1487,7 +1491,7 @@ class CapitalGainsCalculator:
         self.process_dividends()
         self.process_interests()
 
-        print("Second pass completed")
+        LOGGER.info("\nSecond pass complete\n")
         allowance = CAPITAL_GAIN_ALLOWANCES.get(self.tax_year)
         dividend_allowance = DIVIDEND_ALLOWANCES.get(self.tax_year)
 
@@ -1566,7 +1570,9 @@ def calculate_cgt(args: argparse.Namespace) -> None:
     calculator.convert_to_hmrc_transactions(broker_transactions)
     # Second pass calculates capital gain tax for the given tax year.
     report = calculator.calculate_capital_gain()
-    print(report)
+    # The report string is newline-terminated already; avoid a trailing
+    # blank line so piped output stays stable under newline normalisation.
+    print(report, end="")
 
     # Generate PDF report.
     if not args.no_report:
@@ -1575,7 +1581,12 @@ def calculate_cgt(args: argparse.Namespace) -> None:
             output_path=args.output,
             skip_pdflatex=args.no_pdflatex,
         )
-    print("All done!")
+    done_msg = (
+        "Done! Calculations complete (PDF generation skipped)."
+        if args.no_pdflatex
+        else "Done! Report generated successfully."
+    )
+    LOGGER.info(done_msg)
 
 
 def main() -> int:
@@ -1595,8 +1606,8 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    logging_level = logging.DEBUG if args.verbose else logging.WARNING
-    logging.getLogger().setLevel(logging_level)
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
 
     try:
         calculate_cgt(args)

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -661,26 +661,26 @@ class CapitalGainsCalculator:
         LOGGER.info("\nFirst pass complete\n")
         print("Final portfolio")
         if not self.portfolio:
-            print("  * (none)")
+            print("  (none)")
         for stock, position in sorted(self.portfolio.items()):
-            print(f"  * {stock}: {position}")
+            print(f"  {stock}: {position}")
         print("Final balance")
         for (broker, currency), amount in balance.items():
-            print(f"  * {broker}: {round_decimal(amount, 2)} ({currency})")
+            print(f"  {broker}: {round_decimal(amount, 2)} ({currency})")
         if dividends:
             print("Dividends")
             for (symbol, currency), amount in dividends.items():
                 tax = dividends_tax[(symbol, currency)]
                 tax_str = f", excluding {-tax} taxed at source" if tax < 0 else ""
-                print(f"  * {symbol}: {round_decimal(amount, 2)}{tax_str} ({currency})")
+                print(f"  {symbol}: {round_decimal(amount, 2)}{tax_str} ({currency})")
         if interests:
             print("Interest")
             for (broker, currency), amount in interests.items():
-                print(f"  * {broker}: {round_decimal(amount, 2)} ({currency})")
+                print(f"  {broker}: {round_decimal(amount, 2)} ({currency})")
         if interest_taxes:
             print("Interest taxes")
             for (broker, currency), amount in interest_taxes.items():
-                print(f"  * {broker}: {round_decimal(-amount, 2)} ({currency})")
+                print(f"  {broker}: {round_decimal(-amount, 2)} ({currency})")
         print()
 
     def process_acquisition(

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -464,12 +464,12 @@ class CapitalGainsReport:
         out = f"Portfolio at the end of {self.tax_year}/{self.tax_year + 1} tax year\n"
         held = [entry for entry in self.portfolio if entry.quantity > 0]
         if not held:
-            out += "  * (none)\n"
+            out += "  (none)\n"
         for entry in sorted(held, key=lambda entry: entry.symbol):
             unrealized_gains_str = (
                 entry.unrealized_gains_str() if self.show_unrealized_gains else ""
             )
-            out += f"  * {entry!s}{unrealized_gains_str}\n"
+            out += f"  {entry!s}{unrealized_gains_str}\n"
         eris = list(
             self._filter_calculation_log(
                 self.calculation_log_yields,
@@ -487,7 +487,7 @@ class CapitalGainsReport:
                 assert item.eris
                 assert len(item.eris) == 1
                 dist_type = "interest" if item.eris[0].is_interest else "dividend"
-                out += f"  * {item.eris[0].symbol}: £{round_decimal(item.amount, 2)} "
+                out += f"  {item.eris[0].symbol}: £{round_decimal(item.amount, 2)} "
                 out += f"(included as {dist_type})\n"
 
         out += f"Number of disposals: {self.disposal_count}\n"

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -355,7 +355,7 @@ class PortfolioEntry:
     def __str__(self) -> str:
         """Return string representation."""
         return (
-            f"  {self.symbol}: {round_decimal(self.quantity, 2)}, "
+            f"{self.symbol}: {round_decimal(self.quantity, 2)}, "
             f"£{round_decimal(self.amount, 2)}"
         )
 
@@ -461,22 +461,25 @@ class CapitalGainsReport:
 
     def __str__(self) -> str:
         """Return string representation."""
-        out = f"Portfolio at the end of {self.tax_year}/{self.tax_year + 1} tax year:\n"
-        for entry in sorted(self.portfolio, key=lambda entry: entry.symbol):
-            if entry.quantity > 0:
-                unrealized_gains_str = (
-                    entry.unrealized_gains_str() if self.show_unrealized_gains else ""
-                )
-                out += f"{entry!s}{unrealized_gains_str}\n"
+        out = f"Portfolio at the end of {self.tax_year}/{self.tax_year + 1} tax year\n"
+        held = [entry for entry in self.portfolio if entry.quantity > 0]
+        if not held:
+            out += "  * (none)\n"
+        for entry in sorted(held, key=lambda entry: entry.symbol):
+            unrealized_gains_str = (
+                entry.unrealized_gains_str() if self.show_unrealized_gains else ""
+            )
+            out += f"  * {entry!s}{unrealized_gains_str}\n"
         eris = list(
             self._filter_calculation_log(
                 self.calculation_log_yields,
                 RuleType.EXCESS_REPORTED_INCOME_DISTRIBUTION,
             )
         )
-        out += f"For tax year {self.tax_year}/{self.tax_year + 1}:\n"
+        out += "\n"
+        out += f"Tax summary for {self.tax_year}/{self.tax_year + 1}\n"
         if eris:
-            out += "Excess Reported Income:\n"
+            out += "Excess Reported Income\n"
             for item in self._filter_calculation_log(
                 self.calculation_log_yields,
                 RuleType.EXCESS_REPORTED_INCOME_DISTRIBUTION,
@@ -484,7 +487,7 @@ class CapitalGainsReport:
                 assert item.eris
                 assert len(item.eris) == 1
                 dist_type = "interest" if item.eris[0].is_interest else "dividend"
-                out += f"  {item.eris[0].symbol}: £{round_decimal(item.amount, 2)} "
+                out += f"  * {item.eris[0].symbol}: £{round_decimal(item.amount, 2)} "
                 out += f"(included as {dist_type})\n"
 
         out += f"Number of disposals: {self.disposal_count}\n"

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -17,6 +17,7 @@ from cgt_calc.args_validators import (
 )
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
 from cgt_calc.model import BrokerTransaction
+from cgt_calc.setup_logging import parsing_msg
 
 LOGGER = logging.getLogger(__name__)
 
@@ -87,12 +88,12 @@ class BaseSingleFileParser(BaseParser):
         """Load broker data from file path."""
         if file_path == STDIN_PATH:
             if show_parsing_msg:
-                print("Parsing stdin...")
+                parsing_msg("stdin")
             transactions = cls.read_transactions(sys.stdin, STDIN_PATH)
         else:
             with file_path.open(encoding=cls.encoding) as file:
                 if show_parsing_msg:
-                    print(f"Parsing {file_path}...")
+                    parsing_msg(file_path)
                 transactions = cls.read_transactions(file, file_path)
         if not transactions and warn_on_empty:
             LOGGER.warning("No transactions detected in file %s", file_path)

--- a/cgt_calc/parsers/broker_registry.py
+++ b/cgt_calc/parsers/broker_registry.py
@@ -70,10 +70,11 @@ class BrokerRegistry:
                 )
                 all_transactions += transactions
 
+        msg = f"Found {len(all_transactions)} broker transactions"
         if len(all_transactions) == 0:
-            LOGGER.warning("Found 0 broker transactions")
+            LOGGER.warning(msg)
         else:
-            print(f"Found {len(all_transactions)} broker transactions")
+            LOGGER.info(msg)
 
         # ERI Raw is not a broker but is close enough to one to be here
         # Only add ERI for funds that show up in the portfolio

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -22,6 +22,7 @@ from cgt_calc.exceptions import (
 )
 from cgt_calc.model import ActionType, BrokerTransaction
 from cgt_calc.parsers.schwab_cusip_bonds import adjust_cusip_bond_price
+from cgt_calc.setup_logging import parsing_msg
 
 from .base_parsers import BaseSingleFileParser
 
@@ -549,7 +550,7 @@ def _filter_cancelled_buy_transactions(
                 # Found matching pair - mark both for removal
                 indices_to_remove.add(cancel_idx)
                 indices_to_remove.add(buy_idx)
-                LOGGER.info(
+                LOGGER.debug(
                     "Matched Cancel Buy with original Buy: symbol=%s, qty=%s, "
                     "price=%s, buy_date=%s, cancel_date=%s",
                     buy_txn.symbol,
@@ -586,7 +587,7 @@ def _read_schwab_awards(
     initial_prices: dict[datetime.date, dict[str, Decimal]] = defaultdict(dict)
 
     with schwab_award_transactions_file.open(encoding="utf-8") as csv_file:
-        print(f"Parsing {schwab_award_transactions_file}...")
+        parsing_msg(schwab_award_transactions_file)
         lines = list(csv.reader(csv_file))
     if not lines:
         raise ParsingError(

--- a/cgt_calc/render_latex.py
+++ b/cgt_calc/render_latex.py
@@ -1,6 +1,7 @@
 """Render PDF report with LaTeX."""
 
 from decimal import Decimal
+import logging
 from pathlib import Path
 import shutil
 import subprocess
@@ -13,6 +14,8 @@ from .exceptions import LatexRenderError, MissingExternalToolError
 from .model import CapitalGainsReport
 from .util import round_decimal, strip_zeros
 
+LOGGER = logging.getLogger(__name__)
+
 
 def render_pdf(
     report: CapitalGainsReport,
@@ -23,9 +26,12 @@ def render_pdf(
     jobname = output_path.stem
     out_dir = output_path.parent
     tex_path = out_dir / f"{jobname}.tex"
-    # Keep this line identical in both modes: e2e fixtures are compared both
-    # with and without pdflatex in CI.
-    print("Generating PDF report...")
+    progress = (
+        f"Writing LaTeX report to {tex_path}..."
+        if skip_pdflatex
+        else f"Writing PDF report to {output_path}..."
+    )
+    LOGGER.info("%s\n", progress)
     latex_template_env = jinja2.Environment(
         block_start_string="\\BLOCK{",
         block_end_string="}",

--- a/cgt_calc/setup_logging.py
+++ b/cgt_calc/setup_logging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 import sys
 from typing import TYPE_CHECKING, TextIO
 
@@ -11,7 +12,18 @@ import colorama
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from importlib.resources.abc import Traversable
     from typing import Final
+
+LOGGER = logging.getLogger(__name__)
+
+
+def parsing_msg(file: str | Path | Traversable) -> None:
+    """Print progress message for files being parsed."""
+    # Strip package root
+    package_root = f"{Path(__file__).resolve().parent.parent}{os.path.sep}"
+    file = str(file).removeprefix(package_root)
+    LOGGER.info("Parsing %s...", file)
 
 
 class ColourMessageFormatter(logging.Formatter):
@@ -41,7 +53,10 @@ class ColourMessageFormatter(logging.Formatter):
 
         colour = self.COLOURS.get(record.levelno, "")
         if self.use_colour and colour:
-            return f"{colour}{message}{colorama.Style.RESET_ALL}"
+            message = f"{colour}{message}{colorama.Style.RESET_ALL}"
+        if record.levelno in (logging.WARNING, logging.ERROR):
+            # Blank lines both sides so alerts stand apart from the progress flow.
+            message = f"\n{message}\n"
         return message
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Shared test configuration."""
+
+import os
+
+# Force plain CLI output regardless of the environment running the tests:
+# expected-output fixtures are byte-exact and stderr assertions match on the
+# "WARNING:"/"ERROR:" prefixes, so colour and emoji must never leak in.
+os.environ["NO_COLOR"] = "1"
+os.environ.pop("FORCE_COLOR", None)

--- a/tests/freetrade/data/expected_output.txt
+++ b/tests/freetrade/data/expected_output.txt
@@ -1,6 +1,3 @@
-Parsing tests/freetrade/data/transactions.csv...
-Found 17 broker transactions
-First pass completed
 Final portfolio
   * GOOGL: 0.14
   * NDAQ: 2.12
@@ -12,7 +9,6 @@ Dividends
 Interest
   * Freetrade: 9.02 (GBP)
 
-Second pass completed
 Portfolio at the end of 2023/2024 tax year
   * GOOGL: 0.14, £279.58
   * NDAQ: 2.12, £279.58
@@ -32,6 +28,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £9.02
 Total foreign interest proceeds: £0.00
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/freetrade/data/expected_output.txt
+++ b/tests/freetrade/data/expected_output.txt
@@ -1,18 +1,18 @@
 Final portfolio
-  * GOOGL: 0.14
-  * NDAQ: 2.12
-  * TSLA: 1.45
+  GOOGL: 0.14
+  NDAQ: 2.12
+  TSLA: 1.45
 Final balance
-  * Freetrade: 8946.79 (GBP)
+  Freetrade: 8946.79 (GBP)
 Dividends
-  * NDAQ: 1.78 (GBP)
+  NDAQ: 1.78 (GBP)
 Interest
-  * Freetrade: 9.02 (GBP)
+  Freetrade: 9.02 (GBP)
 
 Portfolio at the end of 2023/2024 tax year
-  * GOOGL: 0.14, £279.58
-  * NDAQ: 2.12, £279.58
-  * TSLA: 1.45, £944.86
+  GOOGL: 0.14, £279.58
+  NDAQ: 2.12, £279.58
+  TSLA: 1.45, £944.86
 
 Tax summary for 2023/2024
 Number of disposals: 1

--- a/tests/freetrade/data/expected_output.txt
+++ b/tests/freetrade/data/expected_output.txt
@@ -1,24 +1,24 @@
 Parsing tests/freetrade/data/transactions.csv...
 Found 17 broker transactions
 First pass completed
-Final portfolio:
-  GOOGL: 0.14
-  NDAQ: 2.12
-  TSLA: 1.45
-Final balance:
-  Freetrade: 8946.79 (GBP)
-Dividends:
-  NDAQ: 1.78 (GBP)
-Interests:
-  Freetrade: 9.02 (GBP)
-Disposal proceeds: £2930.36
+Final portfolio
+  * GOOGL: 0.14
+  * NDAQ: 2.12
+  * TSLA: 1.45
+Final balance
+  * Freetrade: 8946.79 (GBP)
+Dividends
+  * NDAQ: 1.78 (GBP)
+Interest
+  * Freetrade: 9.02 (GBP)
 
 Second pass completed
-Portfolio at the end of 2023/2024 tax year:
-  GOOGL: 0.14, £279.58
-  NDAQ: 2.12, £279.58
-  TSLA: 1.45, £944.86
-For tax year 2023/2024:
+Portfolio at the end of 2023/2024 tax year
+  * GOOGL: 0.14, £279.58
+  * NDAQ: 2.12, £279.58
+  * TSLA: 1.45, £944.86
+
+Tax summary for 2023/2024
 Number of disposals: 1
 Disposal proceeds: £2930.36
 Allowable costs: £2502.50

--- a/tests/freetrade/test_freetrade.py
+++ b/tests/freetrade/test_freetrade.py
@@ -19,7 +19,7 @@ from cgt_calc.parsers.freetrade import (
     FreetradeParser,
     FreetradeTransaction,
 )
-from tests.utils import build_cmd
+from tests.utils import build_cmd, stderr_alerts
 
 BASE_ROW_VALUES = {
     FreetradeColumn.TITLE.value: "Buy Apple",
@@ -92,7 +92,7 @@ def test_run_with_freetrade_file() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert result.stderr == "", "Run with example files generated errors"
+    assert stderr_alerts(result.stderr) == [], "Run with example files generated errors"
     expected_file = Path("tests") / "freetrade" / "data" / "expected_output.txt"
     expected = expected_file.read_text()
     cmd_str = " ".join([param or "''" for param in cmd])

--- a/tests/general/data/test_run_with_example_files_output.txt
+++ b/tests/general/data/test_run_with_example_files_output.txt
@@ -4,31 +4,31 @@ Parsing tests/morgan_stanley/data/Releases Report.csv...
 Parsing tests/morgan_stanley/data/Withdrawals Report.csv...
 Found 27 broker transactions
 First pass completed
-Final portfolio:
-  GOOG: 163.20
-  NVDA: 1.00
-  VNRG: 1.00
-  VUAG: 30.50
-Final balance:
-  Charles Schwab: 9479.30 (USD)
-  Trading212: 33391.30 (GBP)
-  Morgan Stanley: 1.00 (USD)
-Dividends:
-  NVDA: 0.10 (GBP)
-Interests:
-  Charles Schwab: 1.40 (USD)
-Disposal proceeds: £43836.90
+Final portfolio
+  * GOOG: 163.20
+  * NVDA: 1.00
+  * VNRG: 1.00
+  * VUAG: 30.50
+Final balance
+  * Charles Schwab: 9479.30 (USD)
+  * Trading212: 33391.30 (GBP)
+  * Morgan Stanley: 1.00 (USD)
+Dividends
+  * NVDA: 0.10 (GBP)
+Interest
+  * Charles Schwab: 1.40 (USD)
 
 Second pass completed
-Portfolio at the end of 2020/2021 tax year:
-  GOOG: 172.00, £12516.55
-  NVDA: 1.00, £401.01
-  VNRG: 1.00, £8.98
-  VUAG: 30.50, £645.19
-For tax year 2020/2021:
-Excess Reported Income:
-  VUAG: £22.26 (included as dividend)
-  VNRG: £0.91 (included as dividend)
+Portfolio at the end of 2020/2021 tax year
+  * GOOG: 172.00, £12516.55
+  * NVDA: 1.00, £401.01
+  * VNRG: 1.00, £8.98
+  * VUAG: 30.50, £645.19
+
+Tax summary for 2020/2021
+Excess Reported Income
+  * VUAG: £22.26 (included as dividend)
+  * VNRG: £0.91 (included as dividend)
 Number of disposals: 4
 Disposal proceeds: £43836.90
 Allowable costs: £18666.33

--- a/tests/general/data/test_run_with_example_files_output.txt
+++ b/tests/general/data/test_run_with_example_files_output.txt
@@ -1,9 +1,3 @@
-Parsing tests/schwab/data/schwab_transactions.csv...
-Parsing tests/trading212/data/2020/from_2020-09-11_to_2021-04-02.csv...
-Parsing tests/morgan_stanley/data/Releases Report.csv...
-Parsing tests/morgan_stanley/data/Withdrawals Report.csv...
-Found 27 broker transactions
-First pass completed
 Final portfolio
   * GOOG: 163.20
   * NVDA: 1.00
@@ -18,7 +12,6 @@ Dividends
 Interest
   * Charles Schwab: 1.40 (USD)
 
-Second pass completed
 Portfolio at the end of 2020/2021 tax year
   * GOOG: 172.00, £12516.55
   * NVDA: 1.00, £401.01
@@ -42,6 +35,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £1.03
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/general/data/test_run_with_example_files_output.txt
+++ b/tests/general/data/test_run_with_example_files_output.txt
@@ -1,27 +1,27 @@
 Final portfolio
-  * GOOG: 163.20
-  * NVDA: 1.00
-  * VNRG: 1.00
-  * VUAG: 30.50
+  GOOG: 163.20
+  NVDA: 1.00
+  VNRG: 1.00
+  VUAG: 30.50
 Final balance
-  * Charles Schwab: 9479.30 (USD)
-  * Trading212: 33391.30 (GBP)
-  * Morgan Stanley: 1.00 (USD)
+  Charles Schwab: 9479.30 (USD)
+  Trading212: 33391.30 (GBP)
+  Morgan Stanley: 1.00 (USD)
 Dividends
-  * NVDA: 0.10 (GBP)
+  NVDA: 0.10 (GBP)
 Interest
-  * Charles Schwab: 1.40 (USD)
+  Charles Schwab: 1.40 (USD)
 
 Portfolio at the end of 2020/2021 tax year
-  * GOOG: 172.00, £12516.55
-  * NVDA: 1.00, £401.01
-  * VNRG: 1.00, £8.98
-  * VUAG: 30.50, £645.19
+  GOOG: 172.00, £12516.55
+  NVDA: 1.00, £401.01
+  VNRG: 1.00, £8.98
+  VUAG: 30.50, £645.19
 
 Tax summary for 2020/2021
 Excess Reported Income
-  * VUAG: £22.26 (included as dividend)
-  * VNRG: £0.91 (included as dividend)
+  VUAG: £22.26 (included as dividend)
+  VNRG: £0.91 (included as dividend)
 Number of disposals: 4
 Disposal proceeds: £43836.90
 Allowable costs: £18666.33

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -22,7 +22,7 @@ from cgt_calc.model import ActionType, BrokerTransaction, RuleType
 from cgt_calc.parsers.eri.model import ERITransaction
 from cgt_calc.spin_off_handler import SpinOffHandler
 from cgt_calc.util import round_decimal
-from tests.utils import build_cmd, stderr_alerts
+from tests.utils import build_cmd
 
 from .calc_test_data import calc_basic_data
 from .calc_test_data_2 import calc_basic_data_2
@@ -825,7 +825,24 @@ def test_run_with_example_files() -> None:
             f"stderr:\n{result.stderr}"
         )
 
-    assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
+    # The progress narrative is a contract: it must reach stderr, in order.
+    # The last two lines depend on whether pdflatex runs, so match by prefix.
+    stderr_lines = [line for line in result.stderr.splitlines() if line.strip()]
+    assert stderr_lines[:-2] == [
+        "Parsing tests/schwab/data/schwab_transactions.csv...",
+        "Loaded 13 transactions from Charles Schwab",
+        "Parsing tests/trading212/data/2020/from_2020-09-11_to_2021-04-02.csv...",
+        "Loaded 8 transactions from Trading 212",
+        "Parsing tests/morgan_stanley/data/Releases Report.csv...",
+        "Parsing tests/morgan_stanley/data/Withdrawals Report.csv...",
+        "Loaded 6 transactions from Morgan Stanley",
+        "Found 27 broker transactions",
+        "First pass complete",
+        "Bed & breakfast match: VUAG disposed 2020-06-03, re-acquired 2020-07-02",
+        "Second pass complete",
+    ]
+    assert stderr_lines[-2].startswith("Writing ")
+    assert stderr_lines[-1].startswith("Done!")
     expected_file = (
         Path("tests") / "general" / "data" / "test_run_with_example_files_output.txt"
     )

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -22,7 +22,7 @@ from cgt_calc.model import ActionType, BrokerTransaction, RuleType
 from cgt_calc.parsers.eri.model import ERITransaction
 from cgt_calc.spin_off_handler import SpinOffHandler
 from cgt_calc.util import round_decimal
-from tests.utils import build_cmd
+from tests.utils import build_cmd, stderr_alerts
 
 from .calc_test_data import calc_basic_data
 from .calc_test_data_2 import calc_basic_data_2
@@ -825,7 +825,7 @@ def test_run_with_example_files() -> None:
             f"stderr:\n{result.stderr}"
         )
 
-    assert result.stderr.strip() == "", "Unexpected stderr message"
+    assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
     expected_file = (
         Path("tests") / "general" / "data" / "test_run_with_example_files_output.txt"
     )

--- a/tests/general/test_warning_scope.py
+++ b/tests/general/test_warning_scope.py
@@ -89,7 +89,7 @@ def test_treaty_mismatch_warning_scoped_to_tax_year(
     assert len(warnings) == expected_warnings
 
 
-def test_bed_and_breakfast_is_logged_at_info(
+def test_bed_and_breakfast_in_tax_year_is_logged_at_info(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Matching a disposal to a repurchase is a record, not a problem."""
@@ -109,6 +109,31 @@ def test_bed_and_breakfast_is_logged_at_info(
     ]
     assert len(bed_and_breakfast) == 1
     assert bed_and_breakfast[0].levelno == logging.INFO
+    assert not [
+        record for record in caplog.records if record.levelno >= logging.WARNING
+    ]
+
+
+def test_bed_and_breakfast_outside_tax_year_is_logged_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The history walk records old matches without user-facing output."""
+    transactions = [
+        buy_transaction(datetime.date(2023, 5, 1), "FOO", 10, 10, 0, -100),
+        sell_transaction(datetime.date(2023, 6, 3), "FOO", 10, 12, 0, 120),
+        buy_transaction(datetime.date(2023, 6, 10), "FOO", 10, 11, 0, -110),
+    ]
+    calculator = _calculator(transactions)
+
+    with caplog.at_level(logging.DEBUG, logger="cgt_calc.main"):
+        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.calculate_capital_gain()
+
+    bed_and_breakfast = [
+        record for record in caplog.records if "Bed & breakfast match" in record.message
+    ]
+    assert len(bed_and_breakfast) == 1
+    assert bed_and_breakfast[0].levelno == logging.DEBUG
     assert not [
         record for record in caplog.records if record.levelno >= logging.WARNING
     ]

--- a/tests/hl/data/test_run_with_hl_files_no_balance_check_output.txt
+++ b/tests/hl/data/test_run_with_hl_files_no_balance_check_output.txt
@@ -1,18 +1,18 @@
 Parsing out/test-hl-inputs/hl-transaction-summary.csv...
 Found 5 broker transactions
 First pass completed
-Final portfolio:
-  VHVG: 3563.00
-Final balance:
-  Hargreaves Lansdown: -55018.97 (GBP)
-Interests:
-  Hargreaves Lansdown: 3.87 (GBP)
-Disposal proceeds: £45000.00
+Final portfolio
+  * VHVG: 3563.00
+Final balance
+  * Hargreaves Lansdown: -55018.97 (GBP)
+Interest
+  * Hargreaves Lansdown: 3.87 (GBP)
 
 Second pass completed
-Portfolio at the end of 2025/2026 tax year:
-  VHVG: 3563.00, £117132.23
-For tax year 2025/2026:
+Portfolio at the end of 2025/2026 tax year
+  * VHVG: 3563.00, £117132.23
+
+Tax summary for 2025/2026
 Number of disposals: 1
 Disposal proceeds: £45000.00
 Allowable costs: £32886.56

--- a/tests/hl/data/test_run_with_hl_files_no_balance_check_output.txt
+++ b/tests/hl/data/test_run_with_hl_files_no_balance_check_output.txt
@@ -1,12 +1,12 @@
 Final portfolio
-  * VHVG: 3563.00
+  VHVG: 3563.00
 Final balance
-  * Hargreaves Lansdown: -55018.97 (GBP)
+  Hargreaves Lansdown: -55018.97 (GBP)
 Interest
-  * Hargreaves Lansdown: 3.87 (GBP)
+  Hargreaves Lansdown: 3.87 (GBP)
 
 Portfolio at the end of 2025/2026 tax year
-  * VHVG: 3563.00, £117132.23
+  VHVG: 3563.00, £117132.23
 
 Tax summary for 2025/2026
 Number of disposals: 1

--- a/tests/hl/data/test_run_with_hl_files_no_balance_check_output.txt
+++ b/tests/hl/data/test_run_with_hl_files_no_balance_check_output.txt
@@ -1,6 +1,3 @@
-Parsing out/test-hl-inputs/hl-transaction-summary.csv...
-Found 5 broker transactions
-First pass completed
 Final portfolio
   * VHVG: 3563.00
 Final balance
@@ -8,7 +5,6 @@ Final balance
 Interest
   * Hargreaves Lansdown: 3.87 (GBP)
 
-Second pass completed
 Portfolio at the end of 2025/2026 tax year
   * VHVG: 3563.00, £117132.23
 
@@ -26,6 +22,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £3.87
 Total foreign interest proceeds: £0.00
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/hl/test_hl.py
+++ b/tests/hl/test_hl.py
@@ -10,7 +10,7 @@ from reportlab.pdfgen import canvas
 
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.parsers.hl import HargreavesLansdownParser
-from tests.utils import build_cmd
+from tests.utils import build_cmd, stderr_alerts
 
 HL_CSV_HEADER = (
     "Transaction Summary, , , ,\n"
@@ -118,7 +118,7 @@ def test_hl_parser() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert result.stderr == "", "Run with example files generated errors"
+    assert stderr_alerts(result.stderr) == [], "Run with example files generated errors"
     expected_file = (
         Path("tests")
         / "hl"

--- a/tests/interactive_brokers/data/expected_output.txt
+++ b/tests/interactive_brokers/data/expected_output.txt
@@ -1,21 +1,21 @@
 Parsing tests/interactive_brokers/data/test_basic.csv...
 Found 12 broker transactions
 First pass completed
-Final portfolio:
-  CNX1: 2.00
-Final balance:
-  Interactive Brokers: 3027.40 (GBP)
-Dividends:
-  IBKR: 1.00, excluding 0.15 taxed at source (GBP)
-  VT: 20.00, excluding 3.0 taxed at source (GBP)
-Disposal proceeds: £2002.00
+Final portfolio
+  * CNX1: 2.00
+Final balance
+  * Interactive Brokers: 3027.40 (GBP)
+Dividends
+  * IBKR: 1.00, excluding 0.15 taxed at source (GBP)
+  * VT: 20.00, excluding 3.0 taxed at source (GBP)
 
 Second pass completed
-Portfolio at the end of 2025/2026 tax year:
-  CNX1: 2.00, £2007.77
-For tax year 2025/2026:
-Excess Reported Income:
-  CNX1: £12.54 (included as dividend)
+Portfolio at the end of 2025/2026 tax year
+  * CNX1: 2.00, £2007.77
+
+Tax summary for 2025/2026
+Excess Reported Income
+  * CNX1: £12.54 (included as dividend)
 Number of disposals: 1
 Disposal proceeds: £2002.00
 Allowable costs: £2010.77

--- a/tests/interactive_brokers/data/expected_output.txt
+++ b/tests/interactive_brokers/data/expected_output.txt
@@ -1,6 +1,3 @@
-Parsing tests/interactive_brokers/data/test_basic.csv...
-Found 12 broker transactions
-First pass completed
 Final portfolio
   * CNX1: 2.00
 Final balance
@@ -9,7 +6,6 @@ Dividends
   * IBKR: 1.00, excluding 0.15 taxed at source (GBP)
   * VT: 20.00, excluding 3.0 taxed at source (GBP)
 
-Second pass completed
 Portfolio at the end of 2025/2026 tax year
   * CNX1: 2.00, £2007.77
 
@@ -29,6 +25,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £0.00
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/interactive_brokers/data/expected_output.txt
+++ b/tests/interactive_brokers/data/expected_output.txt
@@ -1,17 +1,17 @@
 Final portfolio
-  * CNX1: 2.00
+  CNX1: 2.00
 Final balance
-  * Interactive Brokers: 3027.40 (GBP)
+  Interactive Brokers: 3027.40 (GBP)
 Dividends
-  * IBKR: 1.00, excluding 0.15 taxed at source (GBP)
-  * VT: 20.00, excluding 3.0 taxed at source (GBP)
+  IBKR: 1.00, excluding 0.15 taxed at source (GBP)
+  VT: 20.00, excluding 3.0 taxed at source (GBP)
 
 Portfolio at the end of 2025/2026 tax year
-  * CNX1: 2.00, £2007.77
+  CNX1: 2.00, £2007.77
 
 Tax summary for 2025/2026
 Excess Reported Income
-  * CNX1: £12.54 (included as dividend)
+  CNX1: £12.54 (included as dividend)
 Number of disposals: 1
 Disposal proceeds: £2002.00
 Allowable costs: £2010.77

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -263,4 +263,4 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
                 f"stderr:\n{result.stderr}"
             )
         assert stderr_alerts(result.stderr) == []
-        assert "Final balance\n  * Interactive Brokers: 0.00 (GBP)" in result.stdout
+        assert "Final balance\n  Interactive Brokers: 0.00 (GBP)" in result.stdout

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -9,7 +9,7 @@ import pytest
 
 from cgt_calc.model import ActionType, BrokerTransaction
 from cgt_calc.parsers.interactive_brokers import InteractiveBrokersParser
-from tests.utils import build_cmd
+from tests.utils import build_cmd, stderr_alerts
 
 
 class TestInteractiveBrokers:
@@ -163,7 +163,7 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
                 f"stdout:\n{result.stdout}\n"
                 f"stderr:\n{result.stderr}"
             )
-        assert result.stderr == ""
+        assert stderr_alerts(result.stderr) == []
         expected_file = (
             Path("tests") / "interactive_brokers" / "data" / "expected_output.txt"
         )
@@ -262,5 +262,5 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
                 f"stdout:\n{result.stdout}\n"
                 f"stderr:\n{result.stderr}"
             )
-        assert result.stderr == ""
+        assert stderr_alerts(result.stderr) == []
         assert "Final balance\n  * Interactive Brokers: 0.00 (GBP)" in result.stdout

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -263,4 +263,4 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
                 f"stderr:\n{result.stderr}"
             )
         assert result.stderr == ""
-        assert "Final balance:\n  Interactive Brokers: 0.00 (GBP)" in result.stdout
+        assert "Final balance\n  * Interactive Brokers: 0.00 (GBP)" in result.stdout

--- a/tests/raw/data/expected_output.txt
+++ b/tests/raw/data/expected_output.txt
@@ -1,6 +1,3 @@
-Parsing tests/raw/data/test_data.csv...
-Found 16 broker transactions
-First pass completed
 Final portfolio
   * AMZN: 210.00
   * BABA: 30.00
@@ -12,7 +9,6 @@ Dividends
   * OTGLY: 9.68 (USD)
   * OPRA: 3360.00 (USD)
 
-Second pass completed
 Portfolio at the end of 2022/2023 tax year
   * AMZN: 210.00, £1900.67
   * BABA: 30.00, £1942.83
@@ -33,6 +29,3 @@ Total taxable dividends proceeds: £719.29
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £0.00
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/raw/data/expected_output.txt
+++ b/tests/raw/data/expected_output.txt
@@ -1,19 +1,19 @@
 Final portfolio
-  * AMZN: 210.00
-  * BABA: 30.00
-  * META: 119.00
-  * OPRA: 120.00
+  AMZN: 210.00
+  BABA: 30.00
+  META: 119.00
+  OPRA: 120.00
 Final balance
-  * Unknown: -28486.60 (USD)
+  Unknown: -28486.60 (USD)
 Dividends
-  * OTGLY: 9.68 (USD)
-  * OPRA: 3360.00 (USD)
+  OTGLY: 9.68 (USD)
+  OPRA: 3360.00 (USD)
 
 Portfolio at the end of 2022/2023 tax year
-  * AMZN: 210.00, £1900.67
-  * BABA: 30.00, £1942.83
-  * META: 119.00, £18042.21
-  * OPRA: 120.00, £492.03
+  AMZN: 210.00, £1900.67
+  BABA: 30.00, £1942.83
+  META: 119.00, £18042.21
+  OPRA: 120.00, £492.03
 
 Tax summary for 2022/2023
 Number of disposals: 3

--- a/tests/raw/data/expected_output.txt
+++ b/tests/raw/data/expected_output.txt
@@ -1,25 +1,25 @@
 Parsing tests/raw/data/test_data.csv...
 Found 16 broker transactions
 First pass completed
-Final portfolio:
-  AMZN: 210.00
-  BABA: 30.00
-  META: 119.00
-  OPRA: 120.00
-Final balance:
-  Unknown: -28486.60 (USD)
-Dividends:
-  OTGLY: 9.68 (USD)
-  OPRA: 3360.00 (USD)
-Disposal proceeds: £11422.10
+Final portfolio
+  * AMZN: 210.00
+  * BABA: 30.00
+  * META: 119.00
+  * OPRA: 120.00
+Final balance
+  * Unknown: -28486.60 (USD)
+Dividends
+  * OTGLY: 9.68 (USD)
+  * OPRA: 3360.00 (USD)
 
 Second pass completed
-Portfolio at the end of 2022/2023 tax year:
-  AMZN: 210.00, £1900.67
-  BABA: 30.00, £1942.83
-  META: 119.00, £18042.21
-  OPRA: 120.00, £492.03
-For tax year 2022/2023:
+Portfolio at the end of 2022/2023 tax year
+  * AMZN: 210.00, £1900.67
+  * BABA: 30.00, £1942.83
+  * META: 119.00, £18042.21
+  * OPRA: 120.00, £492.03
+
+Tax summary for 2022/2023
 Number of disposals: 3
 Disposal proceeds: £11422.10
 Allowable costs: £13588.22

--- a/tests/raw/data/expected_output_2.txt
+++ b/tests/raw/data/expected_output_2.txt
@@ -1,6 +1,3 @@
-Parsing tests/raw/data/test_data_2.csv...
-Found 9 broker transactions
-First pass completed
 Final portfolio
   * AMZN: 10.00
   * META: 50.00
@@ -9,7 +6,6 @@ Final balance
 Dividends
   * META: 5.00 (USD)
 
-Second pass completed
 Portfolio at the end of 2022/2023 tax year
   * AMZN: 10.00, £766.40
   * META: 50.00, £7664.01
@@ -28,6 +24,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £0.00
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/raw/data/expected_output_2.txt
+++ b/tests/raw/data/expected_output_2.txt
@@ -1,14 +1,14 @@
 Final portfolio
-  * AMZN: 10.00
-  * META: 50.00
+  AMZN: 10.00
+  META: 50.00
 Final balance
-  * Unknown: 0.00 (USD)
+  Unknown: 0.00 (USD)
 Dividends
-  * META: 5.00 (USD)
+  META: 5.00 (USD)
 
 Portfolio at the end of 2022/2023 tax year
-  * AMZN: 10.00, £766.40
-  * META: 50.00, £7664.01
+  AMZN: 10.00, £766.40
+  META: 50.00, £7664.01
 
 Tax summary for 2022/2023
 Number of disposals: 2

--- a/tests/raw/data/expected_output_2.txt
+++ b/tests/raw/data/expected_output_2.txt
@@ -1,20 +1,20 @@
 Parsing tests/raw/data/test_data_2.csv...
 Found 9 broker transactions
 First pass completed
-Final portfolio:
-  AMZN: 10.00
-  META: 50.00
-Final balance:
-  Unknown: 0.00 (USD)
-Dividends:
-  META: 5.00 (USD)
-Disposal proceeds: £8431.31
+Final portfolio
+  * AMZN: 10.00
+  * META: 50.00
+Final balance
+  * Unknown: 0.00 (USD)
+Dividends
+  * META: 5.00 (USD)
 
 Second pass completed
-Portfolio at the end of 2022/2023 tax year:
-  AMZN: 10.00, £766.40
-  META: 50.00, £7664.01
-For tax year 2022/2023:
+Portfolio at the end of 2022/2023 tax year
+  * AMZN: 10.00, £766.40
+  * META: 50.00, £7664.01
+
+Tax summary for 2022/2023
 Number of disposals: 2
 Disposal proceeds: £8431.31
 Allowable costs: £12665.89

--- a/tests/raw/data/expected_output_stdin.txt
+++ b/tests/raw/data/expected_output_stdin.txt
@@ -1,19 +1,19 @@
 Final portfolio
-  * AMZN: 210.00
-  * BABA: 30.00
-  * META: 119.00
-  * OPRA: 120.00
+  AMZN: 210.00
+  BABA: 30.00
+  META: 119.00
+  OPRA: 120.00
 Final balance
-  * Unknown: -28486.60 (USD)
+  Unknown: -28486.60 (USD)
 Dividends
-  * OTGLY: 9.68 (USD)
-  * OPRA: 3360.00 (USD)
+  OTGLY: 9.68 (USD)
+  OPRA: 3360.00 (USD)
 
 Portfolio at the end of 2022/2023 tax year
-  * AMZN: 210.00, £1900.67
-  * BABA: 30.00, £1942.83
-  * META: 119.00, £18042.21
-  * OPRA: 120.00, £492.03
+  AMZN: 210.00, £1900.67
+  BABA: 30.00, £1942.83
+  META: 119.00, £18042.21
+  OPRA: 120.00, £492.03
 
 Tax summary for 2022/2023
 Number of disposals: 3

--- a/tests/raw/data/expected_output_stdin.txt
+++ b/tests/raw/data/expected_output_stdin.txt
@@ -1,6 +1,3 @@
-Parsing stdin...
-Found 16 broker transactions
-First pass completed
 Final portfolio
   * AMZN: 210.00
   * BABA: 30.00
@@ -12,7 +9,6 @@ Dividends
   * OTGLY: 9.68 (USD)
   * OPRA: 3360.00 (USD)
 
-Second pass completed
 Portfolio at the end of 2022/2023 tax year
   * AMZN: 210.00, £1900.67
   * BABA: 30.00, £1942.83
@@ -33,6 +29,3 @@ Total taxable dividends proceeds: £719.29
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £0.00
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/raw/data/expected_output_stdin.txt
+++ b/tests/raw/data/expected_output_stdin.txt
@@ -1,25 +1,25 @@
 Parsing stdin...
 Found 16 broker transactions
 First pass completed
-Final portfolio:
-  AMZN: 210.00
-  BABA: 30.00
-  META: 119.00
-  OPRA: 120.00
-Final balance:
-  Unknown: -28486.60 (USD)
-Dividends:
-  OTGLY: 9.68 (USD)
-  OPRA: 3360.00 (USD)
-Disposal proceeds: £11422.10
+Final portfolio
+  * AMZN: 210.00
+  * BABA: 30.00
+  * META: 119.00
+  * OPRA: 120.00
+Final balance
+  * Unknown: -28486.60 (USD)
+Dividends
+  * OTGLY: 9.68 (USD)
+  * OPRA: 3360.00 (USD)
 
 Second pass completed
-Portfolio at the end of 2022/2023 tax year:
-  AMZN: 210.00, £1900.67
-  BABA: 30.00, £1942.83
-  META: 119.00, £18042.21
-  OPRA: 120.00, £492.03
-For tax year 2022/2023:
+Portfolio at the end of 2022/2023 tax year
+  * AMZN: 210.00, £1900.67
+  * BABA: 30.00, £1942.83
+  * META: 119.00, £18042.21
+  * OPRA: 120.00, £492.03
+
+Tax summary for 2022/2023
 Number of disposals: 3
 Disposal proceeds: £11422.10
 Allowable costs: £13588.22

--- a/tests/raw/test_raw.py
+++ b/tests/raw/test_raw.py
@@ -13,7 +13,7 @@ import pytest
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType
 from cgt_calc.parsers.raw import COLUMNS, RawColumn, RawParser, _parse_decimal
-from tests.utils import build_cmd
+from tests.utils import build_cmd, stderr_alerts
 
 
 def _write_csv(path: Path, rows: list[list[str]]) -> None:
@@ -42,7 +42,7 @@ def test_run_with_raw_files_no_balance_check() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert result.stderr.strip() == "", "Unexpected stderr message"
+    assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
     expected_file = Path("tests") / "raw" / "data" / "expected_output.txt"
     expected = expected_file.read_text()
     cmd_str = " ".join([param or "''" for param in cmd])
@@ -70,7 +70,7 @@ def test_run_with_raw_files() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert result.stderr.strip() == "", "Unexpected stderr message"
+    assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
     expected_file = Path("tests") / "raw" / "data" / "expected_output_2.txt"
     expected = expected_file.read_text()
     cmd_str = " ".join([param or "''" for param in cmd])
@@ -104,7 +104,7 @@ def test_run_with_raw_files_stdin() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert result.stderr.strip() == "", "Unexpected stderr message"
+    assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
     expected_file = Path("tests") / "raw" / "data" / "expected_output_stdin.txt"
     expected = expected_file.read_text()
 

--- a/tests/schwab/data/2023/expected_output.txt
+++ b/tests/schwab/data/2023/expected_output.txt
@@ -1,10 +1,10 @@
 Final portfolio
-  * (none)
+  (none)
 Final balance
-  * Charles Schwab: 1019826.86 (USD)
+  Charles Schwab: 1019826.86 (USD)
 
 Portfolio at the end of 2023/2024 tax year
-  * (none)
+  (none)
 
 Tax summary for 2023/2024
 Number of disposals: 3

--- a/tests/schwab/data/2023/expected_output.txt
+++ b/tests/schwab/data/2023/expected_output.txt
@@ -1,12 +1,8 @@
-Parsing tests/schwab/data/2023/transactions.csv...
-Found 7 broker transactions
-First pass completed
 Final portfolio
   * (none)
 Final balance
   * Charles Schwab: 1019826.86 (USD)
 
-Second pass completed
 Portfolio at the end of 2023/2024 tax year
   * (none)
 
@@ -24,6 +20,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £0.00
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/schwab/data/2023/expected_output.txt
+++ b/tests/schwab/data/2023/expected_output.txt
@@ -1,14 +1,16 @@
 Parsing tests/schwab/data/2023/transactions.csv...
 Found 7 broker transactions
 First pass completed
-Final portfolio:
-Final balance:
-  Charles Schwab: 1019826.86 (USD)
-Disposal proceeds: £248082.51
+Final portfolio
+  * (none)
+Final balance
+  * Charles Schwab: 1019826.86 (USD)
 
 Second pass completed
-Portfolio at the end of 2023/2024 tax year:
-For tax year 2023/2024:
+Portfolio at the end of 2023/2024 tax year
+  * (none)
+
+Tax summary for 2023/2024
 Number of disposals: 3
 Disposal proceeds: £248082.51
 Allowable costs: £232740.33

--- a/tests/schwab/data/bond_interest/expected_output.txt
+++ b/tests/schwab/data/bond_interest/expected_output.txt
@@ -1,12 +1,12 @@
 Final portfolio
-  * (none)
+  (none)
 Final balance
-  * Charles Schwab: 11055.75 (USD)
+  Charles Schwab: 11055.75 (USD)
 Interest
-  * Charles Schwab: 555.75 (USD)
+  Charles Schwab: 555.75 (USD)
 
 Portfolio at the end of 2023/2024 tax year
-  * (none)
+  (none)
 
 Tax summary for 2023/2024
 Number of disposals: 0

--- a/tests/schwab/data/bond_interest/expected_output.txt
+++ b/tests/schwab/data/bond_interest/expected_output.txt
@@ -1,16 +1,18 @@
 Parsing tests/schwab/data/bond_interest/transactions.csv...
 Found 5 broker transactions
 First pass completed
-Final portfolio:
-Final balance:
-  Charles Schwab: 11055.75 (USD)
-Interests:
-  Charles Schwab: 555.75 (USD)
-Disposal proceeds: £0.00
+Final portfolio
+  * (none)
+Final balance
+  * Charles Schwab: 11055.75 (USD)
+Interest
+  * Charles Schwab: 555.75 (USD)
 
 Second pass completed
-Portfolio at the end of 2023/2024 tax year:
-For tax year 2023/2024:
+Portfolio at the end of 2023/2024 tax year
+  * (none)
+
+Tax summary for 2023/2024
 Number of disposals: 0
 Disposal proceeds: £0.00
 Allowable costs: £0.00

--- a/tests/schwab/data/bond_interest/expected_output.txt
+++ b/tests/schwab/data/bond_interest/expected_output.txt
@@ -1,6 +1,3 @@
-Parsing tests/schwab/data/bond_interest/transactions.csv...
-Found 5 broker transactions
-First pass completed
 Final portfolio
   * (none)
 Final balance
@@ -8,7 +5,6 @@ Final balance
 Interest
   * Charles Schwab: 555.75 (USD)
 
-Second pass completed
 Portfolio at the end of 2023/2024 tax year
   * (none)
 
@@ -26,6 +22,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £440.60
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/schwab/data/cash_merger/expected_output.txt
+++ b/tests/schwab/data/cash_merger/expected_output.txt
@@ -1,14 +1,16 @@
 Parsing tests/schwab/data/cash_merger/transactions.csv...
 Found 5 broker transactions
 First pass completed
-Final portfolio:
-Final balance:
-  Charles Schwab: 1000.00 (USD)
-Disposal proceeds: £711.69
+Final portfolio
+  * (none)
+Final balance
+  * Charles Schwab: 1000.00 (USD)
 
 Second pass completed
-Portfolio at the end of 2020/2021 tax year:
-For tax year 2020/2021:
+Portfolio at the end of 2020/2021 tax year
+  * (none)
+
+Tax summary for 2020/2021
 Number of disposals: 1
 Disposal proceeds: £711.69
 Allowable costs: £1783.50

--- a/tests/schwab/data/cash_merger/expected_output.txt
+++ b/tests/schwab/data/cash_merger/expected_output.txt
@@ -1,12 +1,8 @@
-Parsing tests/schwab/data/cash_merger/transactions.csv...
-Found 5 broker transactions
-First pass completed
 Final portfolio
   * (none)
 Final balance
   * Charles Schwab: 1000.00 (USD)
 
-Second pass completed
 Portfolio at the end of 2020/2021 tax year
   * (none)
 
@@ -24,6 +20,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £0.00
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/schwab/data/cash_merger/expected_output.txt
+++ b/tests/schwab/data/cash_merger/expected_output.txt
@@ -1,10 +1,10 @@
 Final portfolio
-  * (none)
+  (none)
 Final balance
-  * Charles Schwab: 1000.00 (USD)
+  Charles Schwab: 1000.00 (USD)
 
 Portfolio at the end of 2020/2021 tax year
-  * (none)
+  (none)
 
 Tax summary for 2020/2021
 Number of disposals: 1

--- a/tests/schwab/data/interest_tax/expected_output.txt
+++ b/tests/schwab/data/interest_tax/expected_output.txt
@@ -1,18 +1,20 @@
 Parsing tests/schwab/data/interest_tax/transactions.csv...
 Found 2 broker transactions
 First pass completed
-Final portfolio:
-Final balance:
-  Charles Schwab: 2.06 (USD)
-Interests:
-  Charles Schwab: 2.94 (USD)
-Interest taxes:
-  Charles Schwab: 0.88 (USD)
-Disposal proceeds: £0.00
+Final portfolio
+  * (none)
+Final balance
+  * Charles Schwab: 2.06 (USD)
+Interest
+  * Charles Schwab: 2.94 (USD)
+Interest taxes
+  * Charles Schwab: 0.88 (USD)
 
 Second pass completed
-Portfolio at the end of 2024/2025 tax year:
-For tax year 2024/2025:
+Portfolio at the end of 2024/2025 tax year
+  * (none)
+
+Tax summary for 2024/2025
 Number of disposals: 0
 Disposal proceeds: £0.00
 Allowable costs: £0.00

--- a/tests/schwab/data/interest_tax/expected_output.txt
+++ b/tests/schwab/data/interest_tax/expected_output.txt
@@ -1,14 +1,14 @@
 Final portfolio
-  * (none)
+  (none)
 Final balance
-  * Charles Schwab: 2.06 (USD)
+  Charles Schwab: 2.06 (USD)
 Interest
-  * Charles Schwab: 2.94 (USD)
+  Charles Schwab: 2.94 (USD)
 Interest taxes
-  * Charles Schwab: 0.88 (USD)
+  Charles Schwab: 0.88 (USD)
 
 Portfolio at the end of 2024/2025 tax year
-  * (none)
+  (none)
 
 Tax summary for 2024/2025
 Number of disposals: 0

--- a/tests/schwab/data/interest_tax/expected_output.txt
+++ b/tests/schwab/data/interest_tax/expected_output.txt
@@ -1,6 +1,3 @@
-Parsing tests/schwab/data/interest_tax/transactions.csv...
-Found 2 broker transactions
-First pass completed
 Final portfolio
   * (none)
 Final balance
@@ -10,7 +7,6 @@ Interest
 Interest taxes
   * Charles Schwab: 0.88 (USD)
 
-Second pass completed
 Portfolio at the end of 2024/2025 tax year
   * (none)
 
@@ -28,6 +24,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £2.31
 Total interest tax paid: £0.69
-
-Generating PDF report...
-All done!

--- a/tests/schwab/data/rsu_settlement/expected_output.txt
+++ b/tests/schwab/data/rsu_settlement/expected_output.txt
@@ -2,16 +2,16 @@ Parsing tests/schwab/data/rsu_settlement/awards.csv...
 Parsing tests/schwab/data/rsu_settlement/transactions.csv...
 Found 4 broker transactions
 First pass completed
-Final portfolio:
-  BAR: 300.00
-Final balance:
-  Charles Schwab: 28068.66 (USD)
-Disposal proceeds: £21783.33
+Final portfolio
+  * BAR: 300.00
+Final balance
+  * Charles Schwab: 28068.66 (USD)
 
 Second pass completed
-Portfolio at the end of 2023/2024 tax year:
-  BAR: 300.00, £32533.02
-For tax year 2023/2024:
+Portfolio at the end of 2023/2024 tax year
+  * BAR: 300.00, £32533.02
+
+Tax summary for 2023/2024
 Number of disposals: 1
 Disposal proceeds: £21783.33
 Allowable costs: £21784.37

--- a/tests/schwab/data/rsu_settlement/expected_output.txt
+++ b/tests/schwab/data/rsu_settlement/expected_output.txt
@@ -1,10 +1,10 @@
 Final portfolio
-  * BAR: 300.00
+  BAR: 300.00
 Final balance
-  * Charles Schwab: 28068.66 (USD)
+  Charles Schwab: 28068.66 (USD)
 
 Portfolio at the end of 2023/2024 tax year
-  * BAR: 300.00, £32533.02
+  BAR: 300.00, £32533.02
 
 Tax summary for 2023/2024
 Number of disposals: 1

--- a/tests/schwab/data/rsu_settlement/expected_output.txt
+++ b/tests/schwab/data/rsu_settlement/expected_output.txt
@@ -1,13 +1,8 @@
-Parsing tests/schwab/data/rsu_settlement/awards.csv...
-Parsing tests/schwab/data/rsu_settlement/transactions.csv...
-Found 4 broker transactions
-First pass completed
 Final portfolio
   * BAR: 300.00
 Final balance
   * Charles Schwab: 28068.66 (USD)
 
-Second pass completed
 Portfolio at the end of 2023/2024 tax year
   * BAR: 300.00, £32533.02
 
@@ -25,6 +20,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £0.00
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -9,7 +9,7 @@ import pytest
 
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.parsers.schwab import AwardPrices, SchwabParser
-from tests.utils import build_cmd
+from tests.utils import build_cmd, stderr_alerts
 
 
 def test_missing_award_file_reports_the_vest_it_cannot_price() -> None:
@@ -68,7 +68,7 @@ def test_run_with_schwab_example_2023_files() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert result.stderr.strip() == "", "Unexpected stderr message"
+    assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
     expected_file = Path("tests") / "schwab" / "data" / "2023" / "expected_output.txt"
     expected = expected_file.read_text()
     cmd_str = " ".join([param or "''" for param in cmd])
@@ -96,13 +96,10 @@ def test_run_with_schwab_cash_merger_files() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    stderr_lines = result.stderr.strip().split("\n")
-    assert len(stderr_lines) == 2
-    assert stderr_lines[0].startswith("WARNING: Cash Merger support is not complete")
-    assert (
-        stderr_lines[1].strip()
-        == "FOO: 100 units on 2021-03-02 for 1000 USD (Charles Schwab)"
-    )
+    alerts = stderr_alerts(result.stderr)
+    assert len(alerts) == 1
+    assert alerts[0].startswith("WARNING: Cash Merger support is not complete")
+    assert "FOO: 100 units on 2021-03-02 for 1000 USD (Charles Schwab)" in result.stderr
     expected_file = (
         Path("tests") / "schwab" / "data" / "cash_merger" / "expected_output.txt"
     )
@@ -134,8 +131,7 @@ def test_run_with_schwab_rsu_settlement_files() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    stderr = result.stderr.strip()
-    assert stderr == ""
+    assert stderr_alerts(result.stderr) == []
     expected_file = (
         Path("tests") / "schwab" / "data" / "rsu_settlement" / "expected_output.txt"
     )
@@ -165,7 +161,7 @@ def test_run_with_schwab_bond_interest_files() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert result.stderr.strip() == "", "Unexpected stderr message"
+    assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
     expected_file = (
         Path("tests") / "schwab" / "data" / "bond_interest" / "expected_output.txt"
     )
@@ -195,7 +191,7 @@ def test_run_with_schwab_interest_tax_files() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert result.stderr == ""
+    assert stderr_alerts(result.stderr) == []
     expected_file = (
         Path("tests") / "schwab" / "data" / "interest_tax" / "expected_output.txt"
     )

--- a/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
+++ b/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
@@ -1,7 +1,3 @@
-Parsing tests/sharesight/data/inputs/All Trades Report - Test.csv...
-Parsing tests/sharesight/data/inputs/Taxable Income Report - Test.csv...
-Found 16 broker transactions
-First pass completed
 Final portfolio
   * FX:ETH: 2.59
   * FundUK:FUND1: 50.00
@@ -13,7 +9,6 @@ Dividends
   * FOO.NASDAQ: 5.00, excluding 0.75 taxed at source (USD)
   * FUND1.UKF: 3.00 (GBP)
 
-Second pass completed
 Portfolio at the end of 2020/2021 tax year
   * FX:ETH: 2.59, £5352.48
   * FundUK:FUND1: 50.00, £13775.00
@@ -33,6 +28,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £0.00
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
+++ b/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
@@ -1,18 +1,18 @@
 Final portfolio
-  * FX:ETH: 2.59
-  * FundUK:FUND1: 50.00
-  * NASDAQ:FOO: 5.00
+  FX:ETH: 2.59
+  FundUK:FUND1: 50.00
+  NASDAQ:FOO: 5.00
 Final balance
-  * Sharesight: -17854.31 (GBP)
-  * Sharesight: 7474.30 (USD)
+  Sharesight: -17854.31 (GBP)
+  Sharesight: 7474.30 (USD)
 Dividends
-  * FOO.NASDAQ: 5.00, excluding 0.75 taxed at source (USD)
-  * FUND1.UKF: 3.00 (GBP)
+  FOO.NASDAQ: 5.00, excluding 0.75 taxed at source (USD)
+  FUND1.UKF: 3.00 (GBP)
 
 Portfolio at the end of 2020/2021 tax year
-  * FX:ETH: 2.59, £5352.48
-  * FundUK:FUND1: 50.00, £13775.00
-  * NASDAQ:FOO: 5.00, £968.97
+  FX:ETH: 2.59, £5352.48
+  FundUK:FUND1: 50.00, £13775.00
+  NASDAQ:FOO: 5.00, £968.97
 
 Tax summary for 2020/2021
 Number of disposals: 4

--- a/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
+++ b/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
@@ -2,24 +2,24 @@ Parsing tests/sharesight/data/inputs/All Trades Report - Test.csv...
 Parsing tests/sharesight/data/inputs/Taxable Income Report - Test.csv...
 Found 16 broker transactions
 First pass completed
-Final portfolio:
-  FX:ETH: 2.59
-  FundUK:FUND1: 50.00
-  NASDAQ:FOO: 5.00
-Final balance:
-  Sharesight: -17854.31 (GBP)
-  Sharesight: 7474.30 (USD)
-Dividends:
-  FOO.NASDAQ: 5.00, excluding 0.75 taxed at source (USD)
-  FUND1.UKF: 3.00 (GBP)
-Disposal proceeds: £12999.61
+Final portfolio
+  * FX:ETH: 2.59
+  * FundUK:FUND1: 50.00
+  * NASDAQ:FOO: 5.00
+Final balance
+  * Sharesight: -17854.31 (GBP)
+  * Sharesight: 7474.30 (USD)
+Dividends
+  * FOO.NASDAQ: 5.00, excluding 0.75 taxed at source (USD)
+  * FUND1.UKF: 3.00 (GBP)
 
 Second pass completed
-Portfolio at the end of 2020/2021 tax year:
-  FX:ETH: 2.59, £5352.48
-  FundUK:FUND1: 50.00, £13775.00
-  NASDAQ:FOO: 5.00, £968.97
-For tax year 2020/2021:
+Portfolio at the end of 2020/2021 tax year
+  * FX:ETH: 2.59, £5352.48
+  * FundUK:FUND1: 50.00, £13775.00
+  * NASDAQ:FOO: 5.00, £968.97
+
+Tax summary for 2020/2021
 Number of disposals: 4
 Disposal proceeds: £12999.61
 Allowable costs: £11017.97

--- a/tests/sharesight/test_sharesight.py
+++ b/tests/sharesight/test_sharesight.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 from pathlib import Path
 import subprocess
 
-from tests.utils import build_cmd
+from tests.utils import build_cmd, stderr_alerts
 
 
 def _write_csv(path: Path, rows: list[list[str]]) -> None:
@@ -42,7 +42,7 @@ def test_run_with_sharesight_files_no_balance_check() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert result.stderr == "", "Run with example files generated errors"
+    assert stderr_alerts(result.stderr) == [], "Run with example files generated errors"
     expected_file = (
         Path("tests")
         / "sharesight"

--- a/tests/trading212/data/2024/expected_output.txt
+++ b/tests/trading212/data/2024/expected_output.txt
@@ -1,10 +1,10 @@
 Final portfolio
-  * (none)
+  (none)
 Final balance
-  * Trading212: 1758.05 (GBP)
+  Trading212: 1758.05 (GBP)
 
 Portfolio at the end of 2024/2025 tax year
-  * (none)
+  (none)
 
 Tax summary for 2024/2025
 Number of disposals: 1

--- a/tests/trading212/data/2024/expected_output.txt
+++ b/tests/trading212/data/2024/expected_output.txt
@@ -1,12 +1,8 @@
-Parsing tests/trading212/data/2024/inputs/transactions.csv...
-Found 7 broker transactions
-First pass completed
 Final portfolio
   * (none)
 Final balance
   * Trading212: 1758.05 (GBP)
 
-Second pass completed
 Portfolio at the end of 2024/2025 tax year
   * (none)
 
@@ -24,6 +20,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £0.00
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/trading212/data/2024/expected_output.txt
+++ b/tests/trading212/data/2024/expected_output.txt
@@ -1,14 +1,16 @@
 Parsing tests/trading212/data/2024/inputs/transactions.csv...
 Found 7 broker transactions
 First pass completed
-Final portfolio:
-Final balance:
-  Trading212: 1758.05 (GBP)
-Disposal proceeds: £3143.21
+Final portfolio
+  * (none)
+Final balance
+  * Trading212: 1758.05 (GBP)
 
 Second pass completed
-Portfolio at the end of 2024/2025 tax year:
-For tax year 2024/2025:
+Portfolio at the end of 2024/2025 tax year
+  * (none)
+
+Tax summary for 2024/2025
 Number of disposals: 1
 Disposal proceeds: £3143.21
 Allowable costs: £2386.06

--- a/tests/trading212/test_trading212.py
+++ b/tests/trading212/test_trading212.py
@@ -16,7 +16,7 @@ from cgt_calc.parsers.trading212 import (
     Trading212Parser,
     Trading212Transaction,
 )
-from tests.utils import build_cmd
+from tests.utils import build_cmd, stderr_alerts
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -515,7 +515,7 @@ def test_run_with_trading212_2024_files() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert result.stderr == "", "Run with example files generated errors"
+    assert stderr_alerts(result.stderr) == [], "Run with example files generated errors"
     expected_file = (
         Path("tests") / "trading212" / "data" / "2024" / "expected_output.txt"
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,3 +11,12 @@ def build_cmd(*args: str) -> list[str]:
         cmd.append("--no-pdflatex")
     cmd += ["--exchange-rates-file", "tests/exchange_rates_data.csv"]
     return cmd
+
+
+def stderr_alerts(stderr: str) -> list[str]:
+    """Return warning/error lines from stderr, ignoring info chatter."""
+    return [
+        line
+        for line in stderr.splitlines()
+        if line.startswith(("WARNING", "ERROR", "CRITICAL"))
+    ]

--- a/tests/vanguard/data/expected_output.txt
+++ b/tests/vanguard/data/expected_output.txt
@@ -1,24 +1,24 @@
 Parsing tests/vanguard/data/cash_investment_report.csv...
 Found 17 broker transactions
 First pass completed
-Final portfolio:
-  BAR: 293.00
-  Emerging Markets Stock Index Fund - Accumulation: 6.77
-  FOO: 1550.00
-  U.S. Equity Index Fund - Accumulation: 0.92
-Final balance:
-  Vanguard: 23.59 (GBP)
-Dividends:
-  FOO: 396.66 (GBP)
-Disposal proceeds: £104.06
+Final portfolio
+  * BAR: 293.00
+  * Emerging Markets Stock Index Fund - Accumulation: 6.77
+  * FOO: 1550.00
+  * U.S. Equity Index Fund - Accumulation: 0.92
+Final balance
+  * Vanguard: 23.59 (GBP)
+Dividends
+  * FOO: 396.66 (GBP)
 
 Second pass completed
-Portfolio at the end of 2022/2023 tax year:
-  BAR: 293.00, £29845.42
-  Emerging Markets Stock Index Fund - Accumulation: 6.77, £1000.00
-  FOO: 1550.00, £14982.06
-  U.S. Equity Index Fund - Accumulation: 0.92, £400.00
-For tax year 2022/2023:
+Portfolio at the end of 2022/2023 tax year
+  * BAR: 293.00, £29845.42
+  * Emerging Markets Stock Index Fund - Accumulation: 6.77, £1000.00
+  * FOO: 1550.00, £14982.06
+  * U.S. Equity Index Fund - Accumulation: 0.92, £400.00
+
+Tax summary for 2022/2023
 Number of disposals: 1
 Disposal proceeds: £104.06
 Allowable costs: £101.86

--- a/tests/vanguard/data/expected_output.txt
+++ b/tests/vanguard/data/expected_output.txt
@@ -1,6 +1,3 @@
-Parsing tests/vanguard/data/cash_investment_report.csv...
-Found 17 broker transactions
-First pass completed
 Final portfolio
   * BAR: 293.00
   * Emerging Markets Stock Index Fund - Accumulation: 6.77
@@ -11,7 +8,6 @@ Final balance
 Dividends
   * FOO: 396.66 (GBP)
 
-Second pass completed
 Portfolio at the end of 2022/2023 tax year
   * BAR: 293.00, £29845.42
   * Emerging Markets Stock Index Fund - Accumulation: 6.77, £1000.00
@@ -32,6 +28,3 @@ Total taxable dividends proceeds: £0.00
 Total UK interest proceeds: £0.00
 Total foreign interest proceeds: £396.66
 Total interest tax paid: £0.00
-
-Generating PDF report...
-All done!

--- a/tests/vanguard/data/expected_output.txt
+++ b/tests/vanguard/data/expected_output.txt
@@ -1,18 +1,18 @@
 Final portfolio
-  * BAR: 293.00
-  * Emerging Markets Stock Index Fund - Accumulation: 6.77
-  * FOO: 1550.00
-  * U.S. Equity Index Fund - Accumulation: 0.92
+  BAR: 293.00
+  Emerging Markets Stock Index Fund - Accumulation: 6.77
+  FOO: 1550.00
+  U.S. Equity Index Fund - Accumulation: 0.92
 Final balance
-  * Vanguard: 23.59 (GBP)
+  Vanguard: 23.59 (GBP)
 Dividends
-  * FOO: 396.66 (GBP)
+  FOO: 396.66 (GBP)
 
 Portfolio at the end of 2022/2023 tax year
-  * BAR: 293.00, £29845.42
-  * Emerging Markets Stock Index Fund - Accumulation: 6.77, £1000.00
-  * FOO: 1550.00, £14982.06
-  * U.S. Equity Index Fund - Accumulation: 0.92, £400.00
+  BAR: 293.00, £29845.42
+  Emerging Markets Stock Index Fund - Accumulation: 6.77, £1000.00
+  FOO: 1550.00, £14982.06
+  U.S. Equity Index Fund - Accumulation: 0.92, £400.00
 
 Tax summary for 2022/2023
 Number of disposals: 1

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -12,7 +12,7 @@ from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType
 from cgt_calc.parsers.vanguard import COLUMNS, VanguardParser
-from tests.utils import build_cmd
+from tests.utils import build_cmd, stderr_alerts
 
 
 def _write_csv(path: Path, rows: list[list[str]]) -> None:
@@ -38,7 +38,7 @@ def test_run_with_vanguard_files() -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert result.stderr == "", "Run with example files generated errors"
+    assert stderr_alerts(result.stderr) == [], "Run with example files generated errors"
     expected_file = Path("tests") / "vanguard" / "data" / "expected_output.txt"
     expected = expected_file.read_text()
     cmd_str = " ".join([param or "''" for param in cmd])


### PR DESCRIPTION
Piped stdout is now purely the tax report; all progress and diagnostics go to stderr as log messages.

- Progress messages (`Parsing ...`, `Found N broker transactions`, pass checkpoints, `Writing ... report to ...`, `Done!`) moved from stdout to stderr at INFO level, which is now the default (`--verbose` still switches to DEBUG).
- Report structure polished: items indented under section headers, `(none)` placeholders for empty sections, tightened section wording (`Final portfolio`, `Interest`, `Tax summary for 2024/2025`), and the first-pass `Disposal proceeds` line removed — it duplicated the Tax summary.
- Log levels tuned for the INFO default: bed & breakfast matches print for the computed tax year only (DEBUG for the rest of the history walk), Cancel-Buy matching details are DEBUG.
- Progress now names the artifact (`Writing PDF report to out/calculations.pdf...`) and `--no-pdflatex` says `Calculations complete (PDF generation skipped)` instead of claiming a report was generated — both possible now that these lines are not part of the fixture-compared stdout.
- Tests: the example-files run pins the exact stderr progress narrative; `stderr_alerts()` asserts no WARNING/ERROR lines elsewhere; `conftest.py` pins `NO_COLOR` so output stays deterministic in any environment; all expected-output fixtures regenerated.

**Breaking:** anything parsing this tool's stdout no longer sees progress lines — stdout is exactly the report, stderr carries the rest.

```
$ cgt-calc --year 2020 ... > report.txt
Parsing tests/schwab/data/schwab_transactions.csv...
Loaded 13 transactions from Charles Schwab
Found 27 broker transactions

First pass complete

Second pass complete

Writing PDF report to out/calculations.pdf...

Done! Report generated successfully.
$ head -4 report.txt
Final portfolio
  GOOG: 163.20
  NVDA: 1.00
  VNRG: 1.00
```