### PR TITLE
Measure coverage of CLI subprocesses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,16 @@ jobs:
             -e CGT_TEST_MODE_STRICT=1 \
             -v "${{ github.workspace }}:/build" \
             local/cgt-calc:test \
-            -lc "cd /build && uv run pytest -q"
+            -lc "cd /build && uv run pytest -q --cov --cov-report=xml"
+
+      - name: Upload coverage to Codecov
+        # The only job running the test suite with pdflatex enabled.
+        uses: codecov/codecov-action@v7
+        with:
+          files: coverage.xml
+          flags: docker
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Upload e2e tests outputs
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,13 +155,24 @@ jobs:
             -e CGT_TEST_MODE_STRICT=1 \
             -v "${{ github.workspace }}:/build" \
             local/cgt-calc:test \
-            -lc "cd /build && uv run pytest -q --cov --cov-report=xml"
+            -lc "cd /build && uv run pytest -q --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy"
 
       - name: Upload coverage to Codecov
         # The only job running the test suite with pdflatex enabled.
         uses: codecov/codecov-action@v7
         with:
           files: coverage.xml
+          flags: docker
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        # Upload also when tests fail: failed tests are the point.
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v7
+        with:
+          report_type: test_results
+          files: junit.xml
           flags: docker
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,11 @@
 codecov:
   notify:
-    # Wait for all matrix jobs before setting statuses,
+    # Wait for all test jobs (matrix and Docker) before setting statuses,
     # so they aren't computed from partial coverage.
-    after_n_builds: 3
+    after_n_builds: 4
 
 comment:
-  after_n_builds: 3
+  after_n_builds: 4
   layout: "reach, diff, flags, components, files"
 
 # Path-based coverage views, shown in the PR comment and the Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,8 @@ testpaths = [
 
 [tool.coverage.run]
 branch = true
+# Measure CLI subprocesses spawned by the end-to-end tests too.
+patch = ["subprocess"]
 source = ["cgt_calc"]
 # Store relative paths so reports are portable outside the
 # environment that generated them.


### PR DESCRIPTION
Two changes that unfreeze the last unmeasurable coverage:

- `patch = ["subprocess"]` in the coverage config (coverage.py ≥ 7.10): the end-to-end tests run the CLI via `subprocess`, which coverage never saw — this measures those runs in every test job. Total measured coverage goes 89% → 92% (`main.py` 89% → 94%).
- The Docker job now uploads coverage with a `docker` flag: it is the only job running the suite with `ENABLE_PDFLATEX=1`, which is exactly the part of `render_latex.py` no other upload can reach (33% → 86%, would-be-frozen number finally moves). Verified locally end-to-end: coverage.xml lands in the mounted workspace with relative paths and parses as valid Cobertura.
- `after_n_builds: 4` so statuses and the PR comment wait for all four uploads.