### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest release and the `main` branch.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Use
+[GitHub private vulnerability reporting](https://github.com/KapJI/capital-gains-calculator/security/advisories/new)
+instead. You will get a response as soon as possible, and you'll be kept informed of the progress
+towards a fix and disclosure.


### PR DESCRIPTION
Private vulnerability reporting is already enabled for the repository; a SECURITY.md makes it discoverable — GitHub links it from the Security tab and new-issue flow, steering vulnerability reports away from public issues. Also completes the community profile checklist.