### PR TITLE
Support Schwab forced disbursement and forced quick sell

### DIFF
--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -222,7 +222,7 @@ def action_from_str(label: str, file: Path) -> ActionType:
     if label == "Buy":
         return ActionType.BUY
 
-    if label in {"Sell", "Sale"}:
+    if label in {"Sell", "Sale", "Forced Quick Sell"}:
         return ActionType.SELL
 
     if label in {
@@ -234,6 +234,9 @@ def action_from_str(label: str, file: Path) -> ActionType:
         "Funds Received",
         "Journal",
         "Cash In Lieu",
+        # Proceeds of the historical autosale programme wired out of the
+        # account, see https://github.com/KapJI/capital-gains-calculator/issues/488
+        "Forced Disbursement",
     }:
         return ActionType.TRANSFER
 
@@ -677,7 +680,7 @@ class SchwabTransaction(BrokerTransaction):
                     f"{details[names.award_date]} "
                     f"(ID {details[names.award_id]})"
                 )
-        elif row[names.action] == "Sale":
+        elif row[names.action] in ("Sale", "Forced Quick Sell"):
             date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
 
             if _restates_acquisitions_only(symbol):
@@ -765,7 +768,13 @@ class SchwabTransaction(BrokerTransaction):
                     ):
                         quantity = (amount + fees) / price
 
-        elif action in [ActionType.DIVIDEND, ActionType.DIVIDEND_TAX]:
+        elif action in [
+            ActionType.DIVIDEND,
+            ActionType.DIVIDEND_TAX,
+            # Pure cash movements, e.g. Forced Disbursement wiring out the
+            # proceeds of the autosale programme.
+            ActionType.TRANSFER,
+        ]:
             date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
             price = None
             amount = _decimal_from_str(row[names.amount])

--- a/tests/schwab/test_schwab_equity_award_json.py
+++ b/tests/schwab/test_schwab_equity_award_json.py
@@ -264,6 +264,8 @@ def test_split_history_demands_a_price_floor_it_can_use() -> None:
         ("Buy", ActionType.BUY),
         ("Sale", ActionType.SELL),
         ("Sell", ActionType.SELL),
+        ("Forced Quick Sell", ActionType.SELL),
+        ("Forced Disbursement", ActionType.TRANSFER),
         ("Deposit", ActionType.STOCK_ACTIVITY),
         ("Qualified Dividend", ActionType.DIVIDEND),
         ("Cash Dividend", ActionType.DIVIDEND),
@@ -340,6 +342,25 @@ def test_unknown_symbol_warns(caplog: pytest.LogCaptureFixture) -> None:
     assert "check the share counts" in caplog.text
     assert transactions[0].action == ActionType.DIVIDEND
     assert transactions[0].amount == Decimal(10)
+
+
+def test_forced_disbursement_parses_as_transfer() -> None:
+    """Parse the Forced Disbursement sample from issue #488."""
+    content = (
+        '{"Transactions": [{"Date": "03/31/2015", "Action": "Forced Disbursement",'
+        ' "Symbol": "GOOG", "Quantity": null, "Description": "Debit",'
+        ' "FeesAndCommissions": null, "DisbursementElection": null,'
+        ' "Amount": "-$2,490.13", "TransactionDetails": []}]}'
+    )
+
+    transactions = _read_json(content)
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert transaction.action == ActionType.TRANSFER
+    assert transaction.amount == Decimal("-2490.13")
+    assert transaction.date == datetime.date(2015, 3, 31)
+    assert transaction.quantity is None or transaction.quantity == 0
 
 
 def test_unimplemented_action_raises() -> None:


### PR DESCRIPTION
Fixes #488.

The historical Schwab autosale programme produced `Forced Quick Sell` (sale of shares) and `Forced Disbursement` (proceeds wired out) rows in the Equity Awards JSON, which crash the parser with `Unknown action`.

- `Forced Disbursement` → TRANSFER, handled as a pure cash movement (the row carries only a negative amount — sample in the issue).
- `Forced Quick Sell` → SELL, routed through the existing Sale branch.

The empty-string `FeesAndCommissions` part of the issue was already fixed by an earlier change. No real `Forced Quick Sell` sample is available, so that path relies on the Sale logic and fails loudly if fields are missing.