### PR TITLE
Add --from/--to for custom reporting periods

### DIFF
--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -11,6 +11,7 @@ import shtab
 
 from .args_validators import (
     DeprecatedAction,
+    date_type,
     existing_file_type,
     optional_file_type,
     output_path_type,
@@ -24,6 +25,7 @@ from .const import (
     DEFAULT_REPORT_PATH,
     DEFAULT_SPIN_OFF_FILE,
 )
+from .dates import get_tax_year_end, get_tax_year_for_date, get_tax_year_start
 from .parsers.broker_registry import BrokerRegistry
 
 LOGGER = logging.getLogger(__name__)
@@ -57,8 +59,24 @@ Environment variables:
         "--year",
         type=year_type,
         metavar="YYYY",
-        default=get_last_elapsed_tax_year(),
-        help="first year of the UK tax year (e.g. 2024 for tax year 2024/25; default: %(default)d)",
+        default=None,
+        help="first year of the UK tax year (e.g. 2024 for tax year 2024/25; "
+        f"default: {get_last_elapsed_tax_year()})",
+    )
+    year_group.add_argument(
+        "--from",
+        dest="period_from",
+        type=date_type,
+        metavar="YYYY-MM-DD",
+        help="start of a custom reporting period, e.g. for the HMRC 2024/25 "
+        "CGT adjustment calculation (requires --to, incompatible with --year)",
+    )
+    year_group.add_argument(
+        "--to",
+        dest="period_to",
+        type=date_type,
+        metavar="YYYY-MM-DD",
+        help="end of a custom reporting period (requires --from)",
     )
 
     # Broker Inputs
@@ -200,3 +218,30 @@ Environment variables:
         help=argparse.SUPPRESS,
     )
     return parser
+
+
+def resolve_reporting_period(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> None:
+    """Validate --year/--from/--to and resolve the effective tax year.
+
+    Sets args.year from the custom period when --from/--to are used,
+    or to the last elapsed tax year when nothing is specified.
+    """
+    if args.period_from is None and args.period_to is None:
+        if args.year is None:
+            args.year = get_last_elapsed_tax_year()
+        return
+    if args.period_from is None or args.period_to is None:
+        parser.error("--from and --to must be used together")
+    if args.year is not None:
+        parser.error("--year cannot be combined with --from/--to")
+    if args.period_from > args.period_to:
+        parser.error("--from must not be after --to")
+    tax_year = get_tax_year_for_date(args.period_from)
+    if tax_year != get_tax_year_for_date(args.period_to):
+        parser.error(
+            "--from and --to must be within the same UK tax year, "
+            f"e.g. {get_tax_year_start(tax_year)} to {get_tax_year_end(tax_year)}"
+        )
+    args.year = tax_year

--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -37,6 +37,16 @@ def year_type(value: str) -> int:
     return year
 
 
+def date_type(value: str) -> datetime.date:
+    """Validate and convert ISO format date argument."""
+    try:
+        return datetime.date.fromisoformat(value)
+    except ValueError as err:
+        raise argparse.ArgumentTypeError(
+            f"invalid date value: '{value}', expected YYYY-MM-DD"
+        ) from err
+
+
 def ticker_list_type(value: str) -> list[str]:
     """Split comma-separated tickers and convert to uppercase list."""
     return [ticker.strip().upper() for ticker in value.split(",") if ticker.strip()]

--- a/cgt_calc/dates.py
+++ b/cgt_calc/dates.py
@@ -20,3 +20,10 @@ def get_tax_year_end(tax_year: int) -> datetime.date:
     """Return tax year end date."""
     # 5 April
     return datetime.date(tax_year + 1, 4, 5)
+
+
+def get_tax_year_for_date(date: datetime.date) -> int:
+    """Return the first year of the UK tax year containing the given date."""
+    if date >= get_tax_year_start(date.year):
+        return date.year
+    return date.year - 1

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from colorama import Fore, Style
 
 from . import render_latex
-from .args_parser import create_parser
+from .args_parser import create_parser, resolve_reporting_period
 from .const import (
     BALANCE_CHECK_CONTEXT_ROWS,
     BED_AND_BREAKFAST_DAYS,
@@ -162,12 +162,20 @@ class CapitalGainsCalculator:
         *,
         balance_check: bool = True,
         calc_unrealized_gains: bool = False,
+        period_start: datetime.date | None = None,
+        period_end: datetime.date | None = None,
     ):
-        """Create calculator object."""
-        self.tax_year = tax_year
+        """Create calculator object.
 
-        self.tax_year_start_date = get_tax_year_start(tax_year)
-        self.tax_year_end_date = get_tax_year_end(tax_year)
+        period_start/period_end narrow the reporting window within the
+        tax year, e.g. for the HMRC 2024/25 CGT adjustment calculation.
+        """
+        self.tax_year = tax_year
+        self.period_start = period_start
+        self.period_end = period_end
+
+        self.tax_year_start_date = period_start or get_tax_year_start(tax_year)
+        self.tax_year_end_date = period_end or get_tax_year_end(tax_year)
 
         self.currency_converter = currency_converter
         self.isin_converter = isin_converter
@@ -1540,6 +1548,8 @@ class CapitalGainsCalculator:
             round_decimal(self.total_foreign_interest, 2),
             round_decimal(self.total_interest_tax, 2),
             show_unrealized_gains=self.calc_unrealized_gains,
+            period_start=self.period_start,
+            period_end=self.period_end,
         )
 
     def make_portfolio_entry(
@@ -1587,6 +1597,8 @@ def calculate_cgt(args: argparse.Namespace) -> None:
         args.interest_fund_tickers,
         balance_check=args.balance_check,
         calc_unrealized_gains=args.calc_unrealized_gains,
+        period_start=args.period_from,
+        period_end=args.period_to,
     )
     # First pass converts broker transactions to HMRC transactions.
     # This means applying same day rule and collapsing all transactions with
