### PR TITLE
Accept the new Freetrade CSV export header

### DIFF
--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -62,6 +62,17 @@ class FreetradeColumn(StrEnum):
 COLUMNS: Final[list[str]] = [column.value for column in FreetradeColumn]
 REQUIRED_COLUMNS: Final[set[str]] = set(COLUMNS)
 
+# Freetrade renamed these columns, older exports still use the names above.
+COLUMN_ALIASES: Final[dict[str, str]] = {
+    "Total Amount in Account Currency": FreetradeColumn.TOTAL_AMOUNT.value,
+    "Total Amount in Instrument Currency": FreetradeColumn.TOTAL_SHARES_AMOUNT.value,
+}
+
+# Newer exports add a block of stock split columns. They are tolerated so that
+# the header validates, their values are not read yet: a stock split row still
+# fails as an unknown type.
+STOCK_SPLIT_PREFIX: Final = "Stock Split "
+
 
 def _parse_decimal(row: dict[str, str], column: FreetradeColumn) -> Decimal:
     """Parse Decimal value for column, raising ValueError with context on failure."""
@@ -185,7 +196,7 @@ class FreetradeParser(BaseSingleFileParser):
         lines = list(csv.reader(file))
         if not lines:
             raise ParsingError(file_path, "Freetrade CSV file is empty")
-        header = lines[0]
+        header = [COLUMN_ALIASES.get(column, column) for column in lines[0]]
         cls._validate_header(header, file_path)
         lines = lines[1:]
         indexed_rows = list(enumerate(lines, start=2))
@@ -212,7 +223,11 @@ class FreetradeParser(BaseSingleFileParser):
             missing_columns = ", ".join(sorted(missing))
             raise ParsingError(file, f"Missing columns: {missing_columns}", row_index=1)
 
-        unknown = provided - REQUIRED_COLUMNS
+        unknown = {
+            column
+            for column in provided - REQUIRED_COLUMNS
+            if not column.startswith(STOCK_SPLIT_PREFIX)
+        }
         if unknown:
             unknown_columns = ", ".join(sorted(unknown))
             raise ParsingError(file, f"Unknown columns: {unknown_columns}", row_index=1)

--- a/tests/freetrade/test_freetrade.py
+++ b/tests/freetrade/test_freetrade.py
@@ -21,6 +21,55 @@ from cgt_calc.parsers.freetrade import (
 )
 from tests.utils import build_cmd, stderr_alerts
 
