### PR TITLE
Track GHCR publishes as deployments

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -146,6 +146,9 @@ jobs:
       - build-amd64
       - build-arm64
     runs-on: ubuntu-latest
+    environment:
+      name: ghcr
+      url: https://github.com/KapJI/capital-gains-calculator/pkgs/container/capital-gains-calculator
     permissions:
       packages: write
     steps:


### PR DESCRIPTION
Attach a `ghcr` environment to the manifest publish job: the Environments panel on the repo homepage shows what's currently published (linking to the package), and every pushed tag gets a deployment record tying together commit, run, and package. Mirrors the `pypi` environment on the PyPI publish job. The environment is auto-created on first run; no protection rules needed.