@@ -1631,6 +1643,7 @@ def main() -> int:
         return 0
 
     args = parser.parse_args()
+    resolve_reporting_period(parser, args)
 
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -388,6 +388,22 @@ class CapitalGainsReport:
     total_foreign_interest: Decimal
     total_interest_tax: Decimal
     show_unrealized_gains: bool
+    # Custom reporting period within the tax year, if one was requested.
+    period_start: datetime.date | None = None
+    period_end: datetime.date | None = None
+
+    def period_label(self) -> str | None:
+        """Label for a custom reporting period, None for a full tax year."""
+        if self.period_start is None or self.period_end is None:
+            return None
+        return f"period {self.period_start} to {self.period_end}"
+
+    @property
+    def title_period(self) -> str:
+        """Reporting period rendered in the PDF report title."""
+        if self.period_start is not None and self.period_end is not None:
+            return f"{self.period_start} to {self.period_end}"
+        return f"{self.tax_year}-{(self.tax_year + 1) % 100:02d}"
 
     def _filter_calculation_log(
         self, calculation_log: CalculationLog, rule_type: RuleType
@@ -473,9 +489,12 @@ class CapitalGainsReport:
     def __str__(self) -> str:
         """Return string representation."""
         bul = bullet(sys.stdout)
+        portfolio_label = (
+            self.period_label() or f"{self.tax_year}/{self.tax_year + 1} tax year"
+        )
         out = (
             style_text(
-                f"Portfolio at the end of {self.tax_year}/{self.tax_year + 1} tax year",
+                f"Portfolio at the end of {portfolio_label}",
                 colour=Style.BRIGHT,
                 emoji="📈",
             )
@@ -498,7 +517,8 @@ class CapitalGainsReport:
         out += "\n"
         out += (
             style_text(
-                f"Tax summary for {self.tax_year}/{self.tax_year + 1}",
+                "Tax summary for "
+                f"{self.period_label() or f'{self.tax_year}/{self.tax_year + 1}'}",
                 colour=Style.BRIGHT,
                 emoji="🧮",
             )

--- a/cgt_calc/resources/template.tex.j2
+++ b/cgt_calc/resources/template.tex.j2
@@ -3,7 +3,7 @@
 \usepackage[margin=3cm]{geometry}
 \setlength{\parindent}{0pt} %--don't indent paragraphs
 \begin{document}
-\centerline{\Large\bfseries Capital Gains Tax Calculations for \VAR{ report.tax_year }-\VAR{ ("{:02d}".format((report.tax_year + 1) % 100)) }}
+\centerline{\Large\bfseries Capital Gains Tax Calculations for \VAR{ report.title_period }}
 
 \BLOCK{ set total_gain = namespace(value=Decimal(0)) }
 \BLOCK{ set total_loss = namespace(value=Decimal(0)) }

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -11,7 +11,11 @@ from typing import IO, TextIO, cast
 
 import pytest
 
-from cgt_calc.args_parser import create_parser
+from cgt_calc.args_parser import (
+    create_parser,
+    get_last_elapsed_tax_year,
+    resolve_reporting_period,
+)
 from cgt_calc.args_validators import (
     STDIN_PATH,
     existing_directory_type,
@@ -576,3 +580,61 @@ def test_initial_prices_alias_warns_deprecated(
     assert args.initial_prices_file == file_path
     assert "Option '--initial-prices' is deprecated" in caplog.text
     assert "--initial-prices-file" in caplog.text
+
+
+def test_resolve_period_from_to() -> None:
+    """Test that --from/--to resolve the tax year from the range."""
+    parser = create_parser()
+    args = parser.parse_args(["--from", "2024-04-06", "--to", "2024-10-29"])
+
+    resolve_reporting_period(parser, args)
+
+    assert args.year == 2024
+    assert args.period_from == datetime.date(2024, 4, 6)
+    assert args.period_to == datetime.date(2024, 10, 29)
+
+
+def test_resolve_period_defaults_year_when_absent() -> None:
+    """Test that --year defaults to the last elapsed tax year."""
+    parser = create_parser()
+    args = parser.parse_args([])
+
+    resolve_reporting_period(parser, args)
+
+    assert args.year == get_last_elapsed_tax_year()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        # --from and --to must be used together.
+        ["--from", "2024-04-06"],
+        ["--to", "2024-10-29"],
+        # --year cannot be combined with a custom period.
+        ["--year", "2024", "--from", "2024-04-06", "--to", "2024-10-29"],
+        # --from must not be after --to.
+        ["--from", "2024-10-29", "--to", "2024-04-06"],
+        # The period must stay within one UK tax year.
+        ["--from", "2024-04-05", "--to", "2024-04-06"],
+        ["--from", "2024-10-29", "--to", "2025-04-06"],
+    ],
+)
+def test_resolve_period_rejects_invalid_combinations(argv: list[str]) -> None:
+    """Test that invalid --year/--from/--to combinations exit with an error."""
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    with pytest.raises(SystemExit) as exc_info:
+        resolve_reporting_period(parser, args)
+
+    assert exc_info.value.code == 2
+
+
+def test_from_rejects_invalid_date() -> None:
+    """Test that malformed dates are rejected at parse time."""
+    parser = create_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--from", "2024-13-01", "--to", "2024-12-31"])
+
+    assert exc_info.value.code == 2

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -19,7 +19,7 @@ from cgt_calc.exceptions import CalculationError, InvalidTransactionError
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.main import CapitalGainsCalculator, main
-from cgt_calc.model import ActionType, BrokerTransaction, RuleType
+from cgt_calc.model import ActionType, BrokerTransaction, CapitalGainsReport, RuleType
 from cgt_calc.parsers.broker_registry import _transaction_sort_key
 from cgt_calc.parsers.eri.model import ERITransaction
 from cgt_calc.spin_off_handler import SpinOffHandler
@@ -38,7 +38,7 @@ from .calc_test_data_2 import calc_basic_data_2
 if TYPE_CHECKING:
     import argparse
 
-    from cgt_calc.model import CalculationLog, CapitalGainsReport
+    from cgt_calc.model import CalculationLog
 
 
 # USD to GBP exchange rate used in tests (creates repeating decimals)
@@ -1066,3 +1066,74 @@ def test_negative_balance_error_shows_only_relevant_transactions() -> None:
     assert message.count("Balance after transaction=") == 3
     assert "currency='EUR'" not in message
     assert "Split of FOO" not in message
+
+
+def test_custom_period_narrows_reporting_window() -> None:
+    """Only dates inside the custom period count towards the report."""
+    currency_converter = CurrencyConverter(None, {})
+    calculator = CapitalGainsCalculator(
+        2024,
+        currency_converter,
+        IsinConverter(),
+        CurrentPriceFetcher(currency_converter, {}, {}),
+        SpinOffHandler(),
+        InitialPrices(),
+        interest_fund_tickers=[],
+        balance_check=False,
+        period_start=datetime.date(2024, 4, 6),
+        period_end=datetime.date(2024, 10, 29),
+    )
+
+    assert calculator.date_in_tax_year(datetime.date(2024, 10, 29))
+    assert not calculator.date_in_tax_year(datetime.date(2024, 10, 30))
+    assert calculator.tax_year_end_date == datetime.date(2024, 10, 29)
+
+
+def test_report_labels_custom_period() -> None:
+    """Report headings and title show the custom period when set."""
+    report = CapitalGainsReport(
+        2024,
+        [],
+        0,
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        None,
+        None,
+        {},
+        {},
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        show_unrealized_gains=False,
+        period_start=datetime.date(2024, 4, 6),
+        period_end=datetime.date(2024, 10, 29),
+    )
+
+    assert report.title_period == "2024-04-06 to 2024-10-29"
+    assert "period 2024-04-06 to 2024-10-29" in str(report)
+
+
+def test_report_labels_full_tax_year() -> None:
+    """Report headings keep the tax year wording without a custom period."""
+    report = CapitalGainsReport(
+        2024,
+        [],
+        0,
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        None,
+        None,
+        {},
+        {},
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        show_unrealized_gains=False,
+    )
+
+    assert report.title_period == "2024-25"
+    assert "Tax summary for 2024/2025" in str(report)


### PR DESCRIPTION
Fixes #721.

Adds `--from YYYY-MM-DD` / `--to YYYY-MM-DD` to report on a sub-period of a tax year, e.g. for the [HMRC 2024/25 CGT adjustment calculation](https://www.tax.service.gov.uk/guidance/work-out-your-capital-gains-tax-adjustment-for-2024-to-2025-tax-year/start/completing-tax-return).

Validation per the issue discussion: `--year` XOR (`--from` AND `--to`), and the period must lie within a single UK tax year (hard error otherwise). The effective tax year (for allowances and rates) is derived from the range. Report headings and the PDF title show the custom period.