### PR TITLE
Enable ruff flake8-unused-arguments (ARG) rule

### DIFF
--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -120,7 +120,7 @@ class DeprecatedAction(argparse.Action):
 
     def __call__(  # type: ignore[explicit-any]
         self,
-        parser: argparse.ArgumentParser,
+        _parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
         values: str | Sequence[Any] | None,
         option_string: str | None = None,

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -139,7 +139,7 @@ class StandardCSVParser(BaseSingleFileParser):
         """Read a single transaction from a row in the CSV."""
 
     @classmethod
-    def pre_reading(cls, file: TextIO, file_path: Path) -> Iterable[str]:
+    def pre_reading(cls, file: TextIO, file_path: Path) -> Iterable[str]:  # noqa: ARG003
         """Do any preprocessing of the file before parsing the csv."""
         return file
 
@@ -248,7 +248,7 @@ class BaseDirParser(BaseSingleFileParser):
         return cls.post_process_transactions(transactions)
 
     @classmethod
-    def file_path_filter(cls, file_path: Path) -> bool:
+    def file_path_filter(cls, file_path: Path) -> bool:  # noqa: ARG003
         """Choose which files to parse."""
         return True
 

--- a/cgt_calc/parsers/eri/importer/invesco.py
+++ b/cgt_calc/parsers/eri/importer/invesco.py
@@ -97,7 +97,9 @@ class InvescoImporter(ERIImporter):
 
     @staticmethod
     def _extract_data_rows(
-        page_num: int, cropped: pdfplumber.page.CroppedPage, columns: list[float]
+        page_num: int,  # noqa: ARG004  # kept for the debug line below
+        cropped: pdfplumber.page.CroppedPage,
+        columns: list[float],
     ) -> list[list[str | None]]:
         table_settings = {
             "vertical_strategy": "explicit",

--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -65,7 +65,7 @@ class HargreavesLansdownParser(StandardCSVParser, BaseDirParser):
     }
 
     @staticmethod
-    def _determine_action_type(reference: str, description: str) -> ActionType | None:
+    def _determine_action_type(reference: str) -> ActionType | None:
         """Map Hargreaves Lansdown CSV reference codes to cgt-calc ActionTypes."""
         ref = reference.strip().upper()
 
@@ -146,7 +146,7 @@ class HargreavesLansdownParser(StandardCSVParser, BaseDirParser):
             return None
 
         description = row.get("Description", "")
-        action_type = cls._determine_action_type(reference, description)
+        action_type = cls._determine_action_type(reference)
         if not action_type:
             raise ParsingError(
                 file_path,

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -108,7 +108,7 @@ def _parse_decimal(value: str, context: str) -> Decimal:
 
 
 def _parse_details(
-    details: str, action: ActionType, amount: Decimal, file: Path
+    details: str, action: ActionType, amount: Decimal
 ) -> tuple[str | None, Decimal | None, Decimal | None, str]:
     """Extract symbol, quantity, price, currency from a Details string."""
     currency = "GBP"
@@ -188,7 +188,7 @@ class VanguardTransaction(BrokerTransaction):
         self.action = action_from_str(self.details_text, file)
         self.amount = _parse_decimal(row[CashColumn.AMOUNT], CashColumn.AMOUNT.value)
         self.symbol, self.quantity, self.price, self.currency = _parse_details(
-            self.details_text, self.action, self.amount, self.source_file
+            self.details_text, self.action, self.amount
         )
 
         super().__init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,6 +356,7 @@ target-version = "py312"
 [tool.ruff.lint]
 select = [
   "A", # flake8-builtins
+  "ARG", # flake8-unused-arguments
   "ASYNC", # flake8-async
   "B", # flake8-bugbear
   "BLE",
@@ -445,7 +446,9 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["PLR2004"]
+# Test doubles intentionally mirror external library signatures (requests,
+# yfinance, ...), so unused arguments there are expected, not bugs.
+"tests/**" = ["PLR2004", "ARG"]
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true


### PR DESCRIPTION
`pylint`'s `unused-argument` is disabled on the assumption ruff's `ARG` rule covers it, but `ARG` was never in the ruff `select` list — so unused arguments went unchecked entirely (e.g. the `page_num` slip in #854).

Enable `ARG` and fix the 6 surfaced production cases:
- Remove dead `description` / `file` params (HL, Vanguard parsers)
- `_`-prefix the argparse `Action.__call__` override arg
- `# noqa` the intentional interface args (`pre_reading`, `file_path_filter`) and the debug-only `page_num`

Ignore `ARG` in `tests/` — doubles there intentionally mirror external signatures (`requests`, `yfinance`), and several receive their args by keyword, so renaming would break them at runtime.
