### PR TITLE
Add Codecov components

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,24 @@ codecov:
 
 comment:
   after_n_builds: 3
+  layout: "reach, diff, flags, components, files"
+
+# Path-based coverage views, shown in the PR comment and the Codecov
+# UI. Display only: no per-component status checks.
+component_management:
+  individual_components:
+    - component_id: core
+      name: Core calculation
+      paths:
+        - cgt_calc/*.py
+    - component_id: parsers
+      name: Broker parsers
+      paths:
+        - cgt_calc/parsers/**
+    - component_id: eri
+      name: ERI importers
+      paths:
+        - cgt_calc/parsers/eri/**
 
 coverage:
   status:


### PR DESCRIPTION
Slice coverage by area — core calculation, broker parsers, ERI importers — in the PR comment (`components` added to the comment layout) and the Codecov UI. Components are path-based views over the existing uploads, so there are no CI changes. Display only: no per-component status checks. Overlapping paths (parsers ⊃ eri) are intentional — each component is an independent view.