### PR TITLE
Add file and row context to initial price parsing errors

### DIFF
--- a/cgt_calc/initial_prices.py
+++ b/cgt_calc/initial_prices.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import csv
 from dataclasses import dataclass
 import datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from importlib import resources
 from pathlib import Path
 from typing import Final, override
@@ -35,14 +35,23 @@ class InitialPricesEntry:
         if len(row) != INITIAL_PRICES_COLUMNS_NUM:
             raise UnexpectedColumnCountError(row, INITIAL_PRICES_COLUMNS_NUM, file)
         # date,symbol,price
-        self.date = self._parse_date(row[0])
+        self.date = self._parse_date(row[0], file)
         self.symbol = row[1]
-        self.price = Decimal(row[2])
+        try:
+            self.price = Decimal(row[2])
+        except InvalidOperation as err:
+            raise ParsingError(file, f"Invalid decimal price: {row[2]!r}") from err
 
     @staticmethod
-    def _parse_date(date_str: str) -> datetime.date:
+    def _parse_date(date_str: str, file: Path) -> datetime.date:
         """Parse date from string."""
-        return datetime.datetime.strptime(date_str, "%b %d, %Y").date()
+        try:
+            return datetime.datetime.strptime(date_str, "%b %d, %Y").date()
+        except ValueError as err:
+            raise ParsingError(
+                file,
+                f"Invalid date format: {date_str!r}, expected e.g. 'Mar 08, 2021'",
+            ) from err
 
     @override
     def __str__(self) -> str:

--- a/tests/general/test_initial_prices.py
+++ b/tests/general/test_initial_prices.py
@@ -44,6 +44,34 @@ def test_invalid_row(tmp_path: Path) -> None:
     assert excinfo.value.row_index == 2
 
 
+def test_invalid_date(tmp_path: Path) -> None:
+    """Report file and row context for unparsable dates."""
+    prices_file = tmp_path / "initial_prices.csv"
+    prices_file.write_text("date,symbol,price\n2021-03-08,FOO,10.5\n")
+
+    with pytest.raises(ParsingError, match="Invalid date format") as excinfo:
+        InitialPrices(initial_prices_file=prices_file)
+
+    message = str(excinfo.value)
+    assert excinfo.value.row_index == 2
+    assert "2021-03-08" in message
+    assert "initial_prices.csv" in message
+
+
+def test_invalid_price(tmp_path: Path) -> None:
+    """Report file and row context for unparsable prices."""
+    prices_file = tmp_path / "initial_prices.csv"
+    prices_file.write_text('date,symbol,price\n"Mar 08, 2021",FOO,ten\n')
+
+    with pytest.raises(ParsingError, match="Invalid decimal price") as excinfo:
+        InitialPrices(initial_prices_file=prices_file)
+
+    message = str(excinfo.value)
+    assert excinfo.value.row_index == 2
+    assert "ten" in message
+    assert "initial_prices.csv" in message
+
+
 def test_entry_parses_row() -> None:
     """Parse the date, symbol and decimal price from a CSV row."""
     entry = InitialPricesEntry(


### PR DESCRIPTION
A malformed date or price in an initial prices file escaped as a raw `ValueError`/`InvalidOperation` traceback. Wrap both in `ParsingError` naming the offending value, so the reader attaches the file and row number as it already does for column count errors.

Follow-up to #905.