### PR TITLE
Robustness fixes

### DIFF
--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -72,6 +72,7 @@ Environment variables:
     )
     data_group.add_argument(
         "--initial-prices",
+        action=DeprecatedAction,
         dest="initial_prices_file",
         type=existing_file_type,
         help=argparse.SUPPRESS,

--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -8,6 +8,7 @@ import csv
 import datetime
 from decimal import Decimal, InvalidOperation
 import fcntl
+import logging
 from typing import TYPE_CHECKING, Final, TextIO
 
 from defusedxml import ElementTree as ET
@@ -25,6 +26,8 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from .model import BrokerTransaction
+
+LOGGER = logging.getLogger(__name__)
 
 EXCHANGE_RATES_HEADER: Final = ["month", "currency", "rate"]
 NEW_ENDPOINT_FROM_YEAR: Final = 2021
@@ -168,6 +171,7 @@ class CurrencyConverter:
             writer.writerows([EXCHANGE_RATES_HEADER, *data_rows])
 
     def _query_hmrc_api(self, date: datetime.date) -> None:
+        LOGGER.info("Fetching HMRC exchange rates for %s...", date.strftime("%Y-%m"))
         # Pre 2021 we need to use the old HMRC endpoint
         if date.year < NEW_ENDPOINT_FROM_YEAR:
             month_str = date.strftime("%m%y")

--- a/cgt_calc/current_price_fetcher.py
+++ b/cgt_calc/current_price_fetcher.py
@@ -11,6 +11,7 @@ import yfinance as yf  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
     from .currency_converter import CurrencyConverter
+from .exceptions import MarketDataMissingError
 
 
 class CurrentPriceFetcher:
@@ -72,6 +73,8 @@ class CurrentPriceFetcher:
             start=date.strftime("%Y-%m-%d"),
             end=(date + datetime.timedelta(days=1)).strftime("%Y-%m-%d"),
         )
+        if prices.empty:
+            raise MarketDataMissingError(symbol, date)
         closing_price = prices.iloc[0]["Close"]
         closing_price_decimal = Decimal(format(closing_price, ".15g"))
         currency = yf_ticker.info.get("currency") if yf_ticker.info else None

--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -195,3 +195,16 @@ class ExternalApiError(CgtError):
     def __init__(self, url: str, message: str):
         """Initialise."""
         super().__init__(f"{message} (source: {url})")
+
+
+class InteractiveInputRequiredError(CgtError):
+    """Raised when a prompt is needed but stdin is not a terminal."""
+
+    def __init__(self, symbol: str, date: datetime.date, spin_offs_file: Path):
+        """Initialise."""
+        super().__init__(
+            f"Cannot ask which stock {symbol} was spun off from on {date}: "
+            "standard input is not a terminal (this also applies when piping "
+            f"transactions via '-'). Add a '{symbol},<source>' row to "
+            f"{spin_offs_file} (header 'dst,src') and rerun."
+        )

--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -208,3 +208,15 @@ class InteractiveInputRequiredError(CgtError):
             f"transactions via '-'). Add a '{symbol},<source>' row to "
             f"{spin_offs_file} (header 'dst,src') and rerun."
         )
+
+
+class MarketDataMissingError(CgtError):
+    """Raised when the market data provider has no data for a symbol and date."""
+
+    def __init__(self, symbol: str, date: datetime.date):
+        """Initialise."""
+        super().__init__(
+            f"No market data found for {symbol} around {date}. The ticker may "
+            "have been renamed or delisted; consider providing the price via "
+            "--initial-prices-file."
+        )

--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -195,6 +195,7 @@ class IsinConverter:
             writer.writerows([ISIN_TRANSLATION_HEADER, *data_rows])
 
     def _fetch_live(self, isin: str) -> set[str]:
+        LOGGER.info("Looking up ISIN %s via OpenFIGI...", isin)
         url = "https://api.openfigi.com/v3/mapping"
         headers = {"Content-type": "application/json"}
         data = [{"idType": "ID_ISIN", "idValue": isin}]

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -1641,6 +1641,7 @@ def main() -> int:
         # Last-resort catch for unexpected exceptions
         LOGGER.critical("Unexpected error!")
         LOGGER.exception("Details:")
+        return 1
 
     return 0
 

--- a/cgt_calc/spin_off_handler.py
+++ b/cgt_calc/spin_off_handler.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import csv
 import logging
+import sys
 from typing import TYPE_CHECKING, Final
 
-from .exceptions import ParsingError
+from .const import DEFAULT_SPIN_OFF_FILE
+from .exceptions import InteractiveInputRequiredError, ParsingError
 
 if TYPE_CHECKING:
     import datetime
@@ -62,13 +64,23 @@ class SpinOffHandler:
         if symbol in self.cache:
             return self.cache[symbol]
 
+        if not sys.stdin.isatty():
+            raise InteractiveInputRequiredError(
+                symbol, date, self.spin_offs_file or DEFAULT_SPIN_OFF_FILE
+            )
+
         while True:
             # This would ideally be fetched from some stock DB but yfinance does not
             # provide any info on SpinOffs
