### PR TITLE
Group and align the tax summary

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -664,20 +664,24 @@ class CapitalGainsCalculator:
             print("  (none)")
         for stock, position in sorted(self.portfolio.items()):
             print(f"  {stock}: {position}")
+        print()
         print("Final balance")
         for (broker, currency), amount in balance.items():
             print(f"  {broker}: {round_decimal(amount, 2)} ({currency})")
         if dividends:
+            print()
             print("Dividends")
             for (symbol, currency), amount in dividends.items():
                 tax = dividends_tax[(symbol, currency)]
                 tax_str = f", excluding {-tax} taxed at source" if tax < 0 else ""
                 print(f"  {symbol}: {round_decimal(amount, 2)}{tax_str} ({currency})")
         if interests:
+            print()
             print("Interest")
             for (broker, currency), amount in interests.items():
                 print(f"  {broker}: {round_decimal(amount, 2)} ({currency})")
         if interest_taxes:
+            print()
             print("Interest taxes")
             for (broker, currency), amount in interest_taxes.items():
                 print(f"  {broker}: {round_decimal(-amount, 2)} ({currency})")

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -344,7 +344,7 @@ class PortfolioEntry:
         if self.unrealized_gains is None:
             str_val = "unknown"
         else:
-            str_val = f"£{round_decimal(self.unrealized_gains, 2)}"
+            str_val = f"£{round_decimal(self.unrealized_gains, 2):,}"
 
         return f" (unrealized gains: {str_val})"
 
@@ -355,8 +355,8 @@ class PortfolioEntry:
     def __str__(self) -> str:
         """Return string representation."""
         return (
-            f"{self.symbol}: {round_decimal(self.quantity, 2)}, "
-            f"£{round_decimal(self.amount, 2)}"
+            f"{self.symbol}: {round_decimal(self.quantity, 2):,}, "
+            f"£{round_decimal(self.amount, 2):,}"
         )
 
 
@@ -478,56 +478,85 @@ class CapitalGainsReport:
         )
         out += "\n"
         out += f"Tax summary for {self.tax_year}/{self.tax_year + 1}\n"
-        if eris:
-            out += "Excess Reported Income\n"
-            for item in self._filter_calculation_log(
-                self.calculation_log_yields,
-                RuleType.EXCESS_REPORTED_INCOME_DISTRIBUTION,
-            ):
-                assert item.eris
-                assert len(item.eris) == 1
-                dist_type = "interest" if item.eris[0].is_interest else "dividend"
-                out += f"  {item.eris[0].symbol}: £{round_decimal(item.amount, 2)} "
-                out += f"(included as {dist_type})\n"
 
-        out += f"Number of disposals: {self.disposal_count}\n"
-        out += f"Disposal proceeds: £{self.disposal_proceeds}\n"
-        out += f"Allowable costs: £{self.allowable_costs}\n"
-        out += f"Capital gain: £{self.capital_gain}\n"
-        out += f"Capital loss: £{-self.capital_loss}\n"
-        out += f"Total capital gain: £{self.total_gain()}\n"
+        capital: list[tuple[str, str]] = [
+            ("Disposals", str(self.disposal_count)),
+            ("Disposal proceeds", f"£{self.disposal_proceeds:,}"),
+            ("Allowable costs", f"£{self.allowable_costs:,}"),
+            ("Gain", f"£{self.capital_gain:,}"),
+            ("Loss", f"£{-self.capital_loss:,}"),
+            ("Total gain", f"£{self.total_gain():,}"),
+        ]
+        capital_notes: list[str] = []
         if self.capital_gain_allowance is not None:
-            out += f"Taxable capital gain: £{self.taxable_gain()}\n"
+            capital.append(("Taxable gain", f"£{self.taxable_gain():,}"))
         else:
-            out += "WARNING: Missing allowance for this tax year\n"
+            capital_notes.append("WARNING: Missing allowance for this tax year")
         if self.show_unrealized_gains:
-            total_unrealized_gains = round_decimal(self.total_unrealized_gains(), 2)
-            out += f"Total unrealized gains: £{total_unrealized_gains}\n"
-            if any(h.unrealized_gains is None for h in self.portfolio):
-                out += (
-                    "WARNING: Some unrealized gains couldn't be calculated."
-                    " Take a look at the symbols with unknown unrealized gains above"
-                    " and factor in their prices.\n"
+            capital.append(
+                (
+                    "Unrealized gains",
+                    f"£{round_decimal(self.total_unrealized_gains(), 2):,}",
                 )
-        out += (
-            "Total dividends proceeds: "
-            f"£{round_decimal(self.total_dividends_amount(), 2)}\n"
-        )
+            )
+            if any(h.unrealized_gains is None for h in self.portfolio):
+                capital_notes.append(
+                    "WARNING: Some unrealized gains couldn't be calculated."
+                    " Take a look at the symbols with unknown unrealized gains"
+                    " above and factor in their prices."
+                )
+
+        dividends: list[tuple[str, str]] = [
+            ("Proceeds", f"£{round_decimal(self.total_dividends_amount(), 2):,}"),
+        ]
         if self.dividend_allowance is not None:
-            out += (
-                "Total amount of dividends tax yearly allowance: "
-                f"£{round_decimal(self.dividend_allowance, 2)}\n"
+            dividends.append(
+                (
+                    "Tax-free allowance",
+                    f"£{round_decimal(self.dividend_allowance, 2):,}",
+                )
             )
         if (
             self.dividend_allowance is not None
             or self.total_dividend_taxes_in_tax_treaties_amount() > 0
         ):
-            out += (
-                "Total taxable dividends proceeds: "
-                f"£{round_decimal(self.total_dividend_taxable_gain(), 2)}\n"
+            dividends.append(
+                (
+                    "Taxable proceeds",
+                    f"£{round_decimal(self.total_dividend_taxable_gain(), 2):,}",
+                )
             )
-        out += f"Total UK interest proceeds: £{self.total_uk_interest}\n"
-        out += f"Total foreign interest proceeds: £{self.total_foreign_interest}\n"
-        out += f"Total interest tax paid: £{self.total_interest_tax}\n"
+
+        interest: list[tuple[str, str]] = [
+            ("UK proceeds", f"£{self.total_uk_interest:,}"),
+            ("Foreign proceeds", f"£{self.total_foreign_interest:,}"),
+            ("Tax paid", f"£{self.total_interest_tax:,}"),
+        ]
+
+        groups: list[tuple[str, list[tuple[str, str]], list[str]]] = [
+            ("Capital gains", capital, capital_notes),
+            ("Dividends", dividends, []),
+            ("Interest", interest, []),
+        ]
+
+        # Right-align values on one shared column across the whole summary so
+        # the decimal points line up.
+        label_width = max(len(label) for _, rows, _ in groups for label, _ in rows) + 1
+        value_width = max(len(value) for _, rows, _ in groups for _, value in rows)
+        for title, rows, notes in groups:
+            out += f"\n{title}\n"
+            for label, value in rows:
+                out += f"  {label + ':':<{label_width}} {value:>{value_width}}\n"
+            for note in notes:
+                out += f"{note}\n"
+
+        if eris:
+            out += "\nExcess Reported Income\n"
+            for item in eris:
+                assert item.eris
+                assert len(item.eris) == 1
+                dist_type = "interest" if item.eris[0].is_interest else "dividend"
+                out += f"  {item.eris[0].symbol}: £{round_decimal(item.amount, 2):,} "
+                out += f"(included as {dist_type})\n"
 
         return out

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -489,7 +489,9 @@ class CapitalGainsReport:
         ]
         capital_notes: list[str] = []
         if self.capital_gain_allowance is not None:
-            capital.append(("Taxable gain", f"£{self.taxable_gain():,}"))
+            capital.append(
+                ("Taxable gain", f"£{round_decimal(self.taxable_gain(), 2):,}")
+            )
         else:
             capital_notes.append("WARNING: Missing allowance for this tax year")
         if self.show_unrealized_gains:

--- a/cgt_calc/parsers/broker_registry.py
+++ b/cgt_calc/parsers/broker_registry.py
@@ -74,7 +74,7 @@ class BrokerRegistry:
         if len(all_transactions) == 0:
             LOGGER.warning(msg)
         else:
-            LOGGER.info(msg)
+            LOGGER.info("\n%s", msg)
 
         # ERI Raw is not a broker but is close enough to one to be here
         # Only add ERI for funds that show up in the portfolio

--- a/cgt_calc/render_latex.py
+++ b/cgt_calc/render_latex.py
@@ -31,7 +31,7 @@ def render_pdf(
         if skip_pdflatex
         else f"Writing PDF report to {output_path}..."
     )
-    LOGGER.info("%s\n", progress)
+    LOGGER.info("\n%s\n", progress)
     latex_template_env = jinja2.Environment(
         block_start_string="\\BLOCK{",
         block_end_string="}",

--- a/tests/freetrade/data/expected_output.txt
+++ b/tests/freetrade/data/expected_output.txt
@@ -15,16 +15,22 @@ Portfolio at the end of 2023/2024 tax year
   TSLA: 1.45, £944.86
 
 Tax summary for 2023/2024
-Number of disposals: 1
-Disposal proceeds: £2930.36
-Allowable costs: £2502.50
-Capital gain: £427.86
-Capital loss: £0.00
-Total capital gain: £427.86
-Taxable capital gain: £0
-Total dividends proceeds: £1.78
-Total amount of dividends tax yearly allowance: £1000.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £9.02
-Total foreign interest proceeds: £0.00
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                  1
+  Disposal proceeds:  £2,930.36
+  Allowable costs:    £2,502.50
+  Gain:                 £427.86
+  Loss:                   £0.00
+  Total gain:           £427.86
+  Taxable gain:              £0
+
+Dividends
+  Proceeds:               £1.78
+  Tax-free allowance: £1,000.00
+  Taxable proceeds:       £0.00
+
+Interest
+  UK proceeds:            £9.02
+  Foreign proceeds:       £0.00
+  Tax paid:               £0.00

--- a/tests/freetrade/data/expected_output.txt
+++ b/tests/freetrade/data/expected_output.txt
@@ -2,10 +2,13 @@ Final portfolio
   GOOGL: 0.14
   NDAQ: 2.12
   TSLA: 1.45
+
 Final balance
   Freetrade: 8946.79 (GBP)
+
 Dividends
   NDAQ: 1.78 (GBP)
+
 Interest
   Freetrade: 9.02 (GBP)
 
@@ -23,7 +26,7 @@ Capital gains
   Gain:                 £427.86
   Loss:                   £0.00
   Total gain:           £427.86
-  Taxable gain:              £0
+  Taxable gain:           £0.00
 
 Dividends
   Proceeds:               £1.78

--- a/tests/general/data/test_run_with_example_files_output.txt
+++ b/tests/general/data/test_run_with_example_files_output.txt
@@ -13,25 +13,32 @@ Interest
   Charles Schwab: 1.40 (USD)
 
 Portfolio at the end of 2020/2021 tax year
-  GOOG: 172.00, £12516.55
+  GOOG: 172.00, £12,516.55
   NVDA: 1.00, £401.01
   VNRG: 1.00, £8.98
   VUAG: 30.50, £645.19
 
 Tax summary for 2020/2021
+
+Capital gains
+  Disposals:                   4
+  Disposal proceeds:  £43,836.90
+  Allowable costs:    £18,666.33
+  Gain:               £25,170.57
+  Loss:                    £0.00
+  Total gain:         £25,170.57
+  Taxable gain:       £12,870.57
+
+Dividends
+  Proceeds:               £23.27
+  Tax-free allowance:  £2,000.00
+  Taxable proceeds:        £0.00
+
+Interest
+  UK proceeds:             £0.00
+  Foreign proceeds:        £1.03
+  Tax paid:                £0.00
+
 Excess Reported Income
   VUAG: £22.26 (included as dividend)
   VNRG: £0.91 (included as dividend)
-Number of disposals: 4
-Disposal proceeds: £43836.90
-Allowable costs: £18666.33
-Capital gain: £25170.57
-Capital loss: £0.00
-Total capital gain: £25170.57
-Taxable capital gain: £12870.57
-Total dividends proceeds: £23.27
-Total amount of dividends tax yearly allowance: £2000.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £1.03
-Total interest tax paid: £0.00

--- a/tests/general/data/test_run_with_example_files_output.txt
+++ b/tests/general/data/test_run_with_example_files_output.txt
@@ -3,12 +3,15 @@ Final portfolio
   NVDA: 1.00
   VNRG: 1.00
   VUAG: 30.50
+
 Final balance
   Charles Schwab: 9479.30 (USD)
   Trading212: 33391.30 (GBP)
   Morgan Stanley: 1.00 (USD)
+
 Dividends
   NVDA: 0.10 (GBP)
+
 Interest
   Charles Schwab: 1.40 (USD)
 

--- a/tests/hl/data/test_run_with_hl_files_no_balance_check_output.txt
+++ b/tests/hl/data/test_run_with_hl_files_no_balance_check_output.txt
@@ -6,19 +6,25 @@ Interest
   Hargreaves Lansdown: 3.87 (GBP)
 
 Portfolio at the end of 2025/2026 tax year
-  VHVG: 3563.00, £117132.23
+  VHVG: 3,563.00, £117,132.23
 
 Tax summary for 2025/2026
-Number of disposals: 1
-Disposal proceeds: £45000.00
-Allowable costs: £32886.56
-Capital gain: £12113.44
-Capital loss: £0.00
-Total capital gain: £12113.44
-Taxable capital gain: £9113.44
-Total dividends proceeds: £0.00
-Total amount of dividends tax yearly allowance: £500.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £3.87
-Total foreign interest proceeds: £0.00
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                   1
+  Disposal proceeds:  £45,000.00
+  Allowable costs:    £32,886.56
+  Gain:               £12,113.44
+  Loss:                    £0.00
+  Total gain:         £12,113.44
+  Taxable gain:        £9,113.44
+
+Dividends
+  Proceeds:                £0.00
+  Tax-free allowance:    £500.00
+  Taxable proceeds:        £0.00
+
+Interest
+  UK proceeds:             £3.87
+  Foreign proceeds:        £0.00
+  Tax paid:                £0.00

--- a/tests/hl/data/test_run_with_hl_files_no_balance_check_output.txt
+++ b/tests/hl/data/test_run_with_hl_files_no_balance_check_output.txt
@@ -1,7 +1,9 @@
 Final portfolio
   VHVG: 3563.00
+
 Final balance
   Hargreaves Lansdown: -55018.97 (GBP)
+
 Interest
   Hargreaves Lansdown: 3.87 (GBP)
 

--- a/tests/interactive_brokers/data/expected_output.txt
+++ b/tests/interactive_brokers/data/expected_output.txt
@@ -1,7 +1,9 @@
 Final portfolio
   CNX1: 2.00
+
 Final balance
   Interactive Brokers: 3027.40 (GBP)
+
 Dividends
   IBKR: 1.00, excluding 0.15 taxed at source (GBP)
   VT: 20.00, excluding 3.0 taxed at source (GBP)
@@ -18,7 +20,7 @@ Capital gains
   Gain:                   £0.00
   Loss:                   £8.77
   Total gain:            £-8.77
-  Taxable gain:              £0
+  Taxable gain:           £0.00
 
 Dividends
   Proceeds:              £33.54

--- a/tests/interactive_brokers/data/expected_output.txt
+++ b/tests/interactive_brokers/data/expected_output.txt
@@ -7,21 +7,28 @@ Dividends
   VT: 20.00, excluding 3.0 taxed at source (GBP)
 
 Portfolio at the end of 2025/2026 tax year
-  CNX1: 2.00, £2007.77
+  CNX1: 2.00, £2,007.77
 
 Tax summary for 2025/2026
+
+Capital gains
+  Disposals:                  1
+  Disposal proceeds:  £2,002.00
+  Allowable costs:    £2,010.77
+  Gain:                   £0.00
+  Loss:                   £8.77
+  Total gain:            £-8.77
+  Taxable gain:              £0
+
+Dividends
+  Proceeds:              £33.54
+  Tax-free allowance:   £500.00
+  Taxable proceeds:       £0.00
+
+Interest
+  UK proceeds:            £0.00
+  Foreign proceeds:       £0.00
+  Tax paid:               £0.00
+
 Excess Reported Income
   CNX1: £12.54 (included as dividend)
-Number of disposals: 1
-Disposal proceeds: £2002.00
-Allowable costs: £2010.77
-Capital gain: £0.00
-Capital loss: £8.77
-Total capital gain: £-8.77
-Taxable capital gain: £0
-Total dividends proceeds: £33.54
-Total amount of dividends tax yearly allowance: £500.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £0.00
-Total interest tax paid: £0.00

--- a/tests/raw/data/expected_output.txt
+++ b/tests/raw/data/expected_output.txt
@@ -3,8 +3,10 @@ Final portfolio
   BABA: 30.00
   META: 119.00
   OPRA: 120.00
+
 Final balance
   Unknown: -28486.60 (USD)
+
 Dividends
   OTGLY: 9.68 (USD)
   OPRA: 3360.00 (USD)
@@ -24,7 +26,7 @@ Capital gains
   Gain:                    £0.00
   Loss:                £2,166.12
   Total gain:         £-2,166.12
-  Taxable gain:               £0
+  Taxable gain:            £0.00
 
 Dividends
   Proceeds:            £2,719.29

--- a/tests/raw/data/expected_output.txt
+++ b/tests/raw/data/expected_output.txt
@@ -10,22 +10,28 @@ Dividends
   OPRA: 3360.00 (USD)
 
 Portfolio at the end of 2022/2023 tax year
-  AMZN: 210.00, £1900.67
-  BABA: 30.00, £1942.83
-  META: 119.00, £18042.21
+  AMZN: 210.00, £1,900.67
+  BABA: 30.00, £1,942.83
+  META: 119.00, £18,042.21
   OPRA: 120.00, £492.03
 
 Tax summary for 2022/2023
-Number of disposals: 3
-Disposal proceeds: £11422.10
-Allowable costs: £13588.22
-Capital gain: £0.00
-Capital loss: £2166.12
-Total capital gain: £-2166.12
-Taxable capital gain: £0
-Total dividends proceeds: £2719.29
-Total amount of dividends tax yearly allowance: £2000.00
-Total taxable dividends proceeds: £719.29
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £0.00
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                   3
+  Disposal proceeds:  £11,422.10
+  Allowable costs:    £13,588.22
+  Gain:                    £0.00
+  Loss:                £2,166.12
+  Total gain:         £-2,166.12
+  Taxable gain:               £0
+
+Dividends
+  Proceeds:            £2,719.29
+  Tax-free allowance:  £2,000.00
+  Taxable proceeds:      £719.29
+
+Interest
+  UK proceeds:             £0.00
+  Foreign proceeds:        £0.00
+  Tax paid:                £0.00

--- a/tests/raw/data/expected_output_2.txt
+++ b/tests/raw/data/expected_output_2.txt
@@ -8,19 +8,25 @@ Dividends
 
 Portfolio at the end of 2022/2023 tax year
   AMZN: 10.00, £766.40
-  META: 50.00, £7664.01
+  META: 50.00, £7,664.01
 
 Tax summary for 2022/2023
-Number of disposals: 2
-Disposal proceeds: £8431.31
-Allowable costs: £12665.89
-Capital gain: £0.00
-Capital loss: £4234.58
-Total capital gain: £-4234.58
-Taxable capital gain: £0
-Total dividends proceeds: £4.03
-Total amount of dividends tax yearly allowance: £2000.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £0.00
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                   2
+  Disposal proceeds:   £8,431.31
+  Allowable costs:    £12,665.89
+  Gain:                    £0.00
+  Loss:                £4,234.58
+  Total gain:         £-4,234.58
+  Taxable gain:               £0
+
+Dividends
+  Proceeds:                £4.03
+  Tax-free allowance:  £2,000.00
+  Taxable proceeds:        £0.00
+
+Interest
+  UK proceeds:             £0.00
+  Foreign proceeds:        £0.00
+  Tax paid:                £0.00

--- a/tests/raw/data/expected_output_2.txt
+++ b/tests/raw/data/expected_output_2.txt
@@ -1,8 +1,10 @@
 Final portfolio
   AMZN: 10.00
   META: 50.00
+
 Final balance
   Unknown: 0.00 (USD)
+
 Dividends
   META: 5.00 (USD)
 
@@ -19,7 +21,7 @@ Capital gains
   Gain:                    £0.00
   Loss:                £4,234.58
   Total gain:         £-4,234.58
-  Taxable gain:               £0
+  Taxable gain:            £0.00
 
 Dividends
   Proceeds:                £4.03

--- a/tests/raw/data/expected_output_stdin.txt
+++ b/tests/raw/data/expected_output_stdin.txt
@@ -3,8 +3,10 @@ Final portfolio
   BABA: 30.00
   META: 119.00
   OPRA: 120.00
+
 Final balance
   Unknown: -28486.60 (USD)
+
 Dividends
   OTGLY: 9.68 (USD)
   OPRA: 3360.00 (USD)
@@ -24,7 +26,7 @@ Capital gains
   Gain:                    £0.00
   Loss:                £2,166.12
   Total gain:         £-2,166.12
-  Taxable gain:               £0
+  Taxable gain:            £0.00
 
 Dividends
   Proceeds:            £2,719.29

--- a/tests/raw/data/expected_output_stdin.txt
+++ b/tests/raw/data/expected_output_stdin.txt
@@ -10,22 +10,28 @@ Dividends
   OPRA: 3360.00 (USD)
 
 Portfolio at the end of 2022/2023 tax year
-  AMZN: 210.00, £1900.67
-  BABA: 30.00, £1942.83
-  META: 119.00, £18042.21
+  AMZN: 210.00, £1,900.67
+  BABA: 30.00, £1,942.83
+  META: 119.00, £18,042.21
   OPRA: 120.00, £492.03
 
 Tax summary for 2022/2023
-Number of disposals: 3
-Disposal proceeds: £11422.10
-Allowable costs: £13588.22
-Capital gain: £0.00
-Capital loss: £2166.12
-Total capital gain: £-2166.12
-Taxable capital gain: £0
-Total dividends proceeds: £2719.29
-Total amount of dividends tax yearly allowance: £2000.00
-Total taxable dividends proceeds: £719.29
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £0.00
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                   3
+  Disposal proceeds:  £11,422.10
+  Allowable costs:    £13,588.22
+  Gain:                    £0.00
+  Loss:                £2,166.12
+  Total gain:         £-2,166.12
+  Taxable gain:               £0
+
+Dividends
+  Proceeds:            £2,719.29
+  Tax-free allowance:  £2,000.00
+  Taxable proceeds:      £719.29
+
+Interest
+  UK proceeds:             £0.00
+  Foreign proceeds:        £0.00
+  Tax paid:                £0.00

--- a/tests/schwab/data/2023/expected_output.txt
+++ b/tests/schwab/data/2023/expected_output.txt
@@ -1,5 +1,6 @@
 Final portfolio
   (none)
+
 Final balance
   Charles Schwab: 1019826.86 (USD)
 

--- a/tests/schwab/data/2023/expected_output.txt
+++ b/tests/schwab/data/2023/expected_output.txt
@@ -7,16 +7,22 @@ Portfolio at the end of 2023/2024 tax year
   (none)
 
 Tax summary for 2023/2024
-Number of disposals: 3
-Disposal proceeds: £248082.51
-Allowable costs: £232740.33
-Capital gain: £15342.18
-Capital loss: £0.00
-Total capital gain: £15342.18
-Taxable capital gain: £9342.18
-Total dividends proceeds: £0.00
-Total amount of dividends tax yearly allowance: £1000.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £0.00
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                    3
+  Disposal proceeds:  £248,082.51
+  Allowable costs:    £232,740.33
+  Gain:                £15,342.18
+  Loss:                     £0.00
+  Total gain:          £15,342.18
+  Taxable gain:         £9,342.18
+
+Dividends
+  Proceeds:                 £0.00
+  Tax-free allowance:   £1,000.00
+  Taxable proceeds:         £0.00
+
+Interest
+  UK proceeds:              £0.00
+  Foreign proceeds:         £0.00
+  Tax paid:                 £0.00

--- a/tests/schwab/data/bond_interest/expected_output.txt
+++ b/tests/schwab/data/bond_interest/expected_output.txt
@@ -9,16 +9,22 @@ Portfolio at the end of 2023/2024 tax year
   (none)
 
 Tax summary for 2023/2024
-Number of disposals: 0
-Disposal proceeds: £0.00
-Allowable costs: £0.00
-Capital gain: £0.00
-Capital loss: £0.00
-Total capital gain: £0.00
-Taxable capital gain: £0
-Total dividends proceeds: £0.00
-Total amount of dividends tax yearly allowance: £1000.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £440.60
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                  0
+  Disposal proceeds:      £0.00
+  Allowable costs:        £0.00
+  Gain:                   £0.00
+  Loss:                   £0.00
+  Total gain:             £0.00
+  Taxable gain:              £0
+
+Dividends
+  Proceeds:               £0.00
+  Tax-free allowance: £1,000.00
+  Taxable proceeds:       £0.00
+
+Interest
+  UK proceeds:            £0.00
+  Foreign proceeds:     £440.60
+  Tax paid:               £0.00

--- a/tests/schwab/data/bond_interest/expected_output.txt
+++ b/tests/schwab/data/bond_interest/expected_output.txt
@@ -1,7 +1,9 @@
 Final portfolio
   (none)
+
 Final balance
   Charles Schwab: 11055.75 (USD)
+
 Interest
   Charles Schwab: 555.75 (USD)
 
@@ -17,7 +19,7 @@ Capital gains
   Gain:                   £0.00
   Loss:                   £0.00
   Total gain:             £0.00
-  Taxable gain:              £0
+  Taxable gain:           £0.00
 
 Dividends
   Proceeds:               £0.00

--- a/tests/schwab/data/cash_merger/expected_output.txt
+++ b/tests/schwab/data/cash_merger/expected_output.txt
@@ -7,16 +7,22 @@ Portfolio at the end of 2020/2021 tax year
   (none)
 
 Tax summary for 2020/2021
-Number of disposals: 1
-Disposal proceeds: £711.69
-Allowable costs: £1783.50
-Capital gain: £0.00
-Capital loss: £1071.81
-Total capital gain: £-1071.81
-Taxable capital gain: £0
-Total dividends proceeds: £0.00
-Total amount of dividends tax yearly allowance: £2000.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £0.00
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                   1
+  Disposal proceeds:     £711.69
+  Allowable costs:     £1,783.50
+  Gain:                    £0.00
+  Loss:                £1,071.81
+  Total gain:         £-1,071.81
+  Taxable gain:               £0
+
+Dividends
+  Proceeds:                £0.00
+  Tax-free allowance:  £2,000.00
+  Taxable proceeds:        £0.00
+
+Interest
+  UK proceeds:             £0.00
+  Foreign proceeds:        £0.00
+  Tax paid:                £0.00

--- a/tests/schwab/data/cash_merger/expected_output.txt
+++ b/tests/schwab/data/cash_merger/expected_output.txt
@@ -1,5 +1,6 @@
 Final portfolio
   (none)
+
 Final balance
   Charles Schwab: 1000.00 (USD)
 
@@ -15,7 +16,7 @@ Capital gains
   Gain:                    £0.00
   Loss:                £1,071.81
   Total gain:         £-1,071.81
-  Taxable gain:               £0
+  Taxable gain:            £0.00
 
 Dividends
   Proceeds:                £0.00

--- a/tests/schwab/data/interest_tax/expected_output.txt
+++ b/tests/schwab/data/interest_tax/expected_output.txt
@@ -11,16 +11,22 @@ Portfolio at the end of 2024/2025 tax year
   (none)
 
 Tax summary for 2024/2025
-Number of disposals: 0
-Disposal proceeds: £0.00
-Allowable costs: £0.00
-Capital gain: £0.00
-Capital loss: £0.00
-Total capital gain: £0.00
-Taxable capital gain: £0
-Total dividends proceeds: £0.00
-Total amount of dividends tax yearly allowance: £500.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £2.31
-Total interest tax paid: £0.69
+
+Capital gains
+  Disposals:                0
+  Disposal proceeds:    £0.00
+  Allowable costs:      £0.00
+  Gain:                 £0.00
+  Loss:                 £0.00
+  Total gain:           £0.00
+  Taxable gain:            £0
+
+Dividends
+  Proceeds:             £0.00
+  Tax-free allowance: £500.00
+  Taxable proceeds:     £0.00
+
+Interest
+  UK proceeds:          £0.00
+  Foreign proceeds:     £2.31
+  Tax paid:             £0.69

--- a/tests/schwab/data/interest_tax/expected_output.txt
+++ b/tests/schwab/data/interest_tax/expected_output.txt
@@ -1,9 +1,12 @@
 Final portfolio
   (none)
+
 Final balance
   Charles Schwab: 2.06 (USD)
+
 Interest
   Charles Schwab: 2.94 (USD)
+
 Interest taxes
   Charles Schwab: 0.88 (USD)
 
@@ -19,7 +22,7 @@ Capital gains
   Gain:                 £0.00
   Loss:                 £0.00
   Total gain:           £0.00
-  Taxable gain:            £0
+  Taxable gain:         £0.00
 
 Dividends
   Proceeds:             £0.00

--- a/tests/schwab/data/rsu_settlement/expected_output.txt
+++ b/tests/schwab/data/rsu_settlement/expected_output.txt
@@ -4,19 +4,25 @@ Final balance
   Charles Schwab: 28068.66 (USD)
 
 Portfolio at the end of 2023/2024 tax year
-  BAR: 300.00, £32533.02
+  BAR: 300.00, £32,533.02
 
 Tax summary for 2023/2024
-Number of disposals: 1
-Disposal proceeds: £21783.33
-Allowable costs: £21784.37
-Capital gain: £0.00
-Capital loss: £1.04
-Total capital gain: £-1.04
-Taxable capital gain: £0
-Total dividends proceeds: £0.00
-Total amount of dividends tax yearly allowance: £1000.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £0.00
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                   1
+  Disposal proceeds:  £21,783.33
+  Allowable costs:    £21,784.37
+  Gain:                    £0.00
+  Loss:                    £1.04
+  Total gain:             £-1.04
+  Taxable gain:               £0
+
+Dividends
+  Proceeds:                £0.00
+  Tax-free allowance:  £1,000.00
+  Taxable proceeds:        £0.00
+
+Interest
+  UK proceeds:             £0.00
+  Foreign proceeds:        £0.00
+  Tax paid:                £0.00

--- a/tests/schwab/data/rsu_settlement/expected_output.txt
+++ b/tests/schwab/data/rsu_settlement/expected_output.txt
@@ -1,5 +1,6 @@
 Final portfolio
   BAR: 300.00
+
 Final balance
   Charles Schwab: 28068.66 (USD)
 
@@ -15,7 +16,7 @@ Capital gains
   Gain:                    £0.00
   Loss:                    £1.04
   Total gain:             £-1.04
-  Taxable gain:               £0
+  Taxable gain:            £0.00
 
 Dividends
   Proceeds:                £0.00

--- a/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
+++ b/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
@@ -2,9 +2,11 @@ Final portfolio
   FX:ETH: 2.59
   FundUK:FUND1: 50.00
   NASDAQ:FOO: 5.00
+
 Final balance
   Sharesight: -17854.31 (GBP)
   Sharesight: 7474.30 (USD)
+
 Dividends
   FOO.NASDAQ: 5.00, excluding 0.75 taxed at source (USD)
   FUND1.UKF: 3.00 (GBP)
@@ -23,7 +25,7 @@ Capital gains
   Gain:                £2,176.98
   Loss:                  £195.34
   Total gain:          £1,981.64
-  Taxable gain:               £0
+  Taxable gain:            £0.00
 
 Dividends
   Proceeds:                £6.92

--- a/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
+++ b/tests/sharesight/data/test_run_with_sharesight_files_no_balance_check_output.txt
@@ -10,21 +10,27 @@ Dividends
   FUND1.UKF: 3.00 (GBP)
 
 Portfolio at the end of 2020/2021 tax year
-  FX:ETH: 2.59, £5352.48
-  FundUK:FUND1: 50.00, £13775.00
+  FX:ETH: 2.59, £5,352.48
+  FundUK:FUND1: 50.00, £13,775.00
   NASDAQ:FOO: 5.00, £968.97
 
 Tax summary for 2020/2021
-Number of disposals: 4
-Disposal proceeds: £12999.61
-Allowable costs: £11017.97
-Capital gain: £2176.98
-Capital loss: £195.34
-Total capital gain: £1981.64
-Taxable capital gain: £0
-Total dividends proceeds: £6.92
-Total amount of dividends tax yearly allowance: £2000.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £0.00
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                   4
+  Disposal proceeds:  £12,999.61
+  Allowable costs:    £11,017.97
+  Gain:                £2,176.98
+  Loss:                  £195.34
+  Total gain:          £1,981.64
+  Taxable gain:               £0
+
+Dividends
+  Proceeds:                £6.92
+  Tax-free allowance:  £2,000.00
+  Taxable proceeds:        £0.00
+
+Interest
+  UK proceeds:             £0.00
+  Foreign proceeds:        £0.00
+  Tax paid:                £0.00

--- a/tests/trading212/data/2024/expected_output.txt
+++ b/tests/trading212/data/2024/expected_output.txt
@@ -1,5 +1,6 @@
 Final portfolio
   (none)
+
 Final balance
   Trading212: 1758.05 (GBP)
 
@@ -15,7 +16,7 @@ Capital gains
   Gain:                 £757.15
   Loss:                   £0.00
   Total gain:           £757.15
-  Taxable gain:              £0
+  Taxable gain:           £0.00
 
 Dividends
   Proceeds:               £0.00

--- a/tests/trading212/data/2024/expected_output.txt
+++ b/tests/trading212/data/2024/expected_output.txt
@@ -7,16 +7,22 @@ Portfolio at the end of 2024/2025 tax year
   (none)
 
 Tax summary for 2024/2025
-Number of disposals: 1
-Disposal proceeds: £3143.21
-Allowable costs: £2386.06
-Capital gain: £757.15
-Capital loss: £0.00
-Total capital gain: £757.15
-Taxable capital gain: £0
-Total dividends proceeds: £0.00
-Total amount of dividends tax yearly allowance: £500.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £0.00
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                  1
+  Disposal proceeds:  £3,143.21
+  Allowable costs:    £2,386.06
+  Gain:                 £757.15
+  Loss:                   £0.00
+  Total gain:           £757.15
+  Taxable gain:              £0
+
+Dividends
+  Proceeds:               £0.00
+  Tax-free allowance:   £500.00
+  Taxable proceeds:       £0.00
+
+Interest
+  UK proceeds:            £0.00
+  Foreign proceeds:       £0.00
+  Tax paid:               £0.00

--- a/tests/vanguard/data/expected_output.txt
+++ b/tests/vanguard/data/expected_output.txt
@@ -9,22 +9,28 @@ Dividends
   FOO: 396.66 (GBP)
 
 Portfolio at the end of 2022/2023 tax year
-  BAR: 293.00, £29845.42
-  Emerging Markets Stock Index Fund - Accumulation: 6.77, £1000.00
-  FOO: 1550.00, £14982.06
+  BAR: 293.00, £29,845.42
+  Emerging Markets Stock Index Fund - Accumulation: 6.77, £1,000.00
+  FOO: 1,550.00, £14,982.06
   U.S. Equity Index Fund - Accumulation: 0.92, £400.00
 
 Tax summary for 2022/2023
-Number of disposals: 1
-Disposal proceeds: £104.06
-Allowable costs: £101.86
-Capital gain: £2.20
-Capital loss: £0.00
-Total capital gain: £2.20
-Taxable capital gain: £0
-Total dividends proceeds: £0.00
-Total amount of dividends tax yearly allowance: £2000.00
-Total taxable dividends proceeds: £0.00
-Total UK interest proceeds: £0.00
-Total foreign interest proceeds: £396.66
-Total interest tax paid: £0.00
+
+Capital gains
+  Disposals:                  1
+  Disposal proceeds:    £104.06
+  Allowable costs:      £101.86
+  Gain:                   £2.20
+  Loss:                   £0.00
+  Total gain:             £2.20
+  Taxable gain:              £0
+
+Dividends
+  Proceeds:               £0.00
+  Tax-free allowance: £2,000.00
+  Taxable proceeds:       £0.00
+
+Interest
+  UK proceeds:            £0.00
+  Foreign proceeds:     £396.66
+  Tax paid:               £0.00

--- a/tests/vanguard/data/expected_output.txt
+++ b/tests/vanguard/data/expected_output.txt
@@ -3,8 +3,10 @@ Final portfolio
   Emerging Markets Stock Index Fund - Accumulation: 6.77
   FOO: 1550.00
   U.S. Equity Index Fund - Accumulation: 0.92
+
 Final balance
   Vanguard: 23.59 (GBP)
+
 Dividends
   FOO: 396.66 (GBP)
 
@@ -23,7 +25,7 @@ Capital gains
   Gain:                   £2.20
   Loss:                   £0.00
   Total gain:             £2.20
-  Taxable gain:              £0
+  Taxable gain:           £0.00
 
 Dividends
   Proceeds:               £0.00


### PR DESCRIPTION
The tax summary was a flat run of "Label: value" lines mixing capital gains, dividends, and interest. It is now grouped by topic with values right-aligned on one shared column, so the decimal points line up ledger-style:

```
Tax summary for 2020/2021

Capital gains
  Disposals:                   4
  Disposal proceeds:  £43,836.90
  Allowable costs:    £18,666.33
  Gain:               £25,170.57
  Loss:                    £0.00
  Total gain:         £25,170.57
  Taxable gain:       £12,870.57

Dividends
  Proceeds:               £23.27
  Tax-free allowance:  £2,000.00
  Taxable proceeds:        £0.00

Interest
  UK proceeds:             £0.00
  Foreign proceeds:        £1.03
  Tax paid:                £0.00

Excess Reported Income
  VUAG: £22.26 (included as dividend)
```

- Labels shortened to read within their group ("Total amount of dividends tax yearly allowance" → "Tax-free allowance").
- Thousands separators in all report amounts, matching the PDF's formatting.
- Excess Reported Income moved to its own trailing group instead of floating between the header and the totals.
- Allowance/unrealized-gains warnings print after their group.