### PR TITLE
Collect coverage and test results in all test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,40 +61,31 @@ jobs:
       - name: Run pytest
         env:
           CGT_TEST_MODE_STRICT: "1"
-        run: uv run pytest -q
-
-  coverage:
-    name: Coverage
-    if: github.repository_owner == 'KapJI'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Prepare and install deps
-        uses: ./.github/actions/install-deps
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Run pytest with coverage
-        env:
-          CGT_TEST_MODE_STRICT: "1"
-        run: uv run pytest -q --cov --cov-report=xml
+        run: uv run pytest -q --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage to Codecov
-        # Runs from this repository authenticate with the token.
-        # Pull requests from forks can't read secrets and fall back
-        # to tokenless uploads, supported for public repositories.
+        # Codecov merges the reports from all matrix jobs. Runs from
+        # this repository authenticate with the token. Pull requests
+        # from forks can't read secrets and fall back to tokenless
+        # uploads, supported for public repositories.
         uses: codecov/codecov-action@v7
         with:
           files: coverage.xml
+          flags: python-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
           # Don't fail CI on upload issues: merge protection comes
           # from the codecov/project status check, not this step.
+          fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        # Upload also when tests fail: failed tests are the point.
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v7
+        with:
+          report_type: test_results
+          files: junit.xml
+          flags: python-${{ matrix.python-version }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   markdown-link-check:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .coverage
 .coverage.*
 coverage.xml
+junit.xml
 .DS_Store
 .mypy_cache/
 .pytest_cache/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,12 @@
+codecov:
+  notify:
+    # Wait for all matrix jobs before setting statuses,
+    # so they aren't computed from partial coverage.
+    after_n_builds: 3
+
+comment:
+  after_n_builds: 3
+
 coverage:
   status:
     project:


### PR DESCRIPTION
Run pytest with coverage and JUnit output in every matrix job and upload both to Codecov with `python-3.x` flags:

- Codecov merges reports server-side: coverage becomes the union across Python versions, and the dedicated Coverage job (a duplicate 3.12 test run) is removed.
- Test analytics reports failed tests as a PR comment with stack traces, attributed per Python version, and detects flaky tests over time.
- `after_n_builds: 3` makes statuses and the PR comment wait for all three uploads instead of reacting to partial coverage.