### PR TITLE
Add tests for ERI importers

### DIFF
--- a/tests/eri_importers/__init__.py
+++ b/tests/eri_importers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ERI importers."""

--- a/tests/eri_importers/helpers.py
+++ b/tests/eri_importers/helpers.py
@@ -1,0 +1,34 @@
+"""Helpers for ERI importer tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    import datetime
+    from decimal import Decimal
+    from pathlib import Path
+
+    from cgt_calc.parsers.eri.model import ERITransaction
+
+
+def write_xlsx(path: Path, rows: list[list[object]]) -> Path:
+    """Write rows to an xlsx file as-is, without an implicit header."""
+    pd.DataFrame(rows).to_excel(path, index=False, header=False)
+    return path
+
+
+def check_transaction(
+    transaction: ERITransaction,
+    isin: str,
+    date: datetime.date,
+    price: Decimal,
+    currency: str,
+) -> None:
+    """Assert the key fields of an ERI transaction."""
+    assert transaction.isin == isin
+    assert transaction.date == date
+    assert transaction.price == price
+    assert transaction.currency == currency

--- a/tests/eri_importers/test_blackrock.py
+++ b/tests/eri_importers/test_blackrock.py
@@ -1,0 +1,186 @@
+"""Tests for the Blackrock/iShares ERI importer."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cgt_calc.exceptions import ParsingError
+from cgt_calc.parsers.eri.importer.blackrock import BlackrockImporter
+from tests.eri_importers.helpers import check_transaction, write_xlsx
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+HEADER: list[object] = [
+    "ISIN",
+    "Reporting Period",
+    "Currency",
+    "Excess of Reported Income per Unit",
+]
+PERIOD = "01 January 2023 to 31 December 2023"
+PERIOD_END = datetime.date(2023, 12, 31)
+
+
+def test_parse_header_in_first_row(tmp_path: Path) -> None:
+    """Parse a report with the header in the first row."""
+    file = write_xlsx(
+        tmp_path / "blackrock-eri-2023.xlsx",
+        [
+            HEADER,
+            ["IE00B3RBWM25", PERIOD, "USD", "1.23456"],
+            ["IE00BK5BQV03", "01/01/2023 - 31/12/2023", "JPN", "Nil"],
+        ],
+    )
+
+    result = BlackrockImporter().parse(file)
+
+    assert result is not None
+    assert result.output_file_name == "blackrock_eri.csv"
+    assert len(result.transactions) == 2
+    check_transaction(
+        result.transactions[0], "IE00B3RBWM25", PERIOD_END, Decimal("1.23456"), "USD"
+    )
+    # JPN is a known data bug in the reports and is read as JPY,
+    # Nil is read as zero.
+    check_transaction(
+        result.transactions[1], "IE00BK5BQV03", PERIOD_END, Decimal(0), "JPY"
+    )
+
+
+def test_parse_header_after_preamble_with_trailing_table(tmp_path: Path) -> None:
+    """Parse a report with preamble rows and a trailing retired funds table."""
+    file = write_xlsx(
+        tmp_path / "ishares-eri-2023.xlsx",
+        [
+            ["Excess Reportable Income Report", None, None, None],
+            [None, None, None, None],
+            HEADER,
+            ["IE00B3RBWM25", PERIOD, "USD", "1.23456"],
+            [None, None, None, None],
+            HEADER,
+            ["IE00BK5BQV03", PERIOD, "USD", "9.99999"],
+        ],
+    )
+
+    result = BlackrockImporter().parse(file)
+
+    assert result is not None
+    assert result.output_file_name == "ishares_eri.csv"
+    # The trailing table is for retired funds and is skipped.
+    assert len(result.transactions) == 1
+    check_transaction(
+        result.transactions[0], "IE00B3RBWM25", PERIOD_END, Decimal("1.23456"), "USD"
+    )
+
+
+def test_unmatched_file_name_is_not_accepted(tmp_path: Path) -> None:
+    """Return None for files from other providers."""
+    file = write_xlsx(tmp_path / "fidelity-eri-2023.xlsx", [HEADER])
+
+    assert BlackrockImporter().parse(file) is None
+
+
+def test_no_isin_column(tmp_path: Path) -> None:
+    """Raise when no ISIN column can be found."""
+    file = write_xlsx(
+        tmp_path / "blackrock-eri-2023.xlsx",
+        [
+            ["Fund", "Period", "Ccy", "Amount"],
+            ["Some Fund", PERIOD, "USD", "1.0"],
+        ],
+    )
+
+    with pytest.raises(ParsingError, match="No ISIN column"):
+        BlackrockImporter().parse(file)
+
+
+def test_too_many_isin_columns(tmp_path: Path) -> None:
+    """Raise when more tables are found than expected."""
+    file = write_xlsx(
+        tmp_path / "blackrock-eri-2023.xlsx",
+        [
+            ["Excess Reportable Income Report", None, None, None],
+            HEADER,
+            ["IE00B3RBWM25", PERIOD, "USD", "1.23456"],
+            HEADER,
+            ["IE00BK5BQV03", PERIOD, "USD", "2.34567"],
+            HEADER,
+            ["IE00B4L5Y983", PERIOD, "USD", "3.45678"],
+        ],
+    )
+
+    with pytest.raises(ParsingError, match="Too many ISIN columns"):
+        BlackrockImporter().parse(file)
+
+
+def test_missing_columns(tmp_path: Path) -> None:
+    """Raise when expected columns are missing."""
+    file = write_xlsx(
+        tmp_path / "blackrock-eri-2023.xlsx",
+        [
+            ["ISIN", "Currency"],
+            ["IE00B3RBWM25", "USD"],
+        ],
+    )
+
+    with pytest.raises(ParsingError, match="Cannot process ERI columns"):
+        BlackrockImporter().parse(file)
+
+
+def test_invalid_isin(tmp_path: Path) -> None:
+    """Raise on rows with an invalid ISIN."""
+    file = write_xlsx(
+        tmp_path / "blackrock-eri-2023.xlsx",
+        [HEADER, ["NOTANISIN", PERIOD, "USD", "1.23456"]],
+    )
+
+    with pytest.raises(ParsingError, match="Not valid ISIN"):
+        BlackrockImporter().parse(file)
+
+
+def test_invalid_currency(tmp_path: Path) -> None:
+    """Raise on rows with an unknown currency code."""
+    file = write_xlsx(
+        tmp_path / "blackrock-eri-2023.xlsx",
+        [HEADER, ["IE00B3RBWM25", PERIOD, "QQQ", "1.23456"]],
+    )
+
+    with pytest.raises(ParsingError, match="Not valid Currency"):
+        BlackrockImporter().parse(file)
+
+
+def test_non_string_currency(tmp_path: Path) -> None:
+    """Raise on rows where the currency is not text."""
+    file = write_xlsx(
+        tmp_path / "blackrock-eri-2023.xlsx",
+        [HEADER, ["IE00B3RBWM25", PERIOD, 123, "1.23456"]],
+    )
+
+    with pytest.raises(ParsingError, match="Not valid Currency"):
+        BlackrockImporter().parse(file)
+
+
+def test_invalid_reporting_period(tmp_path: Path) -> None:
+    """Raise on rows with an unparsable reporting period."""
+    file = write_xlsx(
+        tmp_path / "blackrock-eri-2023.xlsx",
+        [HEADER, ["IE00B3RBWM25", "unknown", "USD", "1.23456"]],
+    )
+
+    with pytest.raises(ParsingError, match="Not valid Reporting period"):
+        BlackrockImporter().parse(file)
+
+
+def test_invalid_amount(tmp_path: Path) -> None:
+    """Raise on rows with an unparsable ERI amount."""
+    file = write_xlsx(
+        tmp_path / "blackrock-eri-2023.xlsx",
+        [HEADER, ["IE00B3RBWM25", PERIOD, "USD", "abc"]],
+    )
+
+    with pytest.raises(ParsingError, match="Not valid ERI amount"):
+        BlackrockImporter().parse(file)

--- a/tests/eri_importers/test_invesco.py
+++ b/tests/eri_importers/test_invesco.py
@@ -1,0 +1,256 @@
+"""Tests for the Invesco ERI importer."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+from reportlab.lib import colors
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.platypus import (
+    Flowable,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+from cgt_calc.parsers.eri.importer.invesco import InvescoImporter
+from cgt_calc.parsers.eri.importer.model import ERIImporter
+from tests.eri_importers.helpers import check_transaction
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from cgt_calc.parsers.eri.model import ERITransaction
+
+# Wide page so every cell stays on a single line and the drawn grid
+# is easy for pdfplumber to detect.
+PAGESIZE = (2400, 700)
+
+HEADER = [
+    "ISIN / Identifier",
+    "CURRENCY OF SHARE CLASS",
+    "PER UNIT EXCESS REPORTABLE INCOME OVER DISTRIBUTIONS",
+    "FUND NAME",
+    "SHARE CLASS",
+    "SEDOL",
+    "DISTRIBUTION PER UNIT",
+    "REPORTING PERIOD START",
+    "REPORTING PERIOD END",
+    "EQUALISATION PER UNIT",
+    "NOTES",
+]
+
+DATA_ROWS: list[list[str]] = [
+    [
+        "IE00B3RBWM25",
+        "USD",
+        "1.23456",
+        "Fund A",
+        "Acc",
+        "B3RBWM2",
+        "0.1",
+        "a",
+        "b",
+        "0.2",
+        "n1",
+    ],
+    # Sub-row without an ISIN, e.g. a share class detail line.
+    ["", "", "", "Fund A sub-class", "Hdg", "AAAAAAA", "0.1", "a", "b", "0.2", "n2"],
+    # JPN is a known data bug in the reports and is read as JPY.
+    [
+        "IE00BK5BQV03",
+        "JPN",
+        "0.55555",
+        "Fund B",
+        "Dist",
+        "BK5BQV0",
+        "0.1",
+        "a",
+        "b",
+        "0.2",
+        "n3",
+    ],
+    # Footnote row that is not part of the data table.
+    ["** Distribution reinvested", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x"],
+]
+
+
+def _build_pdf(path: Path, preamble: list[str], with_table: bool = True) -> Path:
+    """Build a PDF with preamble text lines and optionally a data table."""
+    styles = getSampleStyleSheet()
+    doc = SimpleDocTemplate(str(path), pagesize=PAGESIZE)
+    story: list[Flowable] = [Paragraph(line, styles["Normal"]) for line in preamble]
+    if with_table:
+        story.append(Spacer(1, 20))
+        # The third column is wide enough for its long header to stay
+        # within the cell boundaries.
+        col_widths = [180.0] * len(HEADER)
+        col_widths[2] = 340.0
+        table = Table([HEADER, *DATA_ROWS], colWidths=col_widths)
+        table.setStyle(
+            TableStyle(
+                [
+                    ("GRID", (0, 0), (-1, -1), 1, colors.black),
+                    ("FONTSIZE", (0, 0), (-1, -1), 8),
+                    # Keep text within pdfplumber's intersection
+                    # tolerance of the column edges, so the outermost
+                    # columns stay part of the detected table.
+                    ("LEFTPADDING", (0, 0), (-1, -1), 2),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 2),
+                    ("ALIGN", (-1, 0), (-1, -1), "RIGHT"),
+                ]
+            )
+        )
+        story.append(table)
+    doc.build(story)
+    return path
+
+
+def _check_result_transactions(
+    transactions: list[ERITransaction], period_end: datetime.date
+) -> None:
+    """Assert the transactions parsed from DATA_ROWS."""
+    assert len(transactions) == 2
+    check_transaction(
+        transactions[0], "IE00B3RBWM25", period_end, Decimal("1.23456"), "USD"
+    )
+    check_transaction(
+        transactions[1], "IE00BK5BQV03", period_end, Decimal("0.55555"), "JPY"
+    )
+
+
+def test_parse_v1_report(tmp_path: Path) -> None:
+    """Parse a v1 report with the statement header on the first page."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2022.pdf",
+        [
+            (
+                "STATEMENT OF REPORTABLE INCOME FOR INVESCO MARKETS II PLC "
+                "FOR THE PERIOD ENDED 30 June 2022"
+            ),
+        ],
+    )
+
+    result = InvescoImporter().parse(file)
+
+    assert result is not None
+    assert result.output_file_name == "invesco_eri.csv"
+    _check_result_transactions(result.transactions, datetime.date(2022, 6, 30))
+
+
+def test_parse_v2_report(tmp_path: Path) -> None:
+    """Parse a v2 report with per-page headers."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2023.pdf",
+        [
+            "Invesco Markets II plc",
+            "UK reporting fund status report to investors",
+            "Reporting Period End 31 December 2023",
+        ],
+    )
+
+    result = InvescoImporter().parse(file)
+
+    assert result is not None
+    _check_result_transactions(result.transactions, datetime.date(2023, 12, 31))
+
+
+def test_old_report_is_ignored(tmp_path: Path) -> None:
+    """Reports before the minimum valid year produce no transactions."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2015.pdf",
+        [
+            (
+                "STATEMENT OF REPORTABLE INCOME FOR INVESCO MARKETS II PLC "
+                "FOR THE PERIOD ENDED 30 June 2015"
+            ),
+        ],
+        with_table=False,
+    )
+
+    result = InvescoImporter().parse(file)
+
+    assert result is not None
+    assert result.transactions == []
+
+
+def test_v2_alternative_title_and_old_date(tmp_path: Path) -> None:
+    """Accept the alternative v2 title and skip old reporting periods."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2015.pdf",
+        [
+            "Invesco Markets II plc",
+            "UK reporting fund status Report to Investor",
+            "Reporting Period Ended 31 December 2015",
+        ],
+        with_table=False,
+    )
+
+    result = InvescoImporter().parse(file)
+
+    assert result is not None
+    assert result.transactions == []
+
+
+def test_v2_missing_reporting_date(tmp_path: Path) -> None:
+    """Produce no transactions when the reporting date line is missing."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2023.pdf",
+        [
+            "Invesco Markets II plc",
+            "UK reporting fund status report to investors",
+        ],
+        with_table=False,
+    )
+
+    result = InvescoImporter().parse(file)
+
+    assert result is not None
+    assert result.transactions == []
+
+
+def test_v2_unparseable_reporting_date(tmp_path: Path) -> None:
+    """Produce no transactions when the reporting date cannot be parsed."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2023.pdf",
+        [
+            "Invesco Markets II plc",
+            "UK reporting fund status report to investors",
+            "Reporting Period End soon",
+        ],
+        with_table=False,
+    )
+
+    result = InvescoImporter().parse(file)
+
+    assert result is not None
+    assert result.transactions == []
+
+
+def test_unknown_content_is_not_accepted(tmp_path: Path) -> None:
+    """Return None when the content matches neither format."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2023.pdf",
+        ["Some other document"],
+        with_table=False,
+    )
+
+    assert InvescoImporter().parse(file) is None
+
+
+def test_unmatched_file_name_is_not_accepted(tmp_path: Path) -> None:
+    """Return None for files with other names."""
+    file = _build_pdf(tmp_path / "vanguard.pdf", ["Anything"], with_table=False)
+
+    assert InvescoImporter().parse(file) is None
+
+
+def test_base_importer_is_abstract(tmp_path: Path) -> None:
+    """The base importer does not implement parse."""
+    with pytest.raises(NotImplementedError):
+        ERIImporter(name="base").parse(tmp_path / "any.pdf")

--- a/tests/eri_importers/test_vanguard.py
+++ b/tests/eri_importers/test_vanguard.py
@@ -1,0 +1,184 @@
+"""Tests for the Vanguard ERI importer."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cgt_calc.exceptions import ParsingError
+from cgt_calc.parsers.eri.importer.vanguard import VanguardImporter
+from tests.eri_importers.helpers import check_transaction, write_xlsx
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+HEADER: list[object] = [
+    "ISIN",
+    "Reporting Period",
+    "Currency",
+    "Excess of reporting income",
+]
+PERIOD = "01 January 2024 to 31 December 2024"
+PERIOD_END = datetime.date(2024, 12, 31)
+
+
+def test_parse_header_in_first_row(tmp_path: Path) -> None:
+    """Parse a report with the header in the first row."""
+    # The file name check is case-insensitive.
+    file = write_xlsx(
+        tmp_path / "Vanguard-ERI-2024.xlsx",
+        [
+            HEADER,
+            ["IE00B3RBWM25", PERIOD, "USD", "1.23456"],
+            ["IE00BK5BQV03", PERIOD, "GBP", "Nil"],
+        ],
+    )
+
+    result = VanguardImporter().parse(file)
+
+    assert result is not None
+    assert result.output_file_name == "vanguard_eri.csv"
+    assert len(result.transactions) == 2
+    check_transaction(
+        result.transactions[0], "IE00B3RBWM25", PERIOD_END, Decimal("1.23456"), "USD"
+    )
+    check_transaction(
+        result.transactions[1], "IE00BK5BQV03", PERIOD_END, Decimal(0), "GBP"
+    )
+
+
+def test_parse_header_after_preamble_with_trailing_table(tmp_path: Path) -> None:
+    """Parse a report with preamble rows and a trailing retired funds table."""
+    file = write_xlsx(
+        tmp_path / "vanguard-eri-2024.xlsx",
+        [
+            ["Vanguard Excess Reportable Income", None, None, None],
+            [None, None, None, None],
+            HEADER,
+            ["IE00B3RBWM25", PERIOD, "USD", "1.23456"],
+            [None, None, None, None],
+            HEADER,
+            ["IE00BK5BQV03", PERIOD, "USD", "9.99999"],
+        ],
+    )
+
+    result = VanguardImporter().parse(file)
+
+    assert result is not None
+    # The trailing table is for retired funds and is skipped.
+    assert len(result.transactions) == 1
+    check_transaction(
+        result.transactions[0], "IE00B3RBWM25", PERIOD_END, Decimal("1.23456"), "USD"
+    )
+
+
+def test_unmatched_file_name_is_not_accepted(tmp_path: Path) -> None:
+    """Return None for files from other providers."""
+    file = write_xlsx(tmp_path / "blackrock-eri-2024.xlsx", [HEADER])
+
+    assert VanguardImporter().parse(file) is None
+
+
+def test_no_isin_column(tmp_path: Path) -> None:
+    """Raise when no ISIN column can be found."""
+    file = write_xlsx(
+        tmp_path / "vanguard-eri-2024.xlsx",
+        [
+            ["Fund", "Period", "Ccy", "Amount"],
+            ["Some Fund", PERIOD, "USD", "1.0"],
+        ],
+    )
+
+    with pytest.raises(ParsingError, match="No ISIN column"):
+        VanguardImporter().parse(file)
+
+
+def test_too_many_isin_columns(tmp_path: Path) -> None:
+    """Raise when more tables are found than expected."""
+    file = write_xlsx(
+        tmp_path / "vanguard-eri-2024.xlsx",
+        [
+            ["Vanguard Excess Reportable Income", None, None, None],
+            HEADER,
+            ["IE00B3RBWM25", PERIOD, "USD", "1.23456"],
+            HEADER,
+            ["IE00BK5BQV03", PERIOD, "USD", "2.34567"],
+            HEADER,
+            ["IE00B4L5Y983", PERIOD, "USD", "3.45678"],
+        ],
+    )
+
+    with pytest.raises(ParsingError, match="Too many ISIN columns"):
+        VanguardImporter().parse(file)
+
+
+def test_non_string_currency(tmp_path: Path) -> None:
+    """Raise on rows where the currency is not text."""
+    file = write_xlsx(
+        tmp_path / "vanguard-eri-2024.xlsx",
+        [HEADER, ["IE00B3RBWM25", PERIOD, 123, "1.23456"]],
+    )
+
+    with pytest.raises(ParsingError, match="Not valid Currency"):
+        VanguardImporter().parse(file)
+
+
+def test_missing_columns(tmp_path: Path) -> None:
+    """Raise when expected columns are missing."""
+    file = write_xlsx(
+        tmp_path / "vanguard-eri-2024.xlsx",
+        [
+            ["ISIN", "Currency"],
+            ["IE00B3RBWM25", "USD"],
+        ],
+    )
+
+    with pytest.raises(ParsingError, match="Cannot process ERI columns"):
+        VanguardImporter().parse(file)
+
+
+def test_invalid_isin(tmp_path: Path) -> None:
+    """Raise on rows with an invalid ISIN."""
+    file = write_xlsx(
+        tmp_path / "vanguard-eri-2024.xlsx",
+        [HEADER, ["NOTANISIN", PERIOD, "USD", "1.23456"]],
+    )
+
+    with pytest.raises(ParsingError, match="Not valid ISIN"):
+        VanguardImporter().parse(file)
+
+
+def test_invalid_currency(tmp_path: Path) -> None:
+    """Raise on rows with an unknown currency code."""
+    file = write_xlsx(
+        tmp_path / "vanguard-eri-2024.xlsx",
+        [HEADER, ["IE00B3RBWM25", PERIOD, "QQQ", "1.23456"]],
+    )
+
+    with pytest.raises(ParsingError, match="Not valid Currency"):
+        VanguardImporter().parse(file)
+
+
+def test_invalid_reporting_period(tmp_path: Path) -> None:
+    """Raise on rows with an unparsable reporting period."""
+    file = write_xlsx(
+        tmp_path / "vanguard-eri-2024.xlsx",
+        [HEADER, ["IE00B3RBWM25", "unknown", "USD", "1.23456"]],
+    )
+
+    with pytest.raises(ParsingError, match="Not valid Reporting period"):
+        VanguardImporter().parse(file)
+
+
+def test_invalid_amount(tmp_path: Path) -> None:
+    """Raise on rows with an unparsable ERI amount."""
+    file = write_xlsx(
+        tmp_path / "vanguard-eri-2024.xlsx",
+        [HEADER, ["IE00B3RBWM25", PERIOD, "USD", "abc"]],
+    )
+
+    with pytest.raises(ParsingError, match="Not valid ERI amount"):
+        VanguardImporter().parse(file)


### PR DESCRIPTION
The Blackrock/iShares, Vanguard and Invesco ERI importers had no tests at all, while their output becomes the ERI data bundled with the package — a parsing regression there silently corrupts shipped tax data.

Fixtures are synthesized at test time (no binaries in the repo): xlsx reports via pandas, PDF reports via reportlab, following the approach of the HL tests. Covered: header-detection variants (first-row and after-preamble), trailing retired-funds table cutoff, both Invesco PDF formats (v1/v2) incl. reporting-date edge cases, file-name gating, the JPN→JPY data-bug fixup, Nil amounts, and all `ParsingError` paths.

Coverage: importers 0% → 98% (blackrock/vanguard/model 100%, invesco 97%), project total 77% → 84%.