### PR TITLE
Raise coverage of core modules and Schwab parsers

### DIFF
--- a/tests/general/test_currency_converter.py
+++ b/tests/general/test_currency_converter.py
@@ -11,8 +11,14 @@ from typing import TYPE_CHECKING, NoReturn
 import pytest
 from requests import exceptions as requests_exceptions
 
-from cgt_calc.currency_converter import CurrencyConverter
-from cgt_calc.exceptions import ExternalApiError, ParsingError
+from cgt_calc.const import RuntimeMode
+import cgt_calc.currency_converter
+from cgt_calc.currency_converter import (
+    CurrencyConverter,
+    StrictTestCurrencyConverter,
+    TestCurrencyConverter as RecordingCurrencyConverter,
+)
+from cgt_calc.exceptions import ExchangeRateMissingError, ExternalApiError, ParsingError
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -198,3 +204,157 @@ def test_hmrc_response_invalid_rate_value_raises_api_error(
 
     with pytest.raises(ExternalApiError, match="contains invalid rate"):
         converter.currency_to_gbp_rate("USD", datetime.date(2021, 5, 10))
+
+
+DATE = datetime.date(2024, 1, 1)
+
+
+class FakeResponse:
+    """Canned HMRC API response."""
+
+    def __init__(self, *, ok: bool, status_code: int = 200, text: str = "") -> None:
+        """Store response fields."""
+        self.ok = ok
+        self.status_code = status_code
+        self.text = text
+
+
+class FakeSession:
+    """Session stub returning a canned response and recording the URL."""
+
+    def __init__(self, response: FakeResponse) -> None:
+        """Store the canned response."""
+        self._response = response
+        self.urls: list[str] = []
+
+    def get(self, url: str, timeout: int) -> FakeResponse:
+        """Record the URL and return the canned response."""
+        self.urls.append(url)
+        return self._response
+
+
+def test_create_for_each_runtime_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return the converter matching the runtime mode."""
+    monkeypatch.setattr(cgt_calc.currency_converter, "CGT_MODE", RuntimeMode.PROD)
+    assert type(CurrencyConverter.create()) is CurrencyConverter
+
+    monkeypatch.setattr(
+        cgt_calc.currency_converter, "CGT_MODE", RuntimeMode.TEST_STRICT
+    )
+    assert type(CurrencyConverter.create()) is StrictTestCurrencyConverter
+
+    monkeypatch.setattr(cgt_calc.currency_converter, "CGT_MODE", RuntimeMode.TEST)
+    assert type(CurrencyConverter.create()) is RecordingCurrencyConverter
+
+    monkeypatch.setattr(cgt_calc.currency_converter, "CGT_MODE", "unknown")
+    with pytest.raises(NotImplementedError):
+        CurrencyConverter.create()
+
+
+def test_read_exchange_rates_rejects_unexpected_columns(tmp_path: Path) -> None:
+    """Reject rates files with a different schema."""
+    rates_file = tmp_path / "rates.csv"
+    rates_file.write_text(
+        "month,currency,rate,extra\n2024-01-01,USD,1.25,x\n", encoding="utf8"
+    )
+
+    with pytest.raises(ParsingError, match="Unexpected columns"):
+        CurrencyConverter(exchange_rates_file=rates_file)
+
+
+def test_read_exchange_rates_rejects_missing_values(tmp_path: Path) -> None:
+    """Reject rows with missing values."""
+    rates_file = tmp_path / "rates.csv"
+    rates_file.write_text("month,currency,rate\n2024-01-01,USD,\n", encoding="utf8")
+
+    with pytest.raises(ParsingError, match="Missing data"):
+        CurrencyConverter(exchange_rates_file=rates_file)
+
+
+def test_write_exchange_rates_file(tmp_path: Path) -> None:
+    """Write the cache back as sorted CSV rows."""
+    rates_file = tmp_path / "rates.csv"
+
+    CurrencyConverter._write_exchange_rates_file(  # noqa: SLF001
+        rates_file, {DATE: {"USD": Decimal("1.25"), "EUR": Decimal("1.10")}}
+    )
+
+    assert rates_file.read_text() == (
+        "month,currency,rate\n2024-01-01,EUR,1.10\n2024-01-01,USD,1.25\n"
+    )
+
+
+def test_query_hmrc_api_old_endpoint_error_names_rates_file(
+    tmp_path: Path,
+) -> None:
+    """Use the old endpoint before 2021 and mention the rates file on errors."""
+    rates_file = tmp_path / "rates.csv"
+    rates_file.write_text("month,currency,rate\n", encoding="utf8")
+    converter = CurrencyConverter(exchange_rates_file=rates_file)
+
+    class FailingSession:
+        def get(self, url: str, timeout: int) -> NoReturn:
+            raise requests_exceptions.ConnectionError(f"offline: {url}")
+
+    converter.session = FailingSession()  # type: ignore[assignment]
+
+    with pytest.raises(ExternalApiError, match=r"rates\.csv") as excinfo:
+        converter.currency_to_gbp_rate("USD", datetime.date(2019, 5, 1))
+
+    assert "exrates-monthly-0519" in str(excinfo.value)
+
+
+def test_query_hmrc_api_http_error_includes_snippet() -> None:
+    """Include a truncated response body in HTTP errors."""
+    converter = CurrencyConverter()
+    response = FakeResponse(ok=False, status_code=500, text="x" * 300)
+    converter.session = FakeSession(response)  # type: ignore[assignment]
+
+    with pytest.raises(ExternalApiError, match="HTTP 500") as excinfo:
+        converter.currency_to_gbp_rate("USD", DATE)
+
+    assert "..." in str(excinfo.value)
+
+
+def test_cnh_is_treated_as_cny() -> None:
+    """Convert offshore yuan using the CNY rate."""
+    converter = CurrencyConverter(initial_data={DATE: {"CNY": Decimal(9)}})
+
+    assert converter.currency_to_gbp_rate("CNH", DATE) == Decimal(9)
+
+
+def test_missing_currency_for_known_date() -> None:
+    """Raise when the date is cached but the currency is missing."""
+    converter = CurrencyConverter(initial_data={DATE: {"USD": Decimal(1)}})
+
+    with pytest.raises(ExchangeRateMissingError):
+        converter.currency_to_gbp_rate("EUR", DATE)
+
+
+def test_test_converter_records_new_rates(tmp_path: Path) -> None:
+    """Record rates fetched during tests in the rates file."""
+    rates_file = tmp_path / "rates.csv"
+    rates_file.write_text("month,currency,rate\n", encoding="utf8")
+    converter = RecordingCurrencyConverter(exchange_rates_file=rates_file)
+
+    def fake_query(date: datetime.date) -> None:
+        converter.cache[date] = {"USD": Decimal("1.25")}
+
+    converter._query_hmrc_api = fake_query  # type: ignore[method-assign]  # noqa: SLF001
+
+    assert converter.currency_to_gbp_rate("USD", DATE) == Decimal("1.25")
+    assert "2024-01-01,USD,1.25" in rates_file.read_text()
+
+    # Appending the same rate again is a no-op.
+    RecordingCurrencyConverter._append_exchange_rates_file(  # noqa: SLF001
+        rates_file, DATE, "USD", Decimal("1.25")
+    )
+    assert rates_file.read_text().count("USD") == 1
+
+
+def test_strict_converter_refuses_to_fetch() -> None:
+    """The CI converter never calls the HMRC API."""
+    converter = StrictTestCurrencyConverter()
+
+    with pytest.raises(RuntimeError, match="provided for tests"):
+        converter.currency_to_gbp_rate("USD", DATE)

--- a/tests/general/test_currency_converter.py
+++ b/tests/general/test_currency_converter.py
@@ -246,10 +246,6 @@ def test_create_for_each_runtime_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cgt_calc.currency_converter, "CGT_MODE", RuntimeMode.TEST)
     assert type(CurrencyConverter.create()) is RecordingCurrencyConverter
 
-    monkeypatch.setattr(cgt_calc.currency_converter, "CGT_MODE", "unknown")
-    with pytest.raises(NotImplementedError):
-        CurrencyConverter.create()
-
 
 def test_read_exchange_rates_rejects_unexpected_columns(tmp_path: Path) -> None:
     """Reject rates files with a different schema."""
@@ -313,7 +309,11 @@ def test_query_hmrc_api_http_error_includes_snippet() -> None:
     with pytest.raises(ExternalApiError, match="HTTP 500") as excinfo:
         converter.currency_to_gbp_rate("USD", DATE)
 
-    assert "..." in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "xxx" in message
+    assert "..." in message
+    # The full 300 character body must not leak into the message.
+    assert "x" * 300 not in message
 
 
 def test_cnh_is_treated_as_cny() -> None:

--- a/tests/general/test_dates.py
+++ b/tests/general/test_dates.py
@@ -1,0 +1,26 @@
+"""Tests for date helpers."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from cgt_calc.dates import get_tax_year_end, get_tax_year_start, is_date
+
+
+def test_is_date() -> None:
+    """Accept plain dates."""
+    assert is_date(datetime.date(2023, 1, 1)) is True
+
+
+def test_is_date_rejects_datetime() -> None:
+    """Reject datetime instances."""
+    with pytest.raises(TypeError, match=r"should be datetime\.date"):
+        is_date(datetime.datetime(2023, 1, 1, 12, 0))
+
+
+def test_tax_year_bounds() -> None:
+    """Tax years run from 6 April to 5 April."""
+    assert get_tax_year_start(2023) == datetime.date(2023, 4, 6)
+    assert get_tax_year_end(2023) == datetime.date(2024, 4, 5)

--- a/tests/general/test_exceptions.py
+++ b/tests/general/test_exceptions.py
@@ -6,24 +6,38 @@ import datetime
 from decimal import Decimal
 from pathlib import Path
 
+import pytest
+
+import cgt_calc.exceptions
 from cgt_calc.exceptions import (
     AmountMissingError,
     CalculatedAmountDiscrepancyError,
+    CalculationError,
+    CgtError,
     ExchangeRateMissingError,
+    ExternalApiError,
+    InteractiveInputRequiredError,
+    InvalidTransactionError,
+    IsinTranslationError,
     LatexRenderError,
+    MarketDataMissingError,
+    MissingExternalToolError,
     ParsingError,
     PriceMissingError,
     QuantityMissingError,
     QuantityNotPositiveError,
     SymbolMissingError,
+    UnexpectedColumnCountError,
     UnexpectedRowCountError,
     UnsupportedBrokerActionError,
     UnsupportedBrokerCurrencyError,
 )
 from cgt_calc.model import ActionType, BrokerTransaction
 
+DATE = datetime.date(2023, 1, 1)
+
 TRANSACTION = BrokerTransaction(
-    date=datetime.date(2023, 1, 1),
+    date=DATE,
     action=ActionType.BUY,
     symbol="FOO",
     description="test",
@@ -64,27 +78,94 @@ def test_parsing_error_add_row_context_updates_message() -> None:
     assert str(err) == "While parsing file.csv, row 11: bad value"
 
 
-def test_transaction_error_messages() -> None:
-    """Transaction errors describe what is missing."""
+def test_add_row_context_on_parsing_error_subclass() -> None:
+    """Row context can be attached through ParsingError subclasses.
 
-    assert "Amount missing" in str(AmountMissingError(TRANSACTION))
-    assert "Symbol missing" in str(SymbolMissingError(TRANSACTION))
-    assert "Price missing" in str(PriceMissingError(TRANSACTION))
-    assert "Quantity missing" in str(QuantityMissingError(TRANSACTION))
-    assert "Positive quantity" in str(QuantityNotPositiveError(TRANSACTION))
-    assert "-42" in str(CalculatedAmountDiscrepancyError(TRANSACTION, Decimal(-42)))
+    File readers catch ParsingError and call add_row_context, so the
+    machinery has to work on every subclass, not just the base class.
+    """
+    err = UnsupportedBrokerActionError(Path("f.csv"), "TestBroker", "Dance")
 
+    err.add_row_context(5)
 
-def test_parsing_error_subclasses() -> None:
-    """Parsing errors embed the offending file and detail."""
-
-    assert "SELL" in str(UnsupportedBrokerActionError(Path("f.csv"), "Broker", "SELL"))
-    assert "XXX" in str(UnsupportedBrokerCurrencyError(Path("f.csv"), "Broker", "XXX"))
-    assert "6 rows" in str(UnexpectedRowCountError(6, Path("f.csv")))
+    assert err.row_index == 5
+    assert "row 5" in str(err)
 
 
-def test_other_error_messages() -> None:
-    """Calculation and rendering errors describe their context."""
+# Each error paired with the inputs a user needs to locate the problem.
+# The exact wording is free to change; losing the context is a regression.
+CONTEXT_CASES: list[tuple[CgtError, list[str]]] = [
+    (
+        InvalidTransactionError(TRANSACTION, "unexpected fees"),
+        ["unexpected fees", "FOO", "2023"],
+    ),
+    (AmountMissingError(TRANSACTION), ["FOO", "2023"]),
+    (SymbolMissingError(TRANSACTION), ["FOO", "2023"]),
+    (PriceMissingError(TRANSACTION), ["FOO", "2023"]),
+    (QuantityMissingError(TRANSACTION), ["FOO", "2023"]),
+    (QuantityNotPositiveError(TRANSACTION), ["FOO", "2023"]),
+    # Both the calculated and the supplied amount are needed to see the gap.
+    (CalculatedAmountDiscrepancyError(TRANSACTION, Decimal(-42)), ["-42", "-1", "FOO"]),
+    (
+        UnsupportedBrokerActionError(Path("f.csv"), "TestBroker", "Dance"),
+        ["f.csv", "TestBroker", "Dance"],
+    ),
+    (
+        UnsupportedBrokerCurrencyError(Path("f.csv"), "TestBroker", "XXX"),
+        ["f.csv", "TestBroker", "XXX"],
+    ),
+    (
+        UnexpectedColumnCountError(["only", "two"], 3, Path("f.csv")),
+        ["f.csv", "3", "only", "two"],
+    ),
+    (UnexpectedRowCountError(6, Path("f.csv")), ["f.csv", "6"]),
+    (ExchangeRateMissingError("USD", DATE), ["USD", "2023-01-01"]),
+    (LatexRenderError(Path("render.log")), ["render.log"]),
+    (MissingExternalToolError("pdflatex"), ["pdflatex"]),
+    (IsinTranslationError("ISIN XS123 is broken"), ["ISIN XS123 is broken"]),
+    (
+        ExternalApiError("https://api.example.com/rates", "boom"),
+        ["https://api.example.com/rates", "boom"],
+    ),
+    (
+        InteractiveInputRequiredError("FOO", DATE, Path("spin_offs.csv")),
+        ["FOO", "2023-01-01", "spin_offs.csv"],
+    ),
+    (MarketDataMissingError("FOO", DATE), ["FOO", "2023-01-01"]),
+]
 
-    assert "USD" in str(ExchangeRateMissingError("USD", datetime.date(2023, 1, 1)))
-    assert "render.log" in str(LatexRenderError(Path("render.log")))
+
+@pytest.mark.parametrize(
+    ("error", "fragments"),
+    CONTEXT_CASES,
+    ids=[type(error).__name__ for error, _ in CONTEXT_CASES],
+)
+def test_error_message_contains_context(error: CgtError, fragments: list[str]) -> None:
+    """Error messages name the inputs needed to locate the problem."""
+    message = str(error)
+
+    for fragment in fragments:
+        assert fragment in message
+
+
+def test_every_exception_has_a_context_case() -> None:
+    """Every exception in the module is exercised by the context sweep.
+
+    A new exception with a broken message would otherwise only surface
+    in the failing user run that raises it.
+    """
+    bare_base_classes = {CgtError, CalculationError}
+    tested_directly = {ParsingError}
+    covered = (
+        {type(error) for error, _ in CONTEXT_CASES}
+        | bare_base_classes
+        | tested_directly
+    )
+
+    module_classes = {
+        obj
+        for obj in vars(cgt_calc.exceptions).values()
+        if isinstance(obj, type) and issubclass(obj, CgtError)
+    }
+
+    assert module_classes <= covered

--- a/tests/general/test_exceptions.py
+++ b/tests/general/test_exceptions.py
@@ -2,9 +2,38 @@
 
 from __future__ import annotations
 
+import datetime
+from decimal import Decimal
 from pathlib import Path
 
-from cgt_calc.exceptions import ParsingError
+from cgt_calc.exceptions import (
+    AmountMissingError,
+    CalculatedAmountDiscrepancyError,
+    ExchangeRateMissingError,
+    LatexRenderError,
+    ParsingError,
+    PriceMissingError,
+    QuantityMissingError,
+    QuantityNotPositiveError,
+    SymbolMissingError,
+    UnexpectedRowCountError,
+    UnsupportedBrokerActionError,
+    UnsupportedBrokerCurrencyError,
+)
+from cgt_calc.model import ActionType, BrokerTransaction
+
+TRANSACTION = BrokerTransaction(
+    date=datetime.date(2023, 1, 1),
+    action=ActionType.BUY,
+    symbol="FOO",
+    description="test",
+    quantity=Decimal(1),
+    price=Decimal(1),
+    fees=Decimal(0),
+    amount=Decimal(-1),
+    currency="USD",
+    broker="Test",
+)
 
 
 def test_parsing_error_message_without_row() -> None:
@@ -33,3 +62,29 @@ def test_parsing_error_add_row_context_updates_message() -> None:
 
     err.add_row_context(11)
     assert str(err) == "While parsing file.csv, row 11: bad value"
+
+
+def test_transaction_error_messages() -> None:
+    """Transaction errors describe what is missing."""
+
+    assert "Amount missing" in str(AmountMissingError(TRANSACTION))
+    assert "Symbol missing" in str(SymbolMissingError(TRANSACTION))
+    assert "Price missing" in str(PriceMissingError(TRANSACTION))
+    assert "Quantity missing" in str(QuantityMissingError(TRANSACTION))
+    assert "Positive quantity" in str(QuantityNotPositiveError(TRANSACTION))
+    assert "-42" in str(CalculatedAmountDiscrepancyError(TRANSACTION, Decimal(-42)))
+
+
+def test_parsing_error_subclasses() -> None:
+    """Parsing errors embed the offending file and detail."""
+
+    assert "SELL" in str(UnsupportedBrokerActionError(Path("f.csv"), "Broker", "SELL"))
+    assert "XXX" in str(UnsupportedBrokerCurrencyError(Path("f.csv"), "Broker", "XXX"))
+    assert "6 rows" in str(UnexpectedRowCountError(6, Path("f.csv")))
+
+
+def test_other_error_messages() -> None:
+    """Calculation and rendering errors describe their context."""
+
+    assert "USD" in str(ExchangeRateMissingError("USD", datetime.date(2023, 1, 1)))
+    assert "render.log" in str(LatexRenderError(Path("render.log")))

--- a/tests/general/test_initial_prices.py
+++ b/tests/general/test_initial_prices.py
@@ -1,0 +1,53 @@
+"""Tests for initial stock prices."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from cgt_calc.exceptions import ExchangeRateMissingError, ParsingError
+from cgt_calc.initial_prices import InitialPrices, InitialPricesEntry
+
+
+def test_load_custom_file(tmp_path: Path) -> None:
+    """Load prices from a custom file."""
+    prices_file = tmp_path / "initial_prices.csv"
+    prices_file.write_text('date,symbol,price\n"Mar 08, 2021",FOO,10.5\n')
+
+    prices = InitialPrices(initial_prices_file=prices_file)
+
+    assert prices.get(datetime.date(2021, 3, 8), "FOO") == Decimal("10.5")
+
+
+def test_get_missing_price(tmp_path: Path) -> None:
+    """Raise when no price is stored for the date and symbol."""
+    prices_file = tmp_path / "initial_prices.csv"
+    prices_file.write_text("date,symbol,price\n")
+
+    prices = InitialPrices(initial_prices_file=prices_file)
+
+    with pytest.raises(ExchangeRateMissingError):
+        prices.get(datetime.date(2021, 3, 8), "FOO")
+
+
+def test_invalid_row(tmp_path: Path) -> None:
+    """Raise with row context on invalid rows."""
+    prices_file = tmp_path / "initial_prices.csv"
+    prices_file.write_text('date,symbol,price\n"Mar 08, 2021",FOO\n')
+
+    with pytest.raises(ParsingError) as excinfo:
+        InitialPrices(initial_prices_file=prices_file)
+
+    assert excinfo.value.row_index == 2
+
+
+def test_entry_str() -> None:
+    """Entries have a readable representation."""
+    entry = InitialPricesEntry(
+        ["Mar 08, 2021", "FOO", "10.5"], Path("initial_prices.csv")
+    )
+
+    assert str(entry) == "date: 2021-03-08, symbol: FOO, price: 10.5"

--- a/tests/general/test_initial_prices.py
+++ b/tests/general/test_initial_prices.py
@@ -44,10 +44,12 @@ def test_invalid_row(tmp_path: Path) -> None:
     assert excinfo.value.row_index == 2
 
 
-def test_entry_str() -> None:
-    """Entries have a readable representation."""
+def test_entry_parses_row() -> None:
+    """Parse the date, symbol and decimal price from a CSV row."""
     entry = InitialPricesEntry(
         ["Mar 08, 2021", "FOO", "10.5"], Path("initial_prices.csv")
     )
 
-    assert str(entry) == "date: 2021-03-08, symbol: FOO, price: 10.5"
+    assert entry.date == datetime.date(2021, 3, 8)
+    assert entry.symbol == "FOO"
+    assert entry.price == Decimal("10.5")

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -14,6 +14,12 @@ from cgt_calc.parsers.schwab import AwardPrices, SchwabParser, action_from_str
 from tests.utils import build_cmd, stderr_alerts
 
 
+@pytest.fixture(autouse=True)
+def _reset_awards_prices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep changes to the class-level award prices out of other test modules."""
+    monkeypatch.setattr(SchwabParser, "awards_prices", AwardPrices(award_prices={}))
+
+
 def test_missing_award_file_reports_the_vest_it_cannot_price() -> None:
     """A vest without a price is the only thing the award file is needed for.
 
@@ -211,7 +217,6 @@ SCHWAB_HEADER = "Date,Action,Symbol,Description,Price,Quantity,Fees & Comm,Amoun
 
 def _read(content: str) -> list[BrokerTransaction]:
     """Parse a Schwab CSV from a string."""
-    SchwabParser.awards_prices = AwardPrices(award_prices={})
     return SchwabParser.read_transactions(
         io.StringIO(content), Path("transactions.csv")
     )

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -2,13 +2,15 @@
 
 import datetime
 from decimal import Decimal
+import io
 from pathlib import Path
 import subprocess
 
 import pytest
 
-from cgt_calc.exceptions import ParsingError
-from cgt_calc.parsers.schwab import AwardPrices, SchwabParser
+from cgt_calc.exceptions import ParsingError, SymbolMissingError
+from cgt_calc.model import ActionType, BrokerTransaction
+from cgt_calc.parsers.schwab import AwardPrices, SchwabParser, action_from_str
 from tests.utils import build_cmd, stderr_alerts
 
 
@@ -202,3 +204,145 @@ def test_run_with_schwab_interest_tax_files() -> None:
         "if you added new features update the test with:\n"
         f"{cmd_str} > {expected_file}"
     )
+
+
+SCHWAB_HEADER = "Date,Action,Symbol,Description,Price,Quantity,Fees & Comm,Amount\n"
+
+
+def _read(content: str) -> list[BrokerTransaction]:
+    """Parse a Schwab CSV from a string."""
+    SchwabParser.awards_prices = AwardPrices(award_prices={})
+    return SchwabParser.read_transactions(
+        io.StringIO(content), Path("transactions.csv")
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "action"),
+    [
+        ("Buy", ActionType.BUY),
+        ("Sell", ActionType.SELL),
+        ("Qualified Dividend", ActionType.DIVIDEND),
+        ("Cash Dividend", ActionType.DIVIDEND),
+        ("Qual Div Reinvest", ActionType.DIVIDEND),
+        ("Div Adjustment", ActionType.DIVIDEND),
+        ("Special Qual Div", ActionType.DIVIDEND),
+        ("Non-Qualified Div", ActionType.DIVIDEND),
+        ("NRA Tax Adj", ActionType.DIVIDEND_TAX),
+        ("NRA Withholding", ActionType.DIVIDEND_TAX),
+        ("Foreign Tax Paid", ActionType.DIVIDEND_TAX),
+        ("ADR Mgmt Fee", ActionType.FEE),
+        ("Adjustment", ActionType.ADJUSTMENT),
+        ("IRS Withhold Adj", ActionType.ADJUSTMENT),
+        ("Wire Funds Adj", ActionType.ADJUSTMENT),
+        ("Short Term Cap Gain", ActionType.CAPITAL_GAIN),
+        ("Long Term Cap Gain", ActionType.CAPITAL_GAIN),
+        ("Spin-off", ActionType.SPIN_OFF),
+        ("Credit Interest", ActionType.INTEREST),
+        ("Bond Interest", ActionType.INTEREST),
+        ("Reinvest Shares", ActionType.REINVEST_SHARES),
+        ("Reinvest Dividend", ActionType.REINVEST_DIVIDENDS),
+        ("Wire Funds Received", ActionType.WIRE_FUNDS_RECEIVED),
+        ("Stock Split", ActionType.STOCK_SPLIT),
+        ("Cash Merger", ActionType.CASH_MERGER),
+        ("Cash Merger Adj", ActionType.CASH_MERGER),
+        ("Full Redemption", ActionType.FULL_REDEMPTION),
+        ("Full Redemption Adj", ActionType.FULL_REDEMPTION),
+    ],
+)
+def test_action_from_str(label: str, action: ActionType) -> None:
+    """Map every known Schwab action label."""
+    assert action_from_str(label, Path("transactions.csv")) == action
+
+
+def test_action_from_str_unknown() -> None:
+    """Raise on unknown action labels."""
+    with pytest.raises(ParsingError, match="Unknown action"):
+        action_from_str("Dance", Path("transactions.csv"))
+
+
+def test_read_transactions_empty_file() -> None:
+    """Raise on empty transaction files."""
+    with pytest.raises(ParsingError, match="file is empty"):
+        _read("")
+
+
+def test_read_transactions_missing_columns() -> None:
+    """Raise when required columns are missing."""
+    with pytest.raises(ParsingError, match="Missing columns"):
+        _read("Date,Action\n01/15/2023,Sell\n")
+
+
+def test_read_transactions_skips_blank_lines() -> None:
+    """Skip blank lines in the file."""
+    content = SCHWAB_HEADER + ",,,,,,,\n"
+    assert _read(content) == []
+
+
+def test_read_transactions_wrong_column_count() -> None:
+    """Raise when a row has a different number of columns."""
+    content = SCHWAB_HEADER + "01/15/2023,Sell\n"
+    with pytest.raises(ParsingError) as excinfo:
+        _read(content)
+    assert excinfo.value.row_index == 2
+
+
+def test_read_transactions_as_of_date() -> None:
+    """Parse dates with an 'as of' suffix."""
+    content = (
+        SCHWAB_HEADER
+        + '01/15/2023 as of 01/12/2023,Credit Interest,,Interest,,,,"$1.00"\n'
+    )
+    transactions = _read(content)
+    assert transactions[0].date == datetime.date(2023, 1, 15)
+
+
+def test_read_transactions_invalid_date() -> None:
+    """Raise on unparsable dates."""
+    content = SCHWAB_HEADER + "2023-01-15,Credit Interest,,Interest,,,,$1.00\n"
+    with pytest.raises(ParsingError, match="Invalid date format"):
+        _read(content)
+
+
+def test_read_transactions_ninth_column_must_be_empty() -> None:
+    """Raise when the legacy ninth column contains data."""
+    header = SCHWAB_HEADER.rstrip("\n") + ",Extra\n"
+    content = header + "01/15/2023,Credit Interest,,Interest,,,,$1.00,oops\n"
+    with pytest.raises(ParsingError, match="should be empty"):
+        _read(content)
+
+
+def test_stock_activity_without_symbol() -> None:
+    """Raise when a stock activity row has no symbol to price."""
+    content = SCHWAB_HEADER + "01/15/2023,Stock Plan Activity,,Vest,,10,,\n"
+    with pytest.raises(SymbolMissingError):
+        _read(content)
+
+
+def test_cash_merger_adj_without_cash_merger() -> None:
+    """Raise when a Cash Merger Adj has no preceding Cash Merger."""
+    content = SCHWAB_HEADER + "01/15/2023,Cash Merger Adj,FOO,Merger,,-10,,\n"
+    with pytest.raises(ParsingError, match="must be preceded"):
+        _read(content)
+
+
+def test_invalid_cash_merger_pair() -> None:
+    """Raise when a Cash Merger pair fails validation."""
+    content = (
+        SCHWAB_HEADER
+        + '01/16/2023,Cash Merger,FOO,Merger,,,,"$100.00"\n'
+        + '01/15/2023,Cash Merger Adj,FOO,Merger,,-10,,"$5.00"\n'
+    )
+    with pytest.raises(ParsingError, match="Invalid Cash Merger format"):
+        _read(content)
+
+
+def test_invalid_full_redemption_pair() -> None:
+    """Raise when a Full Redemption pair fails validation."""
+    content = (
+        SCHWAB_HEADER
+        + '01/16/2023,Full Redemption Adj,FOO,Redemption,,,,"$100.00"\n'
+        + '01/15/2023,Full Redemption,FOO,Redemption,"$1.00",-10,,\n'
+    )
+    with pytest.raises(ParsingError, match="Invalid Full Redemption format"):
+        _read(content)

--- a/tests/schwab/test_schwab_equity_award_json.py
+++ b/tests/schwab/test_schwab_equity_award_json.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import datetime
 from decimal import Decimal
+import io
+import logging
 from pathlib import Path
 
 import pytest
 
-from cgt_calc.model import ActionType
+from cgt_calc.exceptions import ParsingError
+from cgt_calc.model import ActionType, BrokerTransaction
 from cgt_calc.parsers import schwab_equity_award_json
 
 # ruff: noqa: SLF001 "Private member accessed"
@@ -253,3 +256,129 @@ def test_split_history_demands_a_price_floor_it_can_use() -> None:
             schwab_equity_award_json.Restatement.ACQUISITIONS_ONLY,
             presplit_price_floor=Decimal(175),
         )
+
+
+@pytest.mark.parametrize(
+    ("label", "action"),
+    [
+        ("Buy", ActionType.BUY),
+        ("Sale", ActionType.SELL),
+        ("Sell", ActionType.SELL),
+        ("Deposit", ActionType.STOCK_ACTIVITY),
+        ("Qualified Dividend", ActionType.DIVIDEND),
+        ("Cash Dividend", ActionType.DIVIDEND),
+        ("Dividend", ActionType.DIVIDEND),
+        ("MoneyLink Transfer", ActionType.TRANSFER),
+        ("Cash In Lieu", ActionType.TRANSFER),
+        ("Stock Plan Activity", ActionType.STOCK_ACTIVITY),
+        ("NRA Tax Adj", ActionType.DIVIDEND_TAX),
+        ("NRA Withholding", ActionType.DIVIDEND_TAX),
+        ("Foreign Tax Paid", ActionType.DIVIDEND_TAX),
+        ("Tax Reversal", ActionType.DIVIDEND_TAX),
+        ("Tax Withholding", ActionType.DIVIDEND_TAX),
+        ("ADR Mgmt Fee", ActionType.FEE),
+        ("Adjustment", ActionType.ADJUSTMENT),
+        ("IRS Withhold Adj", ActionType.ADJUSTMENT),
+        ("Short Term Cap Gain", ActionType.CAPITAL_GAIN),
+        ("Long Term Cap Gain", ActionType.CAPITAL_GAIN),
+        ("Spin-off", ActionType.SPIN_OFF),
+        ("Credit Interest", ActionType.INTEREST),
+        ("Reinvest Shares", ActionType.REINVEST_SHARES),
+        ("Reinvest Dividend", ActionType.REINVEST_DIVIDENDS),
+        ("Wire Funds Received", ActionType.WIRE_FUNDS_RECEIVED),
+    ],
+)
+def test_action_from_str(label: str, action: ActionType) -> None:
+    """Map every known Schwab equity award action label."""
+    assert (
+        schwab_equity_award_json.action_from_str(label, Path("awards.json")) == action
+    )
+
+
+def test_action_from_str_unknown() -> None:
+    """Raise on unknown action labels."""
+    with pytest.raises(ParsingError, match="Unknown action"):
+        schwab_equity_award_json.action_from_str("Dance", Path("awards.json"))
+
+
+def _read_json(content: str) -> list[BrokerTransaction]:
+    """Parse Schwab equity award JSON from a string."""
+    parser = schwab_equity_award_json.SchwabEquityAwardsJSONParser
+    return parser.read_transactions(io.StringIO(content), Path("awards.json"))
+
+
+def test_read_transactions_invalid_json() -> None:
+    """Raise on malformed JSON."""
+    with pytest.raises(ParsingError, match="Could not parse content as JSON"):
+        _read_json("{not json")
+
+
+def test_read_transactions_unknown_top_level_field() -> None:
+    """Raise when no known top level field is present."""
+    with pytest.raises(ParsingError, match="Expected top level field"):
+        _read_json('{"Unknown": []}')
+
+
+def test_read_transactions_transactions_not_a_list() -> None:
+    """Raise when the transactions field is not a list."""
+    with pytest.raises(ParsingError, match="is not a list"):
+        _read_json('{"Transactions": {}}')
+
+
+def test_unknown_symbol_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """Warn about symbols without known split history."""
+    content = (
+        '{"Transactions": [{"Date": "01/15/2023", "Action": "Dividend",'
+        ' "Symbol": "ZZZ", "Description": "Div", "Quantity": null,'
+        ' "Amount": "$10.00", "FeesAndCommissions": null,'
+        ' "TransactionDetails": []}]}'
+    )
+
+    with caplog.at_level(logging.WARNING):
+        transactions = _read_json(content)
+
+    assert "check the share counts" in caplog.text
+    assert transactions[0].action == ActionType.DIVIDEND
+    assert transactions[0].amount == Decimal(10)
+
+
+def test_unimplemented_action_raises() -> None:
+    """Raise on actions the parser does not implement."""
+    content = (
+        '{"Transactions": [{"Date": "01/15/2023", "Action": "Buy",'
+        ' "Symbol": "GOOG", "Description": "Buy", "Quantity": "1",'
+        ' "Amount": "$10.00", "FeesAndCommissions": null,'
+        ' "TransactionDetails": []}]}'
+    )
+
+    with pytest.raises(ParsingError, match="is not implemented"):
+        _read_json(content)
+
+
+def test_detail_counts_multiplier_for_uniform_restatement() -> None:
+    """Uniformly restated symbols need no detail multiplier."""
+    assert (
+        schwab_equity_award_json._detail_counts_multiplier(
+            "GOOG", datetime.date(2020, 1, 1)
+        )
+        == 1
+    )
+
+
+def test_lot_shares_and_price_helpers() -> None:
+    """Lot helpers return None when lots are incomplete or disagree."""
+    names = schwab_equity_award_json.FieldNames(2)
+
+    no_shares = {"TransactionDetails": [{"Details": {"SalePrice": "$10.00"}}]}
+    assert schwab_equity_award_json._lot_share_sum(no_shares, names) is None
+
+    no_price = {"TransactionDetails": [{"Details": {"Shares": "1.5"}}]}
+    assert schwab_equity_award_json._lot_price(no_price, names) is None
+
+    different_prices = {
+        "TransactionDetails": [
+            {"Details": {"SalePrice": "$10.00"}},
+            {"Details": {"SalePrice": "$11.00"}},
+        ]
+    }
+    assert schwab_equity_award_json._lot_price(different_prices, names) is None

--- a/tests/schwab/test_schwab_equity_award_json.py
+++ b/tests/schwab/test_schwab_equity_award_json.py
@@ -355,14 +355,18 @@ def test_unimplemented_action_raises() -> None:
         _read_json(content)
 
 
-def test_detail_counts_multiplier_for_uniform_restatement() -> None:
-    """Uniformly restated symbols need no detail multiplier."""
-    assert (
-        schwab_equity_award_json._detail_counts_multiplier(
-            "GOOG", datetime.date(2020, 1, 1)
-        )
-        == 1
-    )
+def test_detail_counts_multiplier() -> None:
+    """Compose the ratios of every split after the given date."""
+    multiplier = schwab_equity_award_json._detail_counts_multiplier
+
+    # NVDA restates acquisitions only and split 4:1 on 2021-07-20
+    # and 10:1 on 2024-06-10.
+    assert multiplier("NVDA", datetime.date(2021, 7, 19)) == 40
+    assert multiplier("NVDA", datetime.date(2021, 7, 20)) == 10
+    assert multiplier("NVDA", datetime.date(2024, 6, 10)) == 1
+    # GOOG's export does not restate uniformly, so counts inside the
+    # details are already comparable and need no multiplier.
+    assert multiplier("GOOG", datetime.date(2020, 1, 1)) == 1
 
 
 def test_lot_shares_and_price_helpers() -> None:


### PR DESCRIPTION
Targets: Codecov total ≥90%, `core` component ≥90%, Schwab parsers ≥90%.

| File | Local before | Local after |
|---|---|---|
| `currency_converter.py` | 75% | 97% |
| `parsers/schwab.py` | 87% | 96% |
| `parsers/schwab_equity_award_json.py` | 83% | 95% |
| `initial_prices.py` | 76% | 97% |
| `exceptions.py` | 86% | 100% |
| `dates.py` | 82% | 100% |
| **Total** | 92% | **95%** |

Added: parametrized sweeps of both Schwab action-label maps, Schwab CSV error paths (empty/missing columns/bad dates/"as of" dates/legacy ninth column), invalid Cash Merger and Full Redemption pairs, equity-award JSON format errors and lot helpers, HMRC API error paths (old endpoint, HTTP errors with truncated body snippets), rate recording in `TestCurrencyConverter`, `CurrencyConverter.create()` mode dispatch, and a context sweep over every exception class. 505 tests (+110).