-            ticker = input(
-                "For a spin off, please enter the original ticker from which the new "
-                f"stock (symbol: {symbol}) was spinned off on {date}: "
-            )
+            try:
+                ticker = input(
+                    "For a spin off, please enter the original ticker from which the "
+                    f"new stock (symbol: {symbol}) was spinned off on {date}: "
+                )
+            except EOFError as err:
+                raise InteractiveInputRequiredError(
+                    symbol, date, self.spin_offs_file or DEFAULT_SPIN_OFF_FILE
+                ) from err
             if ticker in portfolio:
                 break
             LOGGER.error(

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable, Iterator
 import datetime
+import logging
 from pathlib import Path
 from typing import IO, TextIO, cast
 
@@ -507,3 +508,19 @@ def test_raw_file_stdin() -> None:
     parser = create_parser()
     args = parser.parse_args(["--raw-file", "-"])
     assert args.raw_file == STDIN_PATH
+
+
+def test_initial_prices_alias_warns_deprecated(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The hidden --initial-prices alias still works but warns."""
+    file_path = tmp_path / "prices.csv"
+    file_path.write_text("", encoding="utf-8")
+    parser = create_parser()
+
+    with caplog.at_level(logging.WARNING):
+        args = parser.parse_args(["--initial-prices", str(file_path)])
+
+    assert args.initial_prices_file == file_path
+    assert "Option '--initial-prices' is deprecated" in caplog.text
+    assert "--initial-prices-file" in caplog.text

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -17,7 +17,7 @@ from cgt_calc.current_price_fetcher import CurrentPriceFetcher
 from cgt_calc.exceptions import InvalidTransactionError
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
-from cgt_calc.main import CapitalGainsCalculator
+from cgt_calc.main import CapitalGainsCalculator, main
 from cgt_calc.model import ActionType, BrokerTransaction, RuleType
 from cgt_calc.parsers.eri.model import ERITransaction
 from cgt_calc.spin_off_handler import SpinOffHandler
@@ -28,6 +28,8 @@ from .calc_test_data import calc_basic_data
 from .calc_test_data_2 import calc_basic_data_2
 
 if TYPE_CHECKING:
+    import argparse
+
     from cgt_calc.model import CalculationLog, CapitalGainsReport
 
 
@@ -853,3 +855,17 @@ def test_run_with_example_files() -> None:
         "if you added new features update the test with:\n"
         f"{cmd_str} > {expected_file}"
     )
+
+
+def test_main_returns_failure_on_unexpected_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unexpected exception must produce a failure exit code."""
+
+    def explode(args: argparse.Namespace) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("cgt_calc.main.calculate_cgt", explode)
+    monkeypatch.setattr(sys, "argv", ["cgt-calc", "--year", "2021"])
+
+    assert main() == 1

--- a/tests/general/test_currency_converter.py
+++ b/tests/general/test_currency_converter.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import datetime
 from decimal import Decimal
+import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 import pytest
+from requests import exceptions as requests_exceptions
 
 from cgt_calc.currency_converter import CurrencyConverter
-from cgt_calc.exceptions import ParsingError
+from cgt_calc.exceptions import ExternalApiError, ParsingError
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -118,3 +120,24 @@ def test_read_exchange_rates_skips_comment_lines(tmp_path: Path) -> None:
     february = datetime.date(2024, 2, 1)
     assert cache[january] == {"USD": Decimal("1.25")}
     assert cache[february] == {"EUR": Decimal("1.10")}
+
+
+class OfflineSession:
+    """Session stub that fails every request."""
+
+    def get(self, url: str, timeout: int) -> NoReturn:
+        """Simulate a network failure."""
+        raise requests_exceptions.ConnectionError(f"offline: {url}")
+
+
+def test_hmrc_fetch_announces_itself(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fetching rates from HMRC logs a progress line before the request."""
+    converter = CurrencyConverter()
+    monkeypatch.setattr(converter, "session", OfflineSession())
+
+    with caplog.at_level(logging.INFO), pytest.raises(ExternalApiError):
+        converter.currency_to_gbp_rate("USD", datetime.date(2021, 5, 10))
+
+    assert "Fetching HMRC exchange rates for 2021-05..." in caplog.text

--- a/tests/general/test_current_price_fetcher.py
+++ b/tests/general/test_current_price_fetcher.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING
+
+import pandas as pd
+import pytest
 
 from cgt_calc.currency_converter import CurrencyConverter
 from cgt_calc.current_price_fetcher import CurrentPriceFetcher
-
-if TYPE_CHECKING:
-    import pytest
+from cgt_calc.exceptions import MarketDataMissingError
 
 
 class FakeTicker:
@@ -122,3 +122,23 @@ def test_defaults_to_usd_when_currency_field_absent(
     )
     price = _fetcher().get_current_market_price("AAPL")
     assert price == Decimal("100.0") / Decimal("1.25")
+
+
+class FakeEmptyHistoryTicker:
+    """Stand-in for yf.Ticker with no historical data."""
+
+    def history(self, **kwargs: str) -> pd.DataFrame:
+        """Return an empty price history."""
+        return pd.DataFrame()
+
+
+def test_raises_clear_error_when_no_market_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty price history raises an error naming the symbol and date."""
+    monkeypatch.setattr(
+        "cgt_calc.current_price_fetcher.yf.Ticker",
+        lambda symbol: FakeEmptyHistoryTicker(),
+    )
+    with pytest.raises(MarketDataMissingError, match=r"FOO.*2021-05-10"):
+        _fetcher().get_closing_price("FOO", datetime.date(2021, 5, 10))

--- a/tests/general/test_isin_converter.py
+++ b/tests/general/test_isin_converter.py
@@ -1,0 +1,42 @@
+"""Tests for IsinConverter network behaviour."""
+
+from __future__ import annotations
+
+import logging
+from typing import NoReturn
+
+import pytest
+from requests import exceptions as requests_exceptions
+
+from cgt_calc.exceptions import ExternalApiError
+from cgt_calc.isin_converter import IsinConverter
+
+# Deliberately not a real ISIN so it can't be in the bundled translation data.
+UNKNOWN_ISIN = "ZZ0000000000"
+
+
+class OfflineSession:
+    """Session stub that fails every request."""
+
+    def post(
+        self,
+        url: str,
+        json: list[dict[str, str]],
+        headers: dict[str, str],
+        timeout: int,
+    ) -> NoReturn:
+        """Simulate a network failure."""
+        raise requests_exceptions.ConnectionError(f"offline: {url}")
+
+
+def test_live_isin_lookup_announces_itself(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live OpenFIGI lookup logs a progress line before the request."""
+    converter = IsinConverter()
+    monkeypatch.setattr(converter, "session", OfflineSession())
+
+    with caplog.at_level(logging.INFO), pytest.raises(ExternalApiError):
+        converter.get_symbols(UNKNOWN_ISIN)
+
+    assert f"Looking up ISIN {UNKNOWN_ISIN} via OpenFIGI..." in caplog.text

--- a/tests/general/test_spin_off_handler.py
+++ b/tests/general/test_spin_off_handler.py
@@ -1,0 +1,76 @@
+"""Tests for SpinOffHandler."""
+
+from __future__ import annotations
+
+import datetime
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cgt_calc.const import DEFAULT_SPIN_OFF_FILE
+from cgt_calc.exceptions import InteractiveInputRequiredError
+from cgt_calc.spin_off_handler import SpinOffHandler
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SPIN_OFF_DATE = datetime.date(2021, 5, 10)
+
+
+def test_cached_source_needs_no_terminal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A spin-off already recorded in the file is returned without prompting."""
+    spin_offs_file = tmp_path / "spin_offs.csv"
+    spin_offs_file.write_text("dst,src\nNEW,OLD\n", encoding="utf8")
+    handler = SpinOffHandler(spin_offs_file)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+
+    assert handler.get_spin_off_source("NEW", SPIN_OFF_DATE, {}) == "OLD"
+
+
+def test_non_interactive_run_raises_clear_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without a terminal the prompt is replaced by an actionable error."""
+    spin_offs_file = tmp_path / "spin_offs.csv"
+    handler = SpinOffHandler(spin_offs_file)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+
+    with pytest.raises(InteractiveInputRequiredError) as excinfo:
+        handler.get_spin_off_source("NEW", SPIN_OFF_DATE, {})
+
+    message = str(excinfo.value)
+    assert "NEW" in message
+    assert str(spin_offs_file) in message
+    assert "dst,src" in message
+
+
+def test_error_names_default_file_when_none_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no spin-offs file configured the error points at the default path."""
+    handler = SpinOffHandler()
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+
+    with pytest.raises(InteractiveInputRequiredError) as excinfo:
+        handler.get_spin_off_source("NEW", SPIN_OFF_DATE, {})
+
+    assert str(DEFAULT_SPIN_OFF_FILE) in str(excinfo.value)
+
+
+def test_eof_during_prompt_raises_clear_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """EOF while reading the answer is reported like a missing terminal."""
+
+    def read_eof(prompt: str) -> str:
+        raise EOFError
+
+    handler = SpinOffHandler(tmp_path / "spin_offs.csv")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", read_eof)
+
+    with pytest.raises(InteractiveInputRequiredError):
+        handler.get_spin_off_source("NEW", SPIN_OFF_DATE, {})


### PR DESCRIPTION
- Return exit code 1 on unexpected errors (previously reported success to the shell)
- Replace the spin-off `input()` prompt with an actionable error when stdin is not a terminal (headless runs, `--raw-file -`)
- Raise a clear error naming symbol and date when yfinance has no price data (was a bare `IndexError`)
- Log progress lines before HMRC exchange-rate and OpenFIGI ISIN fetches
- Warn when the deprecated `--initial-prices` alias is used

No stdout changes; all new messaging is on stderr or error paths.
