### PR TITLE
Add tests for the least covered modules

### DIFF
--- a/tests/general/test_broker_registry.py
+++ b/tests/general/test_broker_registry.py
@@ -1,0 +1,52 @@
+"""Tests for the broker registry."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from cgt_calc.args_parser import create_parser
+from cgt_calc.isin_converter import IsinConverter
+from cgt_calc.parsers.broker_registry import BrokerRegistry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_load_all_transactions_without_files(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Warn when no transactions are found."""
+    args = create_parser().parse_args(["--year", "2023"])
+
+    with caplog.at_level(logging.WARNING):
+        transactions = BrokerRegistry.load_all_transactions(args, IsinConverter())
+
+    assert transactions == []
+    assert "Found 0 broker transactions" in caplog.text
+
+
+def test_load_all_transactions_from_raw_file(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Load and sort transactions from a single broker."""
+    raw_file = tmp_path / "raw.csv"
+    raw_file.write_text(
+        "date,action,symbol,quantity,price,fees,currency\n"
+        "2023-02-09,DIVIDEND,OPRA,4200,0.80,0.0,USD\n"
+        "2022-11-14,SELL,META,19,116.00,0.05,USD\n"
+    )
+    args = create_parser().parse_args(["--year", "2023", "--raw-file", str(raw_file)])
+
+    with caplog.at_level(logging.INFO):
+        transactions = BrokerRegistry.load_all_transactions(args, IsinConverter())
+
+    assert len(transactions) == 2
+    assert "Loaded 2 transactions from RAW format" in caplog.text
+    # Transactions are sorted by date.
+    assert [str(transaction.date) for transaction in transactions] == [
+        "2022-11-14",
+        "2023-02-09",
+    ]

--- a/tests/general/test_isin_converter.py
+++ b/tests/general/test_isin_converter.py
@@ -2,14 +2,26 @@
 
 from __future__ import annotations
 
+import datetime
+from decimal import Decimal
 import logging
+from pathlib import Path
 from typing import NoReturn
 
 import pytest
 from requests import exceptions as requests_exceptions
 
-from cgt_calc.exceptions import ExternalApiError
-from cgt_calc.isin_converter import IsinConverter
+from cgt_calc.const import RuntimeMode
+from cgt_calc.exceptions import (
+    ExternalApiError,
+    InvalidTransactionError,
+    IsinTranslationError,
+    ParsingError,
+    UnexpectedColumnCountError,
+)
+import cgt_calc.isin_converter
+from cgt_calc.isin_converter import IsinConverter, IsinTranslationEntry
+from cgt_calc.model import ActionType, BrokerTransaction
 
 # Deliberately not a real ISIN so it can't be in the bundled translation data.
 UNKNOWN_ISIN = "ZZ0000000000"
@@ -40,3 +52,254 @@ def test_live_isin_lookup_announces_itself(
         converter.get_symbols(UNKNOWN_ISIN)
 
     assert f"Looking up ISIN {UNKNOWN_ISIN} via OpenFIGI..." in caplog.text
+
+
+# Real, valid ISINs that are not in the bundled translation data.
+ISIN_A = "US0378331005"
+ISIN_B = "US5949181045"
+
+FigiData = list[dict[str, str]]
+
+
+class FakeResponse:
+    """Canned OpenFIGI response."""
+
+    def __init__(self, payload: list[dict[str, FigiData]]) -> None:
+        """Store the payload."""
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self) -> list[dict[str, FigiData]]:
+        """Return the payload."""
+        return self._payload
+
+
+class FakeSession:
+    """Session stub returning a canned response."""
+
+    def __init__(self, payload: list[dict[str, FigiData]]) -> None:
+        """Store the payload."""
+        self._payload = payload
+        self.calls = 0
+
+    def post(
+        self,
+        url: str,
+        json: list[dict[str, str]],
+        headers: dict[str, str],
+        timeout: int,
+    ) -> FakeResponse:
+        """Return the canned response."""
+        self.calls += 1
+        return FakeResponse(self._payload)
+
+
+def _transaction(isin: str, symbol: str | None) -> BrokerTransaction:
+    """Create a minimal transaction with the given ISIN and symbol."""
+    return BrokerTransaction(
+        date=datetime.date(2023, 1, 1),
+        action=ActionType.BUY,
+        symbol=symbol,
+        description="test",
+        quantity=Decimal(1),
+        price=Decimal(1),
+        fees=Decimal(0),
+        amount=Decimal(-1),
+        currency="USD",
+        broker="Test",
+        isin=isin,
+    )
+
+
+def _converter_with_session(
+    monkeypatch: pytest.MonkeyPatch, payload: list[dict[str, FigiData]]
+) -> tuple[IsinConverter, FakeSession]:
+    """Create a converter with a canned OpenFIGI session."""
+    converter = IsinConverter()
+    session = FakeSession(payload)
+    monkeypatch.setattr(converter, "session", session)
+    return converter, session
+
+
+def test_fetch_live_prefers_london_exchange(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prefer LN tickers and cache the result."""
+    converter, session = _converter_with_session(
+        monkeypatch,
+        [
+            {
+                "data": [
+                    {"ticker": "FOO", "exchCode": "LN"},
+                    {"ticker": "FOOL", "exchCode": "LI"},
+                    {"ticker": "FOOUS", "exchCode": "UN"},
+                ]
+            }
+        ],
+    )
+
+    assert converter.get_symbols(ISIN_A) == {"FOO"}
+    # The second lookup is served from the cache.
+    assert converter.get_symbols(ISIN_A) == {"FOO"}
+    assert session.calls == 1
+
+
+def test_fetch_live_falls_back_to_uk_exchanges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fall back to other UK exchanges when LN is missing."""
+    converter, _ = _converter_with_session(
+        monkeypatch,
+        [
+            {
+                "data": [
+                    {"ticker": "FOOL", "exchCode": "LI"},
+                    {"ticker": "FOOUS", "exchCode": "UN"},
+                ]
+            }
+        ],
+    )
+
+    assert converter.get_symbols(ISIN_A) == {"FOOL"}
+
+
+def test_fetch_live_falls_back_to_shortest_ticker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use the shortest ticker when no UK exchange is available."""
+    converter, _ = _converter_with_session(
+        monkeypatch,
+        [
+            {
+                "data": [
+                    {"ticker": "FOOLONG", "exchCode": "UN"},
+                    {"ticker": "FOO", "exchCode": "UW"},
+                ]
+            }
+        ],
+    )
+
+    assert converter.get_symbols(ISIN_A) == {"FOO"}
+
+
+def test_fetch_live_invalid_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return no symbols on unexpected responses."""
+    converter, _ = _converter_with_session(monkeypatch, [{}])
+
+    assert converter.get_symbols(ISIN_A) == set()
+
+
+def test_fetch_live_no_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return no symbols when the response has no tickers."""
+    converter, _ = _converter_with_session(monkeypatch, [{"data": []}])
+
+    assert converter.get_symbols(ISIN_A) == set()
+
+
+def test_validate_data_rejects_invalid_isin() -> None:
+    """Reject translation data with an invalid ISIN."""
+    converter = IsinConverter()
+    converter.data = {"NOTANISIN": {"FOO"}}
+
+    with pytest.raises(IsinTranslationError, match="Invalid ISIN"):
+        converter.validate_data()
+
+
+def test_validate_data_rejects_empty_symbol() -> None:
+    """Reject ticker lists containing empty values."""
+    converter = IsinConverter()
+    converter.data = {ISIN_A: {"FOO", ""}}
+
+    with pytest.raises(IsinTranslationError, match="contains an empty value"):
+        converter.validate_data()
+
+
+def test_validate_data_rejects_conflicting_symbols() -> None:
+    """Reject the same ticker linked to two ISINs."""
+    converter = IsinConverter()
+    converter.data = {ISIN_A: {"FOO"}, ISIN_B: {"FOO"}}
+
+    with pytest.raises(IsinTranslationError, match="already linked"):
+        converter.validate_data()
+
+
+def test_add_from_transaction_rejects_invalid_isin() -> None:
+    """Reject transactions with an invalid ISIN."""
+    converter = IsinConverter()
+
+    with pytest.raises(InvalidTransactionError, match="invalid ISIN"):
+        converter.add_from_transaction(_transaction("NOTANISIN", "FOO"))
+
+
+def test_add_from_transaction_rejects_mismatched_symbol() -> None:
+    """Reject transactions conflicting with the existing mapping."""
+    converter = IsinConverter()
+    converter.data[ISIN_A] = {"FOO"}
+
+    with pytest.raises(InvalidTransactionError, match="does not match"):
+        converter.add_from_transaction(_transaction(ISIN_A, "BAR"))
+
+
+def test_add_from_transaction_adds_mapping() -> None:
+    """Add new mappings and expose them in the symbol map."""
+    converter = IsinConverter()
+
+    converter.add_from_transaction(_transaction(ISIN_A, "FOO"))
+
+    assert converter.get_symbols(ISIN_A) == {"FOO"}
+    assert converter.get_symbol_to_isin_map()["FOO"] == ISIN_A
+
+
+def test_translation_file_roundtrip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Write learned mappings to the translation file and read them back."""
+    monkeypatch.setattr(cgt_calc.isin_converter, "CGT_MODE", RuntimeMode.PROD)
+    translation_file = tmp_path / "isin_translation.csv"
+
+    converter = IsinConverter(isin_translation_file=translation_file)
+    converter.add_from_transaction(_transaction(ISIN_A, "FOO"))
+
+    assert translation_file.read_text() == f"ISIN,symbol\n{ISIN_A},FOO\n"
+
+    restored = IsinConverter(isin_translation_file=translation_file)
+    assert restored.get_symbols(ISIN_A) == {"FOO"}
+
+
+def test_translation_file_empty(tmp_path: Path) -> None:
+    """Treat an empty translation file as no data."""
+    translation_file = tmp_path / "isin_translation.csv"
+    translation_file.write_text("")
+
+    converter = IsinConverter(isin_translation_file=translation_file)
+
+    assert converter.write_data == {}
+
+
+def test_translation_file_bad_header(tmp_path: Path) -> None:
+    """Raise on translation files with an unexpected header."""
+    translation_file = tmp_path / "isin_translation.csv"
+    translation_file.write_text("Wrong,Header\n")
+
+    with pytest.raises(ParsingError, match="Unexpected header"):
+        IsinConverter(isin_translation_file=translation_file)
+
+
+def test_translation_file_invalid_row(tmp_path: Path) -> None:
+    """Raise with row context on invalid translation rows."""
+    translation_file = tmp_path / "isin_translation.csv"
+    translation_file.write_text("ISIN,symbol\nNOTANISIN,FOO\n")
+
+    with pytest.raises(ParsingError, match="invalid ISIN") as excinfo:
+        IsinConverter(isin_translation_file=translation_file)
+
+    assert excinfo.value.row_index == 2
+
+
+def test_translation_entry() -> None:
+    """Translation entries validate their rows."""
+    entry = IsinTranslationEntry([ISIN_A, "FOO"], Path("test.csv"))
+    assert str(entry) == f"ISIN: {ISIN_A}, symbol: {{'FOO'}}"
+
+    with pytest.raises(UnexpectedColumnCountError):
+        IsinTranslationEntry([ISIN_A], Path("test.csv"))

--- a/tests/general/test_logging.py
+++ b/tests/general/test_logging.py
@@ -1,0 +1,127 @@
+"""Tests for colour and emoji aware logging."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, TextIO, cast
+
+import colorama
+
+from cgt_calc.logging import ColourMessageFormatter, ConsoleUI
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class FakeStream:
+    """Stream stub with a configurable encoding and tty flag."""
+
+    def __init__(self, encoding: str = "utf-8", *, atty: bool = False) -> None:
+        """Create the stream stub."""
+        self.encoding = encoding
+        self._atty = atty
+
+    def isatty(self) -> bool:
+        """Return the configured tty flag."""
+        return self._atty
+
+
+def _stream(encoding: str = "utf-8", *, atty: bool = False) -> TextIO:
+    """Create a stream stub typed as TextIO."""
+    return cast("TextIO", FakeStream(encoding, atty=atty))
+
+
+def _record(level: int, msg: str) -> logging.LogRecord:
+    """Create a log record."""
+    return logging.LogRecord(
+        name="test",
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=None,
+        exc_info=None,
+    )
+
+
+def test_painted_with_colour_and_emoji(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wrap the message in colour codes and prefix the emoji."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("NO_EMOJI", raising=False)
+    monkeypatch.setenv("FORCE_COLOR", "1")
+
+    result = ConsoleUI().painted(
+        _stream(), "hello", colour=colorama.Fore.CYAN, emoji="📄"
+    )
+
+    assert result == f"📄  {colorama.Fore.CYAN}hello{colorama.Style.RESET_ALL}"
+
+
+def test_painted_respects_no_emoji(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep colours but drop emoji when NO_EMOJI is set."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.setenv("NO_EMOJI", "1")
+
+    result = ConsoleUI().painted(
+        _stream(), "hello", colour=colorama.Fore.CYAN, emoji="📄"
+    )
+
+    assert "📄" not in result
+    assert colorama.Fore.CYAN in result
+
+
+def test_painted_plain_without_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return the plain message for non-tty streams."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("NO_EMOJI", raising=False)
+
+    result = ConsoleUI().painted(
+        _stream(), "hello", colour=colorama.Fore.CYAN, emoji="📄"
+    )
+
+    assert result == "hello"
+
+
+def test_painted_uses_tty_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Colourise tty streams without FORCE_COLOR."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+
+    assert ConsoleUI().supports_colour(_stream(atty=True)) is True
+    assert ConsoleUI().supports_colour(_stream(atty=False)) is False
+
+
+def test_no_emoji_for_non_unicode_encoding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable emoji when the stream encoding is not unicode."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("NO_EMOJI", raising=False)
+    monkeypatch.setenv("FORCE_COLOR", "1")
+
+    assert ConsoleUI().supports_emoji(_stream(encoding="latin-1")) is False
+
+
+def test_formatter_colours_and_wraps_alerts() -> None:
+    """Colourise warnings, add emoji and pad alerts with blank lines."""
+    formatter = ColourMessageFormatter("%(message)s", use_colour=True, use_emoji=True)
+
+    first = formatter.format(_record(logging.WARNING, "danger\nsecond line"))
+    second = formatter.format(_record(logging.WARNING, "again"))
+
+    assert "⚠️" in first
+    assert colorama.Fore.YELLOW in first
+    assert "WARNING: danger" in first
+    # Continuation lines are indented.
+    assert "\n    " in first
+    # The first alert is padded with a leading blank line,
+    # consecutive alerts are not.
+    assert first.startswith("\n")
+    assert not second.startswith("\n")
+
+
+def test_formatter_plain_info() -> None:
+    """Leave info messages untouched without colour and emoji."""
+    formatter = ColourMessageFormatter("%(message)s", use_colour=False, use_emoji=False)
+
+    assert formatter.format(_record(logging.INFO, "hello")) == "hello"

--- a/tests/hl/test_hl.py
+++ b/tests/hl/test_hl.py
@@ -1,5 +1,7 @@
 """Tests for Hargreaves Lansdown parser."""
 
+from decimal import Decimal
+import io
 from pathlib import Path
 import shutil
 import subprocess
@@ -9,6 +11,7 @@ from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
 from cgt_calc.exceptions import ParsingError
+from cgt_calc.model import ActionType
 from cgt_calc.parsers.hl import HargreavesLansdownParser
 from tests.utils import build_cmd, stderr_alerts
 
@@ -190,3 +193,121 @@ def test_hl_blank_reference_skipped(tmp_path: Path) -> None:
     )
 
     assert transactions == []
+
+
+# The tests below call the parser directly: the end-to-end tests above
+# run in a subprocess, which is invisible to coverage.
+
+
+def test_read_row_interest() -> None:
+    """Read an interest row without a contract note."""
+    row = {
+        "Reference": "Interest",
+        "Description": "Gross interest",
+        "Trade date": "01/03/2026",
+        "Value (£)": "12.34",
+    }
+
+    transaction = HargreavesLansdownParser.read_row(row, Path("statement.csv"))
+
+    assert transaction is not None
+    assert transaction.action == ActionType.INTEREST
+    assert transaction.amount == Decimal("12.34")
+    assert transaction.currency == "GBP"
+    assert transaction.fees == Decimal(0)
+
+
+def test_read_row_transfer_with_na_value() -> None:
+    """Read a fee row where the value column is n/a."""
+    row = {
+        "Reference": "MANAGE FEE",
+        "Description": "Management fee",
+        "Trade date": "01/03/2026",
+        "Value (£)": "n/a",
+    }
+
+    transaction = HargreavesLansdownParser.read_row(row, Path("statement.csv"))
+
+    assert transaction is not None
+    assert transaction.action == ActionType.TRANSFER
+    assert transaction.amount == Decimal(0)
+
+
+def test_read_row_blank_reference_returns_none() -> None:
+    """Skip rows without a reference."""
+    row = {"Reference": " ", "Description": "x", "Trade date": "01/03/2026"}
+
+    assert HargreavesLansdownParser.read_row(row, Path("statement.csv")) is None
+
+
+def test_read_row_invalid_date() -> None:
+    """Raise on rows with an invalid trade date."""
+    row = {
+        "Reference": "Interest",
+        "Description": "x",
+        "Trade date": "garbage",
+        "Value (£)": "1",
+    }
+
+    with pytest.raises(ParsingError, match="Invalid date format"):
+        HargreavesLansdownParser.read_row(row, Path("statement.csv"))
+
+
+def test_read_row_buy_with_contract_note(tmp_path: Path) -> None:
+    """Cross-reference a buy row with its contract note PDF."""
+    _create_buy_pdf(str(tmp_path / "B123_contract.pdf"))
+    row = {
+        "Reference": "B123",
+        "Description": "Buy VHVG",
+        "Trade date": "24/02/2026",
+        "Value (£)": "149,994.89",
+    }
+
+    transaction = HargreavesLansdownParser.read_row(row, tmp_path / "statement.csv")
+
+    assert transaction is not None
+    assert transaction.action == ActionType.BUY
+    assert transaction.symbol == "VHVG"
+    assert transaction.isin == "IE00BK5BQV03"
+    assert transaction.quantity == Decimal("4563.00")
+    # Prices in the contract note are in pence.
+    assert transaction.price == Decimal("32.87199")
+    assert transaction.fees == Decimal("11.95")
+
+
+def test_read_row_sell_without_contract_note(tmp_path: Path) -> None:
+    """Raise when the contract note PDF is missing."""
+    row = {
+        "Reference": "S99",
+        "Description": "Sell VHVG",
+        "Trade date": "24/02/2026",
+        "Value (£)": "100.00",
+    }
+
+    with pytest.raises(ParsingError, match="Cannot find contract note"):
+        HargreavesLansdownParser.read_row(row, tmp_path / "statement.csv")
+
+
+def test_read_transactions_reverses_order() -> None:
+    """Return rows in reverse file order."""
+    content = HL_CSV_HEADER + (
+        "02/03/2026,02/03/2026,Interest,Later interest,n/a,n/a,20.00,\n"
+        "01/03/2026,01/03/2026,Interest,Earlier interest,n/a,n/a,10.00,\n"
+    )
+
+    transactions = HargreavesLansdownParser.read_transactions(
+        io.StringIO(content), Path("statement.csv")
+    )
+
+    assert [transaction.description for transaction in transactions] == [
+        "Earlier interest",
+        "Later interest",
+    ]
+
+
+def test_pre_reading_missing_header() -> None:
+    """Raise when the trade date header cannot be found."""
+    file = io.StringIO("no,header,here\n1,2,3\n")
+
+    with pytest.raises(ParsingError, match="Could not find the 'Trade date' header"):
+        list(HargreavesLansdownParser.pre_reading(file, Path("statement.csv")))

--- a/tests/sharesight/test_sharesight.py
+++ b/tests/sharesight/test_sharesight.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import csv
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 import pytest
 
-from cgt_calc.exceptions import ParsingError
+from cgt_calc.exceptions import InvalidTransactionError, ParsingError
+from cgt_calc.model import ActionType
 from cgt_calc.parsers.sharesight import SharesightParser
 
 if TYPE_CHECKING:
@@ -212,3 +214,294 @@ def test_parse_trade_report_invalid_decimal(tmp_path: Path) -> None:
         list(SharesightParser().load_from_dir(tmp_path))
 
     assert excinfo.value.row_index == 2
+
+
+TRADE_HEADER = [
+    "Market",
+    "Code",
+    "Name",
+    "Type",
+    "Date",
+    "Quantity",
+    "Price *",
+    "Brokerage *",
+    "Currency",
+    "Exchange Rate",
+    "Value",
+    "Comments",
+]
+
+LOCAL_DIVIDEND_HEADER = [
+    "Code",
+    "Name",
+    "Date Paid",
+    "Net Dividend",
+    "Tax Deducted",
+    "Tax Credit",
+    "Gross Dividend",
+    "Comments",
+]
+
+FOREIGN_DIVIDEND_HEADER = [
+    "Code",
+    "Name",
+    "Date Paid",
+    "Exchange Rate",
+    "Currency",
+    "Net Amount",
+    "Foreign Tax Deducted",
+    "Gross Amount",
+    "Comments",
+]
+
+
+def test_parse_income_report(tmp_path: Path) -> None:
+    """Parse local and foreign dividends with their taxes."""
+    _write_csv(
+        tmp_path / "Taxable Income Report.csv",
+        [
+            ["Taxable Income Report"],
+            ["Local Income"],
+            ["Dividend Payments"],
+            LOCAL_DIVIDEND_HEADER,
+            ["ABC", "AB Corp", "01/02/2023", "90", "10", "0", "100", "local divi"],
+            ["Total"],
+            ["Total Local Income"],
+            ["Foreign Income"],
+            FOREIGN_DIVIDEND_HEADER,
+            ["XYZ", "X Corp", "03/04/2023", "1.2", "USD", "85", "15", "100", "foreign"],
+            ["Total"],
+        ],
+    )
+
+    transactions = SharesightParser().load_from_dir(tmp_path)
+
+    assert [transaction.action for transaction in transactions] == [
+        ActionType.DIVIDEND,
+        ActionType.DIVIDEND_TAX,
+        ActionType.DIVIDEND,
+        ActionType.DIVIDEND_TAX,
+    ]
+    assert [transaction.amount for transaction in transactions] == [
+        Decimal(100),
+        Decimal(-10),
+        Decimal(100),
+        Decimal(-15),
+    ]
+    assert [transaction.currency for transaction in transactions] == [
+        "GBP",
+        "GBP",
+        "USD",
+        "USD",
+    ]
+
+
+def test_parse_income_report_missing_currency_value(tmp_path: Path) -> None:
+    """Raise when a foreign dividend row has no currency."""
+    _write_csv(
+        tmp_path / "Taxable Income Report.csv",
+        [
+            ["Foreign Income"],
+            FOREIGN_DIVIDEND_HEADER,
+            ["XYZ", "X Corp", "03/04/2023", "1.2", "", "85", "15", "100", "foreign"],
+        ],
+    )
+
+    with pytest.raises(ParsingError, match="Missing currency in column"):
+        SharesightParser().load_from_dir(tmp_path)
+
+
+def test_parse_income_report_section_without_rows(tmp_path: Path) -> None:
+    """Produce nothing when the dividend section ends at the file end."""
+    _write_csv(
+        tmp_path / "Taxable Income Report.csv",
+        [
+            ["Local Income"],
+            ["Dividend Payments"],
+        ],
+    )
+
+    assert SharesightParser().load_from_dir(tmp_path) == []
+
+
+def test_unknown_report_is_ignored(tmp_path: Path) -> None:
+    """Ignore CSV files that are not Sharesight reports."""
+    _write_csv(tmp_path / "Some Other Report.csv", [["Header"], ["Data"]])
+
+    assert SharesightParser().load_from_dir(tmp_path) == []
+
+
+def test_parse_trade_report(tmp_path: Path) -> None:
+    """Parse buys, sells, FX trades and stock activity."""
+    _write_csv(
+        tmp_path / "All Trades Report.csv",
+        [
+            ["All Trades Report"],
+            TRADE_HEADER,
+            [
+                "NASDAQ",
+                "FOO",
+                "Foo Inc",
+                "Buy",
+                "01/02/2023",
+                "10",
+                "5.5",
+                "1",
+                "USD",
+                "1",
+                "44",
+                "buy",
+            ],
+            [
+                "NASDAQ",
+                "FOO",
+                "Foo Inc",
+                "Sell",
+                "02/02/2023",
+                "-5",
+                "6",
+                "",
+                "USD",
+                "1",
+                "30",
+                "sell",
+            ],
+            [
+                "FX",
+                "USDGBP",
+                "FX trade",
+                "Sell",
+                "03/02/2023",
+                "-100",
+                "1.25",
+                "0",
+                "USD",
+                "1.25",
+                "80",
+                "fx",
+            ],
+            [
+                "NASDAQ",
+                "NVDA",
+                "Nvidia",
+                "Buy",
+                "04/02/2023",
+                "2",
+                "100",
+                "0",
+                "USD",
+                "1",
+                "",
+                "Stock Activity vest",
+            ],
+            ["", "", "", "", "", "", "", "", "", "", "", ""],
+        ],
+    )
+
+    transactions = SharesightParser().load_from_dir(tmp_path)
+
+    assert len(transactions) == 4
+
+    buy, sell, fx, grant = transactions
+    assert buy.action == ActionType.BUY
+    assert buy.symbol == "NASDAQ:FOO"
+    assert buy.quantity == Decimal(10)
+    assert buy.amount == Decimal(-56)
+    assert buy.fees == Decimal(1)
+
+    assert sell.action == ActionType.SELL
+    assert sell.quantity == Decimal(5)
+    assert sell.amount == Decimal(30)
+    assert sell.fees == Decimal(0)
+
+    # FX price is derived from the GBP value.
+    assert fx.currency == "GBP"
+    assert fx.price == Decimal("0.8")
+    assert fx.quantity == Decimal(100)
+    assert fx.amount == Decimal(80)
+
+    assert grant.action == ActionType.STOCK_ACTIVITY
+    assert grant.amount is None
+
+
+def test_parse_trade_report_unknown_action(tmp_path: Path) -> None:
+    """Raise on unknown trade types with row context."""
+    _write_csv(
+        tmp_path / "All Trades Report.csv",
+        [
+            TRADE_HEADER,
+            [
+                "NASDAQ",
+                "FOO",
+                "Foo Inc",
+                "Split",
+                "01/02/2023",
+                "10",
+                "5.5",
+                "1",
+                "USD",
+                "1",
+                "44",
+                "",
+            ],
+        ],
+    )
+
+    with pytest.raises(ParsingError, match="Unknown action: Split") as excinfo:
+        SharesightParser().load_from_dir(tmp_path)
+
+    assert excinfo.value.row_index == 2
+
+
+def test_parse_trade_report_fx_without_value(tmp_path: Path) -> None:
+    """Raise on FX trades without a GBP value."""
+    _write_csv(
+        tmp_path / "All Trades Report.csv",
+        [
+            TRADE_HEADER,
+            [
+                "FX",
+                "USDGBP",
+                "FX trade",
+                "Sell",
+                "03/02/2023",
+                "-100",
+                "1.25",
+                "0",
+                "USD",
+                "1.25",
+                "",
+                "fx",
+            ],
+        ],
+    )
+
+    with pytest.raises(ParsingError, match="Missing Value in FX transaction"):
+        SharesightParser().load_from_dir(tmp_path)
+
+
+def test_parse_trade_report_invalid_stock_activity(tmp_path: Path) -> None:
+    """Raise when stock activity is not a buy."""
+    _write_csv(
+        tmp_path / "All Trades Report.csv",
+        [
+            TRADE_HEADER,
+            [
+                "NASDAQ",
+                "NVDA",
+                "Nvidia",
+                "Sell",
+                "04/02/2023",
+                "-2",
+                "100",
+                "0",
+                "USD",
+                "1",
+                "",
+                "Stock Activity vest",
+            ],
+        ],
+    )
+
+    with pytest.raises(InvalidTransactionError, match="must have Type=Buy"):
+        SharesightParser().load_from_dir(tmp_path)


### PR DESCRIPTION
Follow-up to #902, second part of the coverage plan.

The HL and Sharesight end-to-end tests run the tool in a subprocess, which is invisible to coverage — so this adds direct parser tests: HL contract-note cross-referencing (reusing the reportlab PDF fixtures), Sharesight income/trade reports (FX trades, stock activity, dividend taxes, error rows), broker registry loading/sorting, the OpenFIGI lookup fallback chain + translation-file handling in `IsinConverter` (including the PROD write path), and colour/emoji handling in `logging`.

| Module | Before | After |
|---|---|---|
| `parsers/hl.py` | 55% | 99% |
| `parsers/broker_registry.py` | 61% | 100% |
| `parsers/sharesight.py` | 66% | 97% |
| `isin_converter.py` | 68% | 99% |
| `logging.py` | 68% | 96% |
| **Total** | 84% | **89%** |

395 tests passing (+41).