### PR TITLE
Bump codecov-action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Runs from this repository authenticate with the token.
         # Pull requests from forks can't read secrets and fall back
         # to tokenless uploads, supported for public repositories.
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
v5 pins `actions/github-script` v7.0.1 (Node 20), which triggers deprecation warnings on every Coverage run. v7 bumps it to v8 (Node 24) and keeps the same inputs (`files`, `token`, `fail_ci_if_error`).