### PR TITLE
Add explicit permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.12"
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     name: Triage

--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   labeler:
     name: Update labels


### PR DESCRIPTION
Fixes the six CodeQL `actions/missing-workflow-permissions` alerts: CI gets a workflow-level `contents: read` (the coverage job keeps its own block), the PR labeler gets `pull-requests: write`, and the label manager gets `issues: write`, each with `contents: read`.