### PR TITLE
Add shell completions via shtab

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ brokers that pay daily interest.
 - [Prerequisites](#-prerequisites)
 - [Installation](#%EF%B8%8F-installation)
   - [Installing LaTeX](#installing-latex)
+  - [Shell Completions](#shell-completions)
 - [Usage](#-usage)
 - [Terminal Output](#%EF%B8%8F-terminal-output)
 - [Input Data](#-input-data)
@@ -84,6 +85,24 @@ apt install texlive-latex-base
 #### Windows
 
 [Install MiKTeX.](https://miktex.org/download)
+
+### Shell Completions
+
+`cgt-calc` can generate a tab completion script for `bash`, `zsh`, `fish` and `tcsh`. Save it where
+your shell looks for completions, e.g.:
+
+```shell
+# bash
+cgt-calc --print-completion bash > ~/.local/share/bash-completion/completions/cgt-calc
+
+# zsh (the target directory must be in your $fpath)
+cgt-calc --print-completion zsh > ~/.zfunc/_cgt-calc
+
+# fish
+cgt-calc --print-completion fish > ~/.config/fish/completions/cgt-calc.fish
+```
+
+Regenerate the script after upgrading to pick up new options.
 
 ## 🚀 Usage
 

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -7,11 +7,14 @@ import datetime
 import importlib.metadata
 import logging
 
+import shtab
+
 from .args_validators import (
     DeprecatedAction,
     existing_file_type,
     optional_file_type,
     output_path_type,
+    set_completer,
     ticker_list_type,
     year_type,
 )
@@ -64,11 +67,15 @@ Environment variables:
 
     # Additional Data Files
     data_group = parser.add_argument_group("Additional data files")
-    data_group.add_argument(
-        "--initial-prices-file",
-        type=existing_file_type,
-        metavar="PATH",
-        help="stock prices in USD at key events (vesting, splits, etc.) in CSV format",
+    set_completer(
+        data_group.add_argument(
+            "--initial-prices-file",
+            type=existing_file_type,
+            metavar="PATH",
+            help="stock prices in USD at key events (vesting, splits, etc.) "
+            "in CSV format",
+        ),
+        shtab.FILE,
     )
     data_group.add_argument(
         "--initial-prices",
@@ -77,26 +84,35 @@ Environment variables:
         type=existing_file_type,
         help=argparse.SUPPRESS,
     )
-    data_group.add_argument(
-        "--exchange-rates-file",
-        type=optional_file_type,
-        metavar="PATH",
-        default=DEFAULT_EXCHANGE_RATES_FILE,
-        help="monthly exchange rates in CSV format (generated automatically if missing; default: %(default)s)",
+    set_completer(
+        data_group.add_argument(
+            "--exchange-rates-file",
+            type=optional_file_type,
+            metavar="PATH",
+            default=DEFAULT_EXCHANGE_RATES_FILE,
+            help="monthly exchange rates in CSV format (generated automatically if missing; default: %(default)s)",
+        ),
+        shtab.FILE,
     )
-    data_group.add_argument(
-        "--isin-translation-file",
-        type=optional_file_type,
-        default=DEFAULT_ISIN_TRANSLATION_FILE,
-        metavar="PATH",
-        help="ISIN to ticker translations in CSV format (generated automatically if missing; default: %(default)s)",
+    set_completer(
+        data_group.add_argument(
+            "--isin-translation-file",
+            type=optional_file_type,
+            default=DEFAULT_ISIN_TRANSLATION_FILE,
+            metavar="PATH",
+            help="ISIN to ticker translations in CSV format (generated automatically if missing; default: %(default)s)",
+        ),
+        shtab.FILE,
     )
-    data_group.add_argument(
-        "--spin-offs-file",
-        type=optional_file_type,
-        metavar="PATH",
-        default=DEFAULT_SPIN_OFF_FILE,
-        help="spin-offs data in CSV format (default: %(default)s)",
+    set_completer(
+        data_group.add_argument(
+            "--spin-offs-file",
+            type=optional_file_type,
+            metavar="PATH",
+            default=DEFAULT_SPIN_OFF_FILE,
+            help="spin-offs data in CSV format (default: %(default)s)",
+        ),
+        shtab.FILE,
     )
 
     # Calculation Options
@@ -127,13 +143,16 @@ Environment variables:
     output_group = parser.add_argument_group("Output")
 
     output_mutex = output_group.add_mutually_exclusive_group()
-    output_mutex.add_argument(
-        "-o",
-        "--output",
-        type=output_path_type,
-        metavar="PATH",
-        default=DEFAULT_REPORT_PATH,
-        help="path to save the generated PDF report (default: %(default)s)",
+    set_completer(
+        output_mutex.add_argument(
+            "-o",
+            "--output",
+            type=output_path_type,
+            metavar="PATH",
+            default=DEFAULT_REPORT_PATH,
+            help="path to save the generated PDF report (default: %(default)s)",
+        ),
+        shtab.FILE,
     )
     output_mutex.add_argument(
         "--report",
@@ -162,6 +181,11 @@ Environment variables:
         action="version",
         version=f"cgt-calc {importlib.metadata.version(__package__)}",
         help="show version and exit",
+    )
+    shtab.add_argument_to(
+        general_group,  # type: ignore[arg-type]  # groups work like parsers here
+        "--print-completion",
+        help="print shell tab completion script and exit",
     )
     general_group.add_argument(
         "-v",

--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -115,6 +115,13 @@ def existing_directory_type(value: str) -> Path:
     return _existing_path_type(value, require_dir=True)
 
 
+def set_completer(
+    action: argparse.Action, completer: dict[str, str | dict[str, str]]
+) -> None:
+    """Attach shtab completion hint (e.g. shtab.FILE) to an argparse action."""
+    action.complete = completer  # type: ignore[attr-defined]
+
+
 class DeprecatedAction(argparse.Action):
     """Print warning when deprecated argument is used."""
 

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -9,11 +9,14 @@ from pathlib import Path
 import sys
 from typing import ClassVar, TextIO, override
 
+import shtab
+
 from cgt_calc.args_validators import (
     STDIN_PATH,
     DeprecatedAction,
     existing_directory_type,
     existing_file_type,
+    set_completer,
 )
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
 from cgt_calc.logging import parsing_msg
@@ -59,12 +62,16 @@ class BaseSingleFileParser(BaseParser):
     @override
     def register_arguments(cls, arg_group: argparse._ArgumentGroup) -> None:
         """Register argparse arguments for this broker."""
-        arg_group.add_argument(
-            f"--{cls.full_arg}",
-            type=existing_file_type,
-            default=None,
-            metavar="PATH",
-            help=f"{cls.pretty_name} transaction history in {cls.format_name} format",
+        set_completer(
+            arg_group.add_argument(
+                f"--{cls.full_arg}",
+                type=existing_file_type,
+                default=None,
+                metavar="PATH",
+                help=f"{cls.pretty_name} transaction history "
+                f"in {cls.format_name} format",
+            ),
+            shtab.FILE,
         )
         for deprecated_flag in cls.deprecated_flags:
             arg_group.add_argument(
@@ -218,12 +225,16 @@ class BaseDirParser(BaseSingleFileParser):
     @override
     def register_arguments(cls, arg_group: argparse._ArgumentGroup) -> None:
         """Register argparse arguments for this broker."""
-        arg_group.add_argument(
-            f"--{cls.full_arg}",
-            type=existing_directory_type,
-            default=None,
-            metavar="DIR",
-            help=f"directory with {cls.pretty_name} reports in {cls.format_name} format",
+        set_completer(
+            arg_group.add_argument(
+                f"--{cls.full_arg}",
+                type=existing_directory_type,
+                default=None,
+                metavar="DIR",
+                help=f"directory with {cls.pretty_name} reports "
+                f"in {cls.format_name} format",
+            ),
+            shtab.DIRECTORY,
         )
         for deprecated_flag in cls.deprecated_flags:
             arg_group.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   "openpyxl>=3.1.5",
   "xlrd>=2.0.2",
   "iso4217parse>=0.6.2",
+  "shtab>=1.11.0",
 ]
 
 [project.urls]

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -30,6 +30,40 @@ ReturnType = TextIO | IO[bytes]
 DirIterator = Iterator[Path]
 
 
+@pytest.mark.parametrize("shell", ["bash", "zsh", "fish", "tcsh"])
+def test_print_completion_outputs_script(
+    shell: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test that --print-completion prints a completion script and exits."""
+    parser = create_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--print-completion", shell])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "--trading212-dir" in output
+    assert "--initial-prices-file" in output
+
+
+def test_print_completion_zsh_completes_paths(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test path completers and hidden deprecated flags in the zsh script."""
+    parser = create_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--print-completion", "zsh"])
+
+    output = capsys.readouterr().out
+    # Directory options complete directories, file options complete files.
+    assert ":DIR:_files -/" in output
+    assert ":PATH:_files" in output
+    # Deprecated aliases are hidden from help and must not be completed.
+    assert '"--report[' not in output
+    assert '"--trading212[' not in output
+
+
 def test_output_and_no_report_mutually_exclusive() -> None:
     """Test that --output and --no-report are mutually exclusive."""
     parser = create_parser()

--- a/uv.lock
+++ b/uv.lock
@@ -170,6 +170,7 @@ dependencies = [
     { name = "pdfplumber" },
     { name = "pyrate-limiter" },
     { name = "requests" },
+    { name = "shtab" },
     { name = "xlrd" },
     { name = "yfinance" },
 ]
@@ -205,6 +206,7 @@ requires-dist = [
     { name = "pdfplumber", specifier = ">=0.11.9" },
     { name = "pyrate-limiter", specifier = ">=4.0.0" },
     { name = "requests", specifier = ">=2.27.1" },
+    { name = "shtab", specifier = ">=1.11.0" },
     { name = "xlrd", specifier = ">=2.0.2" },
     { name = "yfinance", specifier = ">=1.6.0" },
 ]
@@ -1387,6 +1389,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
     { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
     { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
+]
+
+[[package]]
+name = "shtab"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/1e/6abd32b6c79e64b8e2e2027b05a65ff5215d913997de4fb973f248f79350/shtab-1.11.0.tar.gz", hash = "sha256:57df8a646484b3f00517a42934b173554f827976a77b605ceb6a1a0e649e9266", size = 58653, upload-time = "2026-08-15T21:56:22.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/15/81365f3f0e06614bfabdf5b86bc0c4dc0753bdcce29229a40c5742dee2b2/shtab-1.11.0-py3-none-any.whl", hash = "sha256:87c4ccd586a0d98f41c5d15a4a2da4957ea67ba2ec588561fdb803b612bfd032", size = 17483, upload-time = "2026-08-15T21:56:20.874Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a `--print-completion {bash,zsh,tcsh,fish}` flag powered by [shtab](https://github.com/iterative/shtab) (pure-Python, no transitive dependencies).

- `--*-file` options complete file paths and `--*-dir` options complete directories, wired once in the broker base parsers so new brokers get it automatically.
- Hidden deprecated aliases are excluded from completion.
- Static generation means no Python startup cost on TAB, unlike argcomplete.
- README documents installation per shell.

PowerShell is deliberately out of scope until iterative/shtab#212 lands.