### PR TITLE
Test against Python 3.13 and 3.14 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,37 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Run prek on all files
+        env:
+          SKIP: pytest
         run: |
           uvx prek run --all-files --show-diff-on-failure --color=always
 
       - name: Run python-typing-update
         run: |
           uvx prek run --hook-stage manual python-typing-update --all-files --show-diff-on-failure --color=always
+
+  tests:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7
+
+      - name: Prepare and install deps
+        uses: ./.github/actions/install-deps
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run pytest
+        env:
+          CGT_TEST_MODE_STRICT: "1"
+        run: uv run pytest -q
 
   markdown-link-check:
     name: Markdown link check

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Here's what a generated PDF report looks like:
 
 ## 🔧 Prerequisites
 
-- **Python 3.12** or newer
+- **Python 3.12** or newer (tested on 3.12, 3.13, and 3.14)
 - **pdflatex** must be available in your `PATH` to generate PDF reports (with `--no-pdflatex` the
   LaTeX source is saved instead)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Office/Business :: Financial",
   "Typing :: Typed",
 ]


### PR DESCRIPTION
The project declares `requires-python = ">=3.12"` but only **tested and advertised 3.12** — 3.13 and 3.14 were unverified, even though they're what current systems ship (Debian 13, Fedora, Ubuntu 26.04 LTS, macOS Homebrew, Windows).

- Add a `tests` job with a matrix over **3.12, 3.13, 3.14** (`fail-fast: false`, interpreter pinned via `UV_PYTHON`). The full suite passes on all three.
- Skip the `pytest` hook in the `pre-commit` job (`SKIP=pytest`) so tests run in the new matrix job instead of redundantly; the `pre-commit` job keeps the lint/format/type hooks. (`docker-build` still runs pytest in the shipped image with real `pdflatex`.)
- Add trove classifiers for 3.13 and 3.14, and note the tested range in the README.

The **floor stays at 3.12** — raising it would only drop still-supported 3.12 systems (Ubuntu 24.04 LTS, RHEL/Rocky 10) for no benefit. It's also enforced regardless: the code uses PEP 695 generics (3.12-only syntax) and `numpy>=3.12`. The mypy/ruff/pylint targets stay at 3.12 too, since they should track the minimum supported version.

No dependency blocks this — pandas 3.0.x and numpy 2.5.x explicitly support 3.14, and nothing in the tree requires above 3.12.