+# Header of a Freetrade export downloaded after the format change reported in
+# issue #800: two columns were renamed and the "Stock Split" ones are new.
+NEW_COLUMNS: list[str] = [
+    "Title",
+    "Type",
+    "Timestamp",
+    "Account Currency",
+    "Total Amount in Account Currency",
+    "Buy / Sell",
+    "Ticker",
+    "ISIN",
+    "Price per Share in Account Currency",
+    "Stamp Duty",
+    "Quantity",
+    "Venue",
+    "Order ID",
+    "Order Type",
+    "Instrument Currency",
+    "Total Amount in Instrument Currency",
+    "Price per Share",
+    "FX Rate",
+    "Base FX Rate",
+    "FX Fee (BPS)",
+    "FX Fee Amount",
+    "Dividend Ex Date",
+    "Dividend Pay Date",
+    "Dividend Eligible Quantity",
+    "Dividend Amount Per Share",
+    "Dividend Gross Distribution Amount",
+    "Dividend Net Distribution Amount",
+    "Dividend Withheld Tax Percentage",
+    "Dividend Withheld Tax Amount",
+    "Stock Split Ex Date",
+    "Stock Split Pay Date",
+    "Stock Split New ISIN",
+    "Stock Split Rate of Share Outturn From",
+    "Stock Split Rate of Share Outturn To",
+    "Stock Split Maintain Holding of Initial ISIN",
+    "Stock Split New Share Quantity",
+    "Stock Split Rate of Cash Outturn Amount",
+    "Stock Split Rate of Cash Outturn Currency",
+    "Stock Split Cash Outturn Received Amount",
+    "Stock Split Has Fractional Payout",
+    "Stock Split Rate of Fractional Payout Amount",
+    "Stock Split Rate of Fractional Payout Currency",
+    "Stock Split Fractional Payout Cash Received Amount",
+    "Stock Split Fractional Payout Cash Received Currency",
+]
+
 BASE_ROW_VALUES = {
     FreetradeColumn.TITLE.value: "Buy Apple",
     FreetradeColumn.TYPE.value: "ORDER",
@@ -53,6 +102,13 @@ BASE_ROW_VALUES = {
     FreetradeColumn.DIVIDEND_WITHHELD_AMOUNT.value: "0",
 }
 
+# The two columns Freetrade renamed, spelled out rather than read back from the
+# parser so that a wrong mapping there fails these tests.
+RENAMED_COLUMNS: dict[str, str] = {
+    FreetradeColumn.TOTAL_AMOUNT.value: "Total Amount in Account Currency",
+    FreetradeColumn.TOTAL_SHARES_AMOUNT.value: "Total Amount in Instrument Currency",
+}
+
 
 def _default_row(overrides: dict[str, str] | None = None) -> list[str]:
     """Return default row data with optional overrides."""
@@ -60,6 +116,17 @@ def _default_row(overrides: dict[str, str] | None = None) -> list[str]:
     if overrides:
         values.update(overrides)
     return [values[column] for column in COLUMNS]
+
+
+def _default_new_row(overrides: dict[str, str] | None = None) -> list[str]:
+    """Return default row data laid out for the new header."""
+    values = {
+        RENAMED_COLUMNS.get(column, column): value
+        for column, value in BASE_ROW_VALUES.items()
+    }
+    if overrides:
+        values.update(overrides)
+    return [values.get(column, "") for column in NEW_COLUMNS]
 
 
 def _write_csv(
@@ -168,6 +235,48 @@ def test_read_freetrade_transactions_success(tmp_path: Path) -> None:
     assert transaction.price == Decimal(100)
     assert transaction.amount == Decimal(-100)
     assert transaction.currency == "GBP"
+
+
+def test_read_freetrade_transactions_new_header_success(tmp_path: Path) -> None:
+    """Renamed and added columns of the newer export parse like the old ones."""
+    path = _write_csv(tmp_path, NEW_COLUMNS, [_default_new_row()])
+
+    transactions = FreetradeParser().load_from_file(path)
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert transaction.action is ActionType.BUY
+    assert transaction.symbol == "AAPL"
+    assert transaction.quantity == Decimal(1)
+    assert transaction.price == Decimal(100)
+    assert transaction.amount == Decimal(-100)
+    assert transaction.currency == "GBP"
+
+
+def test_read_freetrade_transactions_new_header_top_up(tmp_path: Path) -> None:
+    """The renamed account currency amount is read from its new column."""
+    overrides = {
+        FreetradeColumn.TYPE.value: "TOP_UP",
+        FreetradeColumn.TICKER.value: "",
+        RENAMED_COLUMNS[FreetradeColumn.TOTAL_AMOUNT.value]: "150",
+    }
+    path = _write_csv(tmp_path, NEW_COLUMNS, [_default_new_row(overrides)])
+
+    transactions = FreetradeParser().load_from_file(path)
+
+    assert len(transactions) == 1
+    assert transactions[0].action is ActionType.TRANSFER
+    assert transactions[0].amount == Decimal(150)
+
+
+def test_read_freetrade_transactions_new_header_missing_column(tmp_path: Path) -> None:
+    """A renamed column still counts as missing when the export drops it."""
+    dropped = RENAMED_COLUMNS[FreetradeColumn.TOTAL_SHARES_AMOUNT.value]
+    header = [column for column in NEW_COLUMNS if column != dropped]
+    path = _write_csv(tmp_path, header)
+
+    with pytest.raises(ParsingError, match="Missing columns: Total Shares Amount"):
+        FreetradeParser().load_from_file(path)
 
 
 def test_freetrade_transaction_unsupported_action(


### PR DESCRIPTION
Fixes #800.

Freetrade renamed two columns and added a block of `Stock Split *` ones, so any export downloaded today dies in `_validate_header` with `Missing columns: Total Amount, Total Shares Amount`:

- `Total Amount` -> `Total Amount in Account Currency`
- `Total Shares Amount` -> `Total Amount in Instrument Currency`

Both are aliased back onto the names the parser already uses while the header is read, so `FreetradeTransaction` is untouched and old exports keep parsing exactly as before. The new tests use the header pasted in the issue verbatim.

Two judgement calls, happy to flip either:

- The `Stock Split *` columns are tolerated by prefix, not by listing all 15 names. The parser reads none of them, and an explicit list means the next column Freetrade adds reopens this issue. The cost is that a genuinely new split column won't be flagged.
- A missing column is still reported under its canonical name: an export lacking `Total Amount in Instrument Currency` reports `Missing columns: Total Shares Amount`. There's a test pinning that. Say the word if you'd rather it echoed the name the user sees in their file.

Out of scope: stock split rows themselves. A `STOCK_SPLIT` row still fails with `Unknown type: 'STOCK_SPLIT'`, and since parsing isn't year-filtered, one historical split anywhere in the file still blocks a run. Mapping Freetrade's split fields onto `ActionType.STOCK_SPLIT` (which wants the *additional* share count, while Freetrade gives "New Share Quantity" plus outturn rates) deserves its own PR rather than a guess that silently skews the multiplier. Happy to file a follow-up issue.

Checks: `uv run pytest` 282 passed, plus ruff, mypy and pylint (10/10).

Disclosure: written with AI assistance (Claude). The failure was reproduced against the header from #800 before anything was changed, and the new tests were confirmed to fail on the unfixed parser.