### PR TITLE
Log decimal quantities and amounts with %s instead of %d

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -802,7 +802,7 @@ class CapitalGainsCalculator:
                 new_amount = amount * spin_off.cost_proportion
                 LOGGER.debug(
                     "Detected spin-off of %s to %s on %s, modyfing the cost amount "
-                    "from %d to %d according to cost-proportion: %.2f",
+                    "from %s to %s according to cost-proportion: %.2f",
                     spin_off.source,
                     spin_off.dest,
                     spin_off.date,
@@ -851,7 +851,7 @@ class CapitalGainsCalculator:
                 same_day_gain = same_day_proceeds - same_day_allowable_cost
                 chargeable_gain += same_day_gain
                 LOGGER.debug(
-                    "SAME DAY, quantity %d, gain %s, disposal price %s, "
+                    "SAME DAY, quantity %s, gain %s, disposal price %s, "
                     "acquisition price %s",
                     available_quantity,
                     same_day_gain,
@@ -1009,7 +1009,7 @@ class CapitalGainsCalculator:
                     )
                     chargeable_gain += bed_and_breakfast_gain
                     LOGGER.debug(
-                        "BED & BREAKFAST, quantity %d, gain %s, disposal price %s, "
+                        "BED & BREAKFAST, quantity %s, gain %s, disposal price %s, "
                         "acquisition price %s%s",
                         available_quantity,
                         bed_and_breakfast_gain,
@@ -1074,7 +1074,7 @@ class CapitalGainsCalculator:
             r104_gain = r104_proceeds - r104_allowable_cost
             chargeable_gain += r104_gain
             LOGGER.debug(
-                "SECTION 104, quantity %d, gain %s, proceeds amount %s, "
+                "SECTION 104, quantity %s, gain %s, proceeds amount %s, "
                 "allowable cost %s",
                 available_quantity,
                 r104_gain,
@@ -1153,7 +1153,7 @@ class CapitalGainsCalculator:
         new_amount = amount + allowable_cost
         LOGGER.debug(
             "Detected excess reported income of %s on %s, "
-            "modyfing the cost amount from %d to %d",
+            "modyfing the cost amount from %s to %s",
             eri.symbol,
             eri.date,
             amount,
@@ -1421,7 +1421,7 @@ class CapitalGainsCalculator:
                             symbol
                         ].quantity
                         LOGGER.debug(
-                            "DISPOSAL on %s of %s, quantity %d, capital gain $%s",
+                            "DISPOSAL on %s of %s, quantity %s, capital gain $%s",
                             date_index,
                             symbol,
                             transaction_quantity,

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 from decimal import Decimal, localcontext
+import logging
 from pathlib import Path
 import subprocess
 import sys
@@ -886,6 +887,50 @@ def test_same_day_sale_funding_purchase_survives_sort() -> None:
         sorted(transactions, key=_transaction_sort_key),
     )
     assert report.total_gain() == Decimal(50)  # 5 * (20 - 10)
+
+
+def test_disposal_debug_log_keeps_fractional_quantity(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fractional share quantities must not be truncated in debug logs.
+
+    Quantities were formatted with ``%d``, which truncates a ``Decimal`` to an
+    integer (e.g. 2.5 -> 2). They must use ``%s`` so partial shares are logged
+    in full.
+    """
+    buy_day = datetime.date(2024, 6, 1)
+    sell_day = datetime.date(2024, 6, 10)
+    transactions = [
+        transaction(
+            buy_day,
+            ActionType.BUY,
+            "SYM",
+            quantity=5,
+            price=10,
+            amount=-50,
+            currency="GBP",
+        ),
+        transaction(
+            sell_day,
+            ActionType.SELL,
+            "SYM",
+            quantity=2.5,
+            price=20,
+            amount=50,
+            currency="GBP",
+        ),
+    ]
+
+    with caplog.at_level(logging.DEBUG, logger="cgt_calc.main"):
+        get_report(create_calculator(), transactions)
+
+    disposal_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("DISPOSAL on")
+    ]
+    assert disposal_logs
+    assert all("quantity 2.5" in message for message in disposal_logs)
 
 
 def test_run_with_example_files() -> None:


### PR DESCRIPTION
Several debug log statements format `Decimal` share quantities and pool cost amounts with `%d`, which truncates to an integer — e.g. a disposal of 2.5 shares logs as `quantity 2`. Switch them to `%s` so fractional shares and exact amounts are logged in full, matching the other `Decimal` fields already formatted with `%s` on the same lines.

DEBUG-level only — no change to reported figures. Adds a regression test covering a fractional disposal quantity.