### PR TITLE
Fix file completion for --schwab-award-file

### DIFF
--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -12,7 +12,9 @@ from enum import StrEnum
 import logging
 from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
 
-from cgt_calc.args_validators import DeprecatedAction, existing_file_type
+import shtab
+
+from cgt_calc.args_validators import DeprecatedAction, existing_file_type, set_completer
 from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import (
     ParsingError,
@@ -678,12 +680,15 @@ class SchwabParser(BaseSingleFileParser):
     @override
     def register_arguments(cls, arg_group: argparse._ArgumentGroup) -> None:
         """Register argparse arguments for this broker."""
-        arg_group.add_argument(
-            "--schwab-award-file",
-            type=existing_file_type,
-            default=None,
-            metavar="PATH",
-            help="Charles Schwab Equity Awards transaction history in CSV format",
+        set_completer(
+            arg_group.add_argument(
+                "--schwab-award-file",
+                type=existing_file_type,
+                default=None,
+                metavar="PATH",
+                help="Charles Schwab Equity Awards transaction history in CSV format",
+            ),
+            shtab.FILE,
         )
         arg_group.add_argument(
             "--schwab-award",

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -64,6 +64,24 @@ def test_print_completion_zsh_completes_paths(
     assert '"--trading212[' not in output
 
 
+def test_print_completion_zsh_covers_all_path_options(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that every PATH/DIR option in the zsh script completes paths."""
+    parser = create_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--print-completion", "zsh"])
+
+    output = capsys.readouterr().out
+    missing = [
+        line.strip()
+        for line in output.splitlines()
+        if (":PATH:" in line or ":DIR:" in line) and "_files" not in line
+    ]
+    assert not missing, f"options without a path completer: {missing}"
+
+
 def test_output_and_no_report_mutually_exclusive() -> None:
     """Test that --output and --no-report are mutually exclusive."""
     parser = create_parser()


### PR DESCRIPTION
`SchwabParser.register_arguments` registers `--schwab-award-file` directly, bypassing the base-class registration where the shtab completer is attached, so the generated scripts had no file completion for it.

Wraps it in `set_completer(..., shtab.FILE)` and adds a regression test asserting every PATH/DIR option in the generated zsh script carries a path completer.