### PR TITLE
Include Python version in uv cache key

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -12,10 +12,12 @@ runs:
       uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
-
-    - name: Set up Python ${{ inputs.python-version }}
-      shell: bash
-      run: uv python install ${{ inputs.python-version }}
+        # Also makes the cache key include this version. Without it
+        # setup-uv falls back to the system Python version, so all
+        # matrix jobs computed an identical key: they raced to save it
+        # ("Unable to reserve cache" warnings) and restored caches
+        # built for a different interpreter.
+        python-version: ${{ inputs.python-version }}
 
     - name: Install dependencies with uv
       shell: bash


### PR DESCRIPTION
Pass the job's Python version to `setup-uv`. This sets `UV_PYTHON` for the rest of the job and, importantly, includes the version in the cache key: without it `setup-uv` falls back to the system Python version (3.12.3 on ubuntu-24.04), so all matrix jobs computed an identical key — they raced to save the same cache ("Failed to save: Unable to reserve cache" warnings) and restored caches built for a different interpreter.