### PR TITLE
Enable ruff pandas-vet (PD) and flake8-boolean-trap (FBT) rules

### DIFF
--- a/cgt_calc/logging.py
+++ b/cgt_calc/logging.py
@@ -102,7 +102,7 @@ class ColourMessageFormatter(logging.Formatter):
         logging.ERROR: "❌",
     }
 
-    def __init__(self, fmt: str, use_colour: bool, use_emoji: bool) -> None:
+    def __init__(self, fmt: str, *, use_colour: bool, use_emoji: bool) -> None:
         """Initialise the formatter."""
         super().__init__(fmt)
         self.use_colour = use_colour
@@ -188,7 +188,9 @@ def setup_logging() -> None:
     handler = logging.StreamHandler(stream)
     handler.setFormatter(
         ColourMessageFormatter(
-            fmt, get_ui().supports_colour(stream), get_ui().supports_emoji(stream)
+            fmt,
+            use_colour=get_ui().supports_colour(stream),
+            use_emoji=get_ui().supports_emoji(stream),
         )
     )
 

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -159,6 +159,7 @@ class CapitalGainsCalculator:
         spin_off_handler: SpinOffHandler,
         initial_prices: InitialPrices,
         interest_fund_tickers: list[str],
+        *,
         balance_check: bool = True,
         calc_unrealized_gains: bool = False,
     ):

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -413,7 +413,7 @@ class CapitalGainsReport:
         assert self.capital_gain_allowance is not None
         return max(Decimal(0), self.total_gain() - self.capital_gain_allowance)
 
-    def total_eri_amount(self, is_interest: bool) -> Decimal:
+    def total_eri_amount(self, *, is_interest: bool) -> Decimal:
         """Total dividends amount just from ERI."""
         total = Decimal(0)
         for item in self._filter_calculation_log(

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -83,7 +83,11 @@ class BaseSingleFileParser(BaseParser):
 
     @classmethod
     def load_from_file(
-        cls, file_path: Path, warn_on_empty: bool = True, show_parsing_msg: bool = True
+        cls,
+        file_path: Path,
+        *,
+        warn_on_empty: bool = True,
+        show_parsing_msg: bool = True,
     ) -> list[BrokerTransaction]:
         """Load broker data from file path."""
         if file_path == STDIN_PATH:

--- a/cgt_calc/parsers/eri/importer/blackrock.py
+++ b/cgt_calc/parsers/eri/importer/blackrock.py
@@ -67,23 +67,23 @@ class BlackrockImporter(ERIImporter):
         header_loc = df[df == "ISIN"].dropna(axis=1, how="all").dropna(how="all")
 
         # first row is the header row
-        if "ISIN" in df.columns.values:
+        if "ISIN" in df.columns:
             max_allowed_isin_columns = 1
             skiprows = 0
         else:
-            if len(header_loc.index.values) == 0:
+            if len(header_loc.index) == 0:
                 raise ParsingError(file, "No ISIN column found!")
             max_allowed_isin_columns = 2
             # skip to the header row
-            skiprows = header_loc.index.values[0] + 1
+            skiprows = header_loc.index[0] + 1
 
-        if len(header_loc.index.values) > max_allowed_isin_columns:
+        if len(header_loc.index) > max_allowed_isin_columns:
             raise ParsingError(file, "Too many ISIN columns found!")
 
         nrows = None
-        if len(header_loc.index.values) == max_allowed_isin_columns:
+        if len(header_loc.index) == max_allowed_isin_columns:
             # filter out final table
-            nrows = header_loc.index.values[max_allowed_isin_columns - 1] - skiprows
+            nrows = header_loc.index[max_allowed_isin_columns - 1] - skiprows
 
         df = pd.read_excel(file, sheet, skiprows=skiprows, nrows=nrows)
         df.columns = df.columns.str.strip()
@@ -95,16 +95,16 @@ class BlackrockImporter(ERIImporter):
         if not len(cleaned_df.columns) == len(COLUMNS):
             raise ParsingError(
                 file,
-                f"Cannot process ERI columns {cleaned_df.columns.values}, "
-                f"all columns {df.columns.values}",
+                f"Cannot process ERI columns {cleaned_df.columns.tolist()}, "
+                f"all columns {df.columns.tolist()}",
             )
 
         # Clean up all the column names
-        for raw_column_name in cleaned_df.columns.values:
+        for raw_column_name in cleaned_df.columns:
             for column_name in COLUMNS:
                 if column_name in raw_column_name:
-                    cleaned_df.rename(
-                        columns={raw_column_name: column_name}, inplace=True
+                    cleaned_df = cleaned_df.rename(
+                        columns={raw_column_name: column_name}
                     )
 
         for _, row in cleaned_df.iterrows():

--- a/cgt_calc/parsers/eri/importer/vanguard.py
+++ b/cgt_calc/parsers/eri/importer/vanguard.py
@@ -63,23 +63,23 @@ class VanguardImporter(ERIImporter):
         header_loc = mask[mask].dropna(axis=1, how="all").dropna(how="all")
 
         # first row is the header row
-        if "ISIN" in df.columns.values:
+        if "ISIN" in df.columns:
             max_allowed_isin_columns = 1
             skiprows = 0
         else:
-            if len(header_loc.index.values) == 0:
+            if len(header_loc.index) == 0:
                 raise ParsingError(file, "No ISIN column found!")
             max_allowed_isin_columns = 2
             # skip to the header row
-            skiprows = header_loc.index.values[0] + 1
+            skiprows = header_loc.index[0] + 1
 
-        if len(header_loc.index.values) > max_allowed_isin_columns:
+        if len(header_loc.index) > max_allowed_isin_columns:
             raise ParsingError(file, "Too many ISIN columns found!")
 
         nrows = None
-        if len(header_loc.index.values) == max_allowed_isin_columns:
+        if len(header_loc.index) == max_allowed_isin_columns:
             # filter out final table
-            nrows = header_loc.index.values[max_allowed_isin_columns - 1] - skiprows
+            nrows = header_loc.index[max_allowed_isin_columns - 1] - skiprows
 
         df = pd.read_excel(file, sheet, skiprows=skiprows, nrows=nrows)
         df.columns = df.columns.str.strip()
@@ -91,16 +91,16 @@ class VanguardImporter(ERIImporter):
         if not len(cleaned_df.columns) == len(COLUMNS):
             raise ParsingError(
                 file,
-                f"Cannot process ERI columns {cleaned_df.columns.values}, "
-                f"all columns {df.columns.values}",
+                f"Cannot process ERI columns {cleaned_df.columns.tolist()}, "
+                f"all columns {df.columns.tolist()}",
             )
 
         # Clean up all the column names
-        for raw_column_name in cleaned_df.columns.values:
+        for raw_column_name in cleaned_df.columns:
             for column_name in COLUMNS:
                 if column_name in raw_column_name:
-                    cleaned_df.rename(
-                        columns={raw_column_name: column_name}, inplace=True
+                    cleaned_df = cleaned_df.rename(
+                        columns={raw_column_name: column_name}
                     )
 
         for _, row in cleaned_df.iterrows():

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -228,6 +228,7 @@ class VanguardTransaction(BrokerTransaction):
         price: Decimal | None,
         amount: Decimal | None,
         currency: str,
+        *,
         is_reversal: bool,
         description: str = "",
     ) -> VanguardTransaction:

--- a/cgt_calc/render_latex.py
+++ b/cgt_calc/render_latex.py
@@ -23,6 +23,7 @@ LOGGER = logging.getLogger(__name__)
 def render_pdf(
     report: CapitalGainsReport,
     output_path: Path,
+    *,
     skip_pdflatex: bool = False,
 ) -> None:
     """Render LaTeX to a PDF report."""

--- a/cgt_calc/resources/template.tex.j2
+++ b/cgt_calc/resources/template.tex.j2
@@ -242,16 +242,16 @@
 \subsection*{Number of interest tax transactions: \VAR{ interest_tax_count.value }}
 \subsection*{Number of excess reported income distributions: \VAR{ eri_count.value }}
 \subsection*{Total amount of dividends proceeds: £\VAR{ "{:,}".format(round_decimal(report.total_dividends_amount(), 2)) }}
-\BLOCK{ if report.total_eri_amount(False) > 0 }
-\subsubsection*{   (including £\VAR{ "{:,}".format(round_decimal(report.total_eri_amount(False), 2))} from excess reported income distributions)}
+\BLOCK{ if report.total_eri_amount(is_interest=False) > 0 }
+\subsubsection*{   (including £\VAR{ "{:,}".format(round_decimal(report.total_eri_amount(is_interest=False), 2))} from excess reported income distributions)}
 \BLOCK{ endif }
 \subsection*{Total amount of dividends tax allowance due to double taxation treaties: £\VAR{ "{:,}".format(round_decimal(report.total_dividend_taxes_in_tax_treaties_amount(), 2)) }}
 \subsection*{Total amount of dividends tax yearly allowance: £\VAR{ "{:,}".format(round_decimal(report.dividend_allowance or Decimal(), 2)) }}
 \subsection*{Total amount of taxable dividends proceeds: £\VAR{ "{:,}".format(round_decimal(report.total_dividend_taxable_gain(), 2)) }}
 \subsection*{Total amount of UK interests proceeds: £\VAR{ "{:,}".format(report.total_uk_interest) }}
 \subsection*{Total amount of foreign interests proceeds: £\VAR{ "{:,}".format(report.total_foreign_interest) }}
-\BLOCK{ if report.total_eri_amount(True) > 0 }
-\subsubsection*{   (including £\VAR{ "{:,}".format(round_decimal(report.total_eri_amount(True), 2))} from excess reported income distributions)}
+\BLOCK{ if report.total_eri_amount(is_interest=True) > 0 }
+\subsubsection*{   (including £\VAR{ "{:,}".format(round_decimal(report.total_eri_amount(is_interest=True), 2))} from excess reported income distributions)}
 \BLOCK{ endif }
 \subsection*{Total amount of interest tax paid: £\VAR{ "{:,}".format(report.total_interest_tax) }}
 \end{document}

--- a/cgt_calc/util.py
+++ b/cgt_calc/util.py
@@ -86,7 +86,7 @@ def approx_equal(
     return abs(val_a - val_b) < approx_quantity
 
 
-def open_with_parents(path: Path, clear_content: bool = True) -> TextIO:
+def open_with_parents(path: Path, *, clear_content: bool = True) -> TextIO:
     """Open a file for writing, creating parent directories if they do not exist."""
     path.parent.mkdir(parents=True, exist_ok=True)
     return path.open("w" if clear_content else "r+", encoding="utf8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -367,6 +367,7 @@ select = [
   "DTZ004", # Use datetime.fromtimestamp(ts, tz=) instead of datetime.utcfromtimestamp(ts)
   "E", # pycodestyle
   "F", # pyflakes
+  "FBT", # flake8-boolean-trap
   "FLY", # flynt
   "FURB", # refurb
   "G", # flake8-logging-format
@@ -448,8 +449,9 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 # Test doubles intentionally mirror external library signatures (requests,
-# yfinance, ...), so unused arguments there are expected, not bugs.
-"tests/**" = ["PLR2004", "ARG"]
+# yfinance, ...), so unused arguments there are expected, not bugs. Likewise,
+# pytest parametrized cases routinely take boolean `expected` values (FBT).
+"tests/**" = ["PLR2004", "ARG", "FBT"]
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -376,6 +376,7 @@ select = [
   "ICN", # flake8-import-conventions
   "LOG", # flake8-logging
   "N", # pep8-naming
+  "PD", # pandas-vet
   "PERF", # Perflint
   "PGH", # pygrep-hooks
   "PIE", # flake8-pie


### PR DESCRIPTION
Enable two more ruff rule sets and fix the findings. Two commits, one per rule.

### `PD` (pandas-vet) — 12 findings in the ERI importers

- **PD011**: drop `.values` in favour of the `Index` directly (`"ISIN" in df.columns`, `len(header_loc.index)`, `header_loc.index[0]`), and `.tolist()` for the two column lists shown in a `ParsingError` — which also reads far cleaner than the pandas 3.0 `StringArray` repr.
- **PD002**: replace `rename(..., inplace=True)` with reassignment.

The ERI importers have no pytest coverage; the rewrites were verified equivalent to the originals with a standalone pandas script.

### `FBT` (flake8-boolean-trap) — 16 findings

Boolean parameters made keyword-only, so callers must name them (e.g. `load_from_file(path, show_parsing_msg=False)`). Two call sites updated to match: the `ColourMessageFormatter` instantiation and the `total_eri_amount()` calls in the LaTeX template.

Ignored under `tests/` (alongside `ARG`/`PLR2004`): pytest parametrized cases routinely pass boolean `expected` values, which are test parameters rather than boolean-trap APIs.
