### PR TITLE
Use dedicated release-drafter autolabeler sub-action

### DIFF
--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-drafter autolabeler
-        uses: release-drafter/release-drafter@v7.7.0
+        uses: release-drafter/release-drafter/autolabeler@v7.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The autolabel workflow ran the full `release-drafter/release-drafter` action, which always tries to draft/update a release and so needs `contents: write`. With the least-privilege `contents: read` token (added when the workflow was split), it fails on every PR with `Resource not accessible by integration` when creating the draft release — e.g. [#881's Autolabeler run](https://github.com/KapJI/capital-gains-calculator/actions/runs/32193961135/job/95894047833).

Switch to the dedicated `release-drafter/release-drafter/autolabeler` sub-action, which only applies labels and works with `pull-requests: write` alone.