### PR TITLE
Support new Trading 212 export columns and action types

### DIFF
--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -40,13 +40,21 @@ class Trading212Column(StrEnum):
     WITHHOLDING_TAX = "Withholding tax"
     CURRENCY_WITHHOLDING_TAX = "Currency (Withholding tax)"
     CHARGE_AMOUNT_GBP = "Charge amount (GBP)"
+    CHARGE_AMOUNT = "Charge amount"
+    CURRENCY_CHARGE_AMOUNT = "Currency (Charge amount)"
+    DEPOSIT_FEE = "Deposit fee"
+    CURRENCY_DEPOSIT_FEE = "Currency (Deposit fee)"
     TRANSACTION_FEE_GBP = "Transaction fee (GBP)"
     TRANSACTION_FEE = "Transaction fee"
     FINRA_FEE_GBP = "Finra fee (GBP)"
     FINRA_FEE = "Finra fee"
     STAMP_DUTY_GBP = "Stamp duty (GBP)"
+    STAMP_DUTY = "Stamp duty"
+    CURRENCY_STAMP_DUTY = "Currency (Stamp duty)"
     STAMP_DUTY_RESERVE_TAX = "Stamp duty reserve tax"
     CURRENCY_STAMP_DUTY_RESERVE_TAX = "Currency (Stamp duty reserve tax)"
+    FRENCH_TRANSACTION_TAX = "French transaction tax"
+    CURRENCY_FRENCH_TRANSACTION_TAX = "Currency (French transaction tax)"
     NOTES = "Notes"
     TRANSACTION_ID = "ID"
     CURRENCY_CONVERSION_FEE_GBP = "Currency conversion fee (GBP)"
@@ -102,6 +110,7 @@ def action_from_str(label: str, file: Path) -> ActionType:
         return ActionType.SELL
 
     if label in [
+        "Card credit",
         "Card debit",
         "Card refund",
         "Deposit",
@@ -114,17 +123,25 @@ def action_from_str(label: str, file: Path) -> ActionType:
         "Dividend (Dividend)",
         "Dividend (Dividends paid by us corporations)",
         "Dividend (Dividend manufactured payment)",
+        "Dividend (Property income distribution)",
+        "Dividend adjustment",
     ]:
         return ActionType.DIVIDEND
 
     if label in [
         "Interest on cash",
         "Lending interest",
+        # Interest distributions from bond and money market funds,
+        # taxed as savings income rather than dividends.
+        "Dividend (Interest)",
     ]:
         return ActionType.INTEREST
 
     if label == "Stock Split":
         return ActionType.STOCK_SPLIT
+
+    if label == "Spin off":
+        return ActionType.SPIN_OFF
 
     if label in [
         "Currency conversion",
@@ -213,6 +230,33 @@ class Trading212Transaction(BrokerTransaction):
                     "Stamp duty reserve tax is not in GBP which is not supported yet",
                 )
             self.stamp_duty += stamp_duty_reserve_tax
+
+        stamp_duty_foreign = decimal_or_none(
+            row, Trading212Column.STAMP_DUTY
+        ) or Decimal(0)
+        if stamp_duty_foreign > 0:
+            stamp_duty_foreign_currency = row.get(Trading212Column.CURRENCY_STAMP_DUTY)
+            if stamp_duty_foreign_currency not in ("GBP", None, ""):
+                raise ParsingError(
+                    file,
+                    "Stamp duty is not in GBP which is not supported yet",
+                )
+            self.stamp_duty += stamp_duty_foreign
+
+        # Transaction tax on French shares, treated like stamp duty.
+        french_transaction_tax = decimal_or_none(
+            row, Trading212Column.FRENCH_TRANSACTION_TAX
+        ) or Decimal(0)
+        if french_transaction_tax > 0:
+            french_transaction_tax_currency = row.get(
+                Trading212Column.CURRENCY_FRENCH_TRANSACTION_TAX
+            )
+            if french_transaction_tax_currency not in ("GBP", None, ""):
+                raise ParsingError(
+                    file,
+                    "French transaction tax is not in GBP which is not supported yet",
+                )
+            self.stamp_duty += french_transaction_tax
 
         self.conversion_fee = decimal_or_none(
             row, Trading212Column.CURRENCY_CONVERSION_FEE_GBP

--- a/tests/trading212/test_trading212.py
+++ b/tests/trading212/test_trading212.py
@@ -466,6 +466,279 @@ def test_read_trading212_transactions_supports_2026_export(tmp_path: Path) -> No
     assert cashback.notes == "Cashback"
 
 
+HEADER_2025_BARE = [
+    "Action",
+    "Time",
+    "ISIN",
+    "Ticker",
+    "Name",
+    "Notes",
+    "ID",
+    "No. of shares",
+    "Price / share",
+    "Currency (Price / share)",
+    "Exchange rate",
+    "Result",
+    "Currency (Result)",
+    "Total",
+    "Currency (Total)",
+    "Withholding tax",
+    "Currency (Withholding tax)",
+    "Charge amount",
+    "Currency (Charge amount)",
+    "Deposit fee",
+    "Currency (Deposit fee)",
+    "Stamp duty",
+    "Currency (Stamp duty)",
+    "Stamp duty reserve tax",
+    "Currency (Stamp duty reserve tax)",
+    "Currency conversion fee",
+    "Currency (Currency conversion fee)",
+    "French transaction tax",
+    "Currency (French transaction tax)",
+]
+
+
+def test_read_trading212_transactions_supports_2025_bare_columns(
+    tmp_path: Path,
+) -> None:
+    """Parse exports with bare tax columns and 2025 action labels."""
+
+    rows = [
+        HEADER_2025_BARE,
+        _make_row(
+            HEADER_2025_BARE,
+            {
+                Trading212Column.ACTION: "Deposit",
+                Trading212Column.TIME: "2025-04-01 08:00:00",
+                Trading212Column.TOTAL: "1000.00",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.DEPOSIT_FEE: "0.70",
+                Trading212Column.CURRENCY_DEPOSIT_FEE: "GBP",
+                Trading212Column.TRANSACTION_ID: "deposit-1",
+            },
+        ),
+        _make_row(
+            HEADER_2025_BARE,
+            {
+                Trading212Column.ACTION: "Market buy",
+                Trading212Column.TIME: "2025-04-02 10:30:00",
+                Trading212Column.ISIN: "GB0000000001",
+                Trading212Column.TICKER: "WID",
+                Trading212Column.NAME: "Widget plc",
+                Trading212Column.NO_OF_SHARES: "50",
+                Trading212Column.PRICE_PER_SHARE: "6.00",
+                Trading212Column.CURRENCY_PRICE_PER_SHARE: "GBP",
+                Trading212Column.TOTAL: "301.50",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.STAMP_DUTY: "1.50",
+                Trading212Column.CURRENCY_STAMP_DUTY: "GBP",
+                Trading212Column.TRANSACTION_ID: "buy-1",
+            },
+        ),
+        _make_row(
+            HEADER_2025_BARE,
+            {
+                Trading212Column.ACTION: "Market buy",
+                Trading212Column.TIME: "2025-04-03 11:00:00",
+                Trading212Column.ISIN: "FR0000000002",
+                Trading212Column.TICKER: "FRA",
+                Trading212Column.NAME: "Frenchie SA",
+                Trading212Column.NO_OF_SHARES: "10",
+                Trading212Column.PRICE_PER_SHARE: "20.00",
+                Trading212Column.CURRENCY_PRICE_PER_SHARE: "EUR",
+                Trading212Column.EXCHANGE_RATE: "1.25",
+                Trading212Column.TOTAL: "161.36",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.FRENCH_TRANSACTION_TAX: "0.51",
+                Trading212Column.CURRENCY_FRENCH_TRANSACTION_TAX: "GBP",
+                Trading212Column.CURRENCY_CONVERSION_FEE: "0.85",
+                Trading212Column.CURRENCY_CURRENCY_CONVERSION_FEE: "GBP",
+                Trading212Column.TRANSACTION_ID: "buy-2",
+            },
+        ),
+        _make_row(
+            HEADER_2025_BARE,
+            {
+                Trading212Column.ACTION: "Card credit",
+                Trading212Column.TIME: "2025-04-04 09:00:00",
+                Trading212Column.TOTAL: "25.00",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.TRANSACTION_ID: "card-credit-1",
+            },
+        ),
+        _make_row(
+            HEADER_2025_BARE,
+            {
+                Trading212Column.ACTION: "Dividend (Interest)",
+                Trading212Column.TIME: "2025-04-05 12:00:00",
+                Trading212Column.ISIN: "IE0000000003",
+                Trading212Column.TICKER: "BOND",
+                Trading212Column.NAME: "Bond Fund",
+                Trading212Column.TOTAL: "0.08",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.TRANSACTION_ID: "interest-1",
+            },
+        ),
+        _make_row(
+            HEADER_2025_BARE,
+            {
+                Trading212Column.ACTION: "Dividend (Property income distribution)",
+                Trading212Column.TIME: "2025-04-06 12:00:00",
+                Trading212Column.ISIN: "GB0000000004",
+                Trading212Column.TICKER: "REIT",
+                Trading212Column.NAME: "Property Trust",
+                Trading212Column.TOTAL: "3.20",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.TRANSACTION_ID: "pid-1",
+            },
+        ),
+        _make_row(
+            HEADER_2025_BARE,
+            {
+                Trading212Column.ACTION: "Dividend adjustment",
+                Trading212Column.TIME: "2025-04-07 12:00:00",
+                Trading212Column.ISIN: "GB0000000004",
+                Trading212Column.TICKER: "REIT",
+                Trading212Column.NAME: "Property Trust",
+                Trading212Column.TOTAL: "-0.02",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.TRANSACTION_ID: "div-adj-1",
+            },
+        ),
+        _make_row(
+            HEADER_2025_BARE,
+            {
+                Trading212Column.ACTION: "Spin off",
+                Trading212Column.TIME: "2025-04-08 06:00:00",
+                Trading212Column.ISIN: "US0000000005",
+                Trading212Column.TICKER: "NEWCO",
+                Trading212Column.NAME: "NewCo Inc",
+                Trading212Column.NO_OF_SHARES: "5",
+                Trading212Column.TOTAL: "0.00",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.TRANSACTION_ID: "spin-off-1",
+            },
+        ),
+    ]
+    folder = _prepare_file(tmp_path, rows)
+
+    transactions = Trading212Parser().load_from_dir(folder)
+
+    assert [transaction.action for transaction in transactions] == [
+        ActionType.TRANSFER,
+        ActionType.BUY,
+        ActionType.BUY,
+        ActionType.TRANSFER,
+        ActionType.INTEREST,
+        ActionType.DIVIDEND,
+        ActionType.DIVIDEND,
+        ActionType.SPIN_OFF,
+    ]
+
+    deposit = transactions[0]
+    assert deposit.action == ActionType.TRANSFER
+    assert deposit.amount == Decimal("1000.00")
+
+    buy = transactions[1]
+    assert isinstance(buy, Trading212Transaction)
+    assert buy.amount == Decimal("-301.50")
+    assert buy.stamp_duty == Decimal("1.50")
+    assert buy.fees == Decimal("1.50")
+    assert buy.price == Decimal("6.00")
+
+    buy_french = transactions[2]
+    assert isinstance(buy_french, Trading212Transaction)
+    assert buy_french.amount == Decimal("-161.36")
+    assert buy_french.stamp_duty == Decimal("0.51")
+    assert buy_french.conversion_fee == Decimal("0.85")
+    assert buy_french.fees == Decimal("1.36")
+    assert buy_french.price == Decimal("16.00")
+
+    card_credit = transactions[3]
+    assert card_credit.action == ActionType.TRANSFER
+    assert card_credit.amount == Decimal("25.00")
+
+    interest = transactions[4]
+    assert interest.action == ActionType.INTEREST
+    assert interest.amount == Decimal("0.08")
+    assert interest.symbol == "BOND"
+
+    pid = transactions[5]
+    assert pid.action == ActionType.DIVIDEND
+    assert pid.amount == Decimal("3.20")
+    assert pid.symbol == "REIT"
+
+    dividend_adjustment = transactions[6]
+    assert dividend_adjustment.action == ActionType.DIVIDEND
+    assert dividend_adjustment.amount == Decimal("-0.02")
+
+    spin_off = transactions[7]
+    assert spin_off.action == ActionType.SPIN_OFF
+    assert spin_off.symbol == "NEWCO"
+    assert spin_off.quantity == Decimal(5)
+
+
+def test_read_trading212_transactions_non_gbp_french_tax(tmp_path: Path) -> None:
+    """Raise ParsingError when French transaction tax is not in GBP."""
+
+    rows = [
+        HEADER_2025_BARE,
+        _make_row(
+            HEADER_2025_BARE,
+            {
+                Trading212Column.ACTION: "Market buy",
+                Trading212Column.TIME: "2025-04-03 11:00:00",
+                Trading212Column.ISIN: "FR0000000002",
+                Trading212Column.TICKER: "FRA",
+                Trading212Column.NAME: "Frenchie SA",
+                Trading212Column.NO_OF_SHARES: "10",
+                Trading212Column.PRICE_PER_SHARE: "20.00",
+                Trading212Column.CURRENCY_PRICE_PER_SHARE: "EUR",
+                Trading212Column.TOTAL: "170.00",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.FRENCH_TRANSACTION_TAX: "0.60",
+                Trading212Column.CURRENCY_FRENCH_TRANSACTION_TAX: "EUR",
+                Trading212Column.TRANSACTION_ID: "buy-fr-tax",
+            },
+        ),
+    ]
+    folder = _prepare_file(tmp_path, rows)
+
+    with pytest.raises(ParsingError, match="French transaction tax is not in GBP"):
+        Trading212Parser().load_from_dir(folder)
+
+
+def test_read_trading212_transactions_non_gbp_stamp_duty(tmp_path: Path) -> None:
+    """Raise ParsingError when bare stamp duty is not in GBP."""
+
+    rows = [
+        HEADER_2025_BARE,
+        _make_row(
+            HEADER_2025_BARE,
+            {
+                Trading212Column.ACTION: "Market buy",
+                Trading212Column.TIME: "2025-04-02 10:30:00",
+                Trading212Column.ISIN: "GB0000000001",
+                Trading212Column.TICKER: "WID",
+                Trading212Column.NAME: "Widget plc",
+                Trading212Column.NO_OF_SHARES: "50",
+                Trading212Column.PRICE_PER_SHARE: "6.00",
+                Trading212Column.CURRENCY_PRICE_PER_SHARE: "GBP",
+                Trading212Column.TOTAL: "301.50",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.STAMP_DUTY: "1.50",
+                Trading212Column.CURRENCY_STAMP_DUTY: "EUR",
+                Trading212Column.TRANSACTION_ID: "buy-1",
+            },
+        ),
+    ]
+    folder = _prepare_file(tmp_path, rows)
+
+    with pytest.raises(ParsingError, match="Stamp duty is not in GBP"):
+        Trading212Parser().load_from_dir(folder)
+
+
 def test_read_trading212_transactions_invalid_decimal(tmp_path: Path) -> None:
     """Raise ParsingError when a decimal value is invalid."""
 


### PR DESCRIPTION
Newer Trading 212 exports use bare (non-GBP-suffixed) tax columns and new action labels which currently fail with `Unknown column(s)` / `Unknown action`.

- New columns: `Stamp duty`, `French transaction tax`, `Deposit fee`, `Charge amount` and their `Currency (...)` counterparts.
- Bare stamp duty and French transaction tax are folded into `stamp_duty` (same pattern as SDRT).
- New actions: `Card credit` → TRANSFER, `Dividend (Property income distribution)` and `Dividend adjustment` → DIVIDEND, `Dividend (Interest)` → INTEREST (fund interest distributions are savings income), `Spin off` → SPIN_OFF.

Labels were cross-checked against other open-source Trading 212 parsers. `Stock split open/close` and `Transfer in/out` are deliberately left unmapped: split pairs don't fit the single-row STOCK_SPLIT model and real export rows appear column-shifted, and share transfers need engine support (same gap as #458).