### PR TITLE
Include job name in uv cache key

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -12,12 +12,10 @@ runs:
       uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
-        # Also makes the cache key include this version. Without it
-        # setup-uv falls back to the system Python version, so all
-        # matrix jobs computed an identical key: they raced to save it
-        # ("Unable to reserve cache" warnings) and restored caches
-        # built for a different interpreter.
         python-version: ${{ inputs.python-version }}
+        # Different jobs on the same Python version still compute the
+        # same key and race to save it, so add the job name too.
+        cache-suffix: ${{ github.job }}
 
     - name: Install dependencies with uv
       shell: bash


### PR DESCRIPTION
Follow-up to #891: jobs running on the same Python version (Pre-commit, Coverage, Tests 3.12, Markdown link check) still compute an identical cache key and race to save it. Add `cache-suffix: ${{ github.job }}` so every job gets its own cache.