### PR TITLE
Fix inaccurate docstrings, comments, and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,11 @@ We use:
 - [shfmt](https://github.com/mvdan/sh#shfmt) - for formatting shell scripts
 - [markdown-link-check](https://github.com/tcort/markdown-link-check) - for checking links in
   Markdown
+- [codespell](https://github.com/codespell-project/codespell) - for catching common misspellings
 
 `prek` can be used to run all checks with one command (see below).
 
-The project uses **Python 3.12** as the minimum supported version
+The project uses **Python 3.12** as the minimum supported version.
 
 ## 🚸 Prek
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@
 Easily calculate **UK Capital Gains Tax** from your investment transaction history.
 
 Supported sources include **Charles Schwab**, **Trading 212**, **Morgan Stanley**, **Sharesight**,
-**Hargreaves Lansdown**, **Vanguard**, **Freetrade**, or a custom **RAW** format.
+**Hargreaves Lansdown**, **Vanguard**, **Freetrade**, **Interactive Brokers**, or a custom **RAW**
+format.
 
 The tool generates a detailed **PDF report** with all calculations.
 
 All prices are automatically converted to **GBP**, and all **HMRC rules** are applied — including
 the **same-day**, **bed and breakfast**, and **Section 104 holding** rules.
 
-The PDF report includes separate **Capital Gains** and **Interest and Dividens** sections, with a
+The PDF report includes separate **Capital Gains** and **Interest and Dividends** sections, with a
 summary at the end. Interest is grouped **monthly per broker** to keep reports concise, even for
 brokers that pay daily interest.
 
@@ -121,13 +122,13 @@ Regenerate the script after upgrading to pick up new options.
   [Broker Instructions](#broker-instructions).
 - The history should include **all transactions** since you first acquired any shares owned during
   the relevant tax years.
-- If you own or have owned **funds from outside the UK** (i.e. Ireland), either them being
-  accumulating or distributing, see the [Offshore Funds](#offshore-funds).
+- If you own or have owned **funds from outside the UK** (e.g. Ireland), whether accumulating or
+  distributing, see the [Offshore Funds](#offshore-funds).
 - Once you've gathered all transactions from all your brokers, generate a report — for example, for
   tax year 2020/21:
 
 ```shell
-cgt-calc --year 2020 --schwab schwab_transactions.csv --trading212-dir trading212/ --mssb-dir mmsb_report/
+cgt-calc --year 2020 --schwab-file schwab_transactions.csv --trading212-dir trading212/ --mssb-dir mssb_report/
 ```
 
 - Run `cgt-calc --help` for all available options.
@@ -156,9 +157,9 @@ keep colours but drop emoji. Use `--verbose` for debug-level detail.
 
 You will need:
 
-- **Exported transaction history in CSV format.** Schwab only allows to download transaction for the
-  last 4 years. If you require more, you can download the history in 4-year chunks and combine them.
-  [See example](tests/schwab/data/schwab_transactions.csv).
+- **Exported transaction history in CSV format.** Schwab only allows you to download transactions
+  for the last 4 years. If you require more, you can download the history in 4-year chunks and
+  combine them. [See example](tests/schwab/data/schwab_transactions.csv).
 - **Exported transaction history from Schwab Equity Awards in CSV format.** Only applicable if you
   receive equity awards in your account (e.g. for Alphabet/Google employees). Follow the same
   procedure as in the normal transaction history but selecting your Equity Award account.
@@ -166,7 +167,7 @@ You will need:
 Example usage for the tax year 2020/21:
 
 ```shell
-cgt-calc --year 2020 --schwab schwab_transactions.csv --schwab-award schwab_awards.csv
+cgt-calc --year 2020 --schwab-file schwab_transactions.csv --schwab-award-file schwab_awards.csv
 ```
 
 _Note: For historic reasons, it is possible to provide the Equity Awards history in JSON format with
@@ -416,7 +417,8 @@ Currently bundled data:
 
 The ERI funds are indexed by ISIN and the tool provides automatic translation from ISIN to tickers,
 in case your broker doesn't supply the ISIN in their transaction history. For instructions on how to
-override ISIN translation look at the Extra options section below.
+override ISIN translation see the **ISIN to ticker translation** entry in the
+[Configuration Files and Data Sources](#configuration-files-and-data-sources) section below.
 
 There are a few **unsupported** functionalities at the moment for taxation on offshore funds:
 
@@ -427,7 +429,7 @@ There are a few **unsupported** functionalities at the moment for taxation on of
   is an optional arrangement which certain funds can support to reduce the amount of excess reported
   income in case you held the fund stocks for less than the reporting period.
 
-Check [ERI data additional instrunctions](docs/excess_reported_income_sources.md) for more
+Check [ERI data additional instructions](docs/excess_reported_income_sources.md) for more
 information.
 
 ### Configuration Files and Data Sources
@@ -480,7 +482,7 @@ a4800eca1914:/data# cgt-calc [...]
 This will create a temporary Docker container with the current directory on the host (where your
 transaction data is) mounted inside the container at `/data`. Follow the usage instructions below as
 normal, and when you're done, simply exit the shell. You will be dropped back into the shell on your
-host, with your output report pdf etc..
+host, with your output report PDF etc.
 
 You can also run a single command directly:
 

--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -49,6 +49,7 @@ class CurrencyConverter:
             **(initial_data or {}),
         }
 
+        # Limit borrowed from the Companies House API guidance:
         # https://developer-specs.company-information.service.gov.uk/guides/rateLimiting
         limiter = limiter_factory.create_inmemory_limiter(
             rate_per_duration=600, duration=Duration.MINUTE * 5
@@ -241,7 +242,7 @@ class CurrencyConverter:
     def currency_to_gbp_rate(self, currency: str, date: datetime.date) -> Decimal:
         """Get the number of currency units per GBP at the given date."""
         assert is_date(date)
-        # offshore (Honk Kong) Chinese Yuan handling
+        # offshore (Hong Kong) Chinese Yuan handling
         if currency == "CNH":
             currency = "CNY"
         if date not in self.cache:

--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -239,7 +239,7 @@ class CurrencyConverter:
         self._write_exchange_rates_file(self.exchange_rates_file, self.cache)
 
     def currency_to_gbp_rate(self, currency: str, date: datetime.date) -> Decimal:
-        """Get GBP/currency rate at given date."""
+        """Get the number of currency units per GBP at the given date."""
         assert is_date(date)
         # offshore (Honk Kong) Chinese Yuan handling
         if currency == "CNH":
@@ -263,9 +263,10 @@ class CurrencyConverter:
 
 
 class TestCurrencyConverter(CurrencyConverter):
-    """Variant of CurrencyConverter that append single currency entry on the input exchange rate files based on usage.
+    """Variant of CurrencyConverter that appends each used rate to the input exchange rate file.
 
-    Created when RuntimeMode is TEST, this is meant to be used to populated test fixture data when adding new ones.
+    Created when RuntimeMode is TEST; this is meant to be used to populate test fixture data
+    when adding new tests.
     """
 
     def __init__(
@@ -282,10 +283,11 @@ class TestCurrencyConverter(CurrencyConverter):
 
     @override
     def currency_to_gbp_rate(self, currency: str, date: datetime.date) -> Decimal:
-        """Get GBP/currency rate at given date.
+        """Get the number of currency units per GBP at the given date.
 
-        When the value is missing from the view of the test_file_cache append that value to the exchange rate CSV file.
-        This allow us to record the rates that are being used in tests.
+        When the value is missing from the view of the test_file_cache, append it
+        to the exchange rate CSV file.
+        This allows us to record the rates that are being used in tests.
         """
         result = super().currency_to_gbp_rate(currency, date)
         if date not in self._test_file_cache:

--- a/cgt_calc/current_price_fetcher.py
+++ b/cgt_calc/current_price_fetcher.py
@@ -15,7 +15,7 @@ from .exceptions import MarketDataMissingError
 
 
 class CurrentPriceFetcher:
-    """Converter which holds rate history."""
+    """Fetches current and historical market prices and converts them to GBP."""
 
     def __init__(
         self,
@@ -23,7 +23,7 @@ class CurrentPriceFetcher:
         current_prices_data: dict[str, Decimal | None] | None = None,
         historical_prices_data: dict[str, dict[datetime.date, Decimal]] | None = None,
     ):
-        """Load data from exchange_rates_file and optionally from initial_data."""
+        """Store the converter and optional pre-seeded price data."""
         self.current_prices_data = current_prices_data
         self.historical_prices_data = historical_prices_data or {}
         self.converter = converter

--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -1,4 +1,4 @@
-"""Exceptions to different errors."""
+"""Exception types for the various error conditions."""
 
 from __future__ import annotations
 
@@ -100,7 +100,7 @@ class PriceMissingError(InvalidTransactionError):
 
 
 class QuantityMissingError(InvalidTransactionError):
-    """Price is missing error."""
+    """Quantity is missing error."""
 
     def __init__(self, transaction: BrokerTransaction):
         """Initialise."""
@@ -108,7 +108,7 @@ class QuantityMissingError(InvalidTransactionError):
 
 
 class QuantityNotPositiveError(InvalidTransactionError):
-    """Quantity is negative error."""
+    """Quantity is not positive error."""
 
     def __init__(self, transaction: BrokerTransaction):
         """Initialise."""

--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -226,7 +226,7 @@ class IsinConverter:
         json_data = json_response[0]["data"]
 
         # https://www.openfigi.com/assets/content/OpenFIGI_Exchange_Codes-3d3e5936ba.csv
-        # Get london exchange first
+        # Get London exchange first
         result = {data["ticker"] for data in json_data if data["exchCode"] == "LN"}
 
         if result:

--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -58,7 +58,7 @@ class IsinTranslationEntry:
 
 
 class IsinConverter:
-    """Converter which holds rate history."""
+    """Converter which holds ISIN-to-ticker mappings."""
 
     def __init__(
         self,
@@ -124,7 +124,7 @@ class IsinConverter:
                 self._write_isin_translation_file()
 
     def get_symbols(self, isin: str) -> set[str]:
-        """Return the symbol associated with the input ISIN or empty string."""
+        """Return the set of symbols associated with the input ISIN (may be empty)."""
         result = self.data.get(isin)
         if result is None:
             result = self._fetch_live(isin)
@@ -135,7 +135,7 @@ class IsinConverter:
         return result
 
     def get_symbol_to_isin_map(self) -> dict[str, str]:
-        """Return a map from symbols to isin's."""
+        """Return a map from symbols to ISINs."""
         symbol_to_isin = {}
         for isin, symbols in self.data.items():
             for symbol in symbols:

--- a/cgt_calc/logging.py
+++ b/cgt_calc/logging.py
@@ -66,7 +66,7 @@ class ConsoleUI:
     def _should_use_emoji(self, stream: TextIO) -> bool:
         """Return True if emoji output should be enabled for the given stream."""
 
-        # Should be available by now
+        # Emoji output requires colour support
         if not self.supports_colour(stream):
             return False
 

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -104,7 +104,7 @@ def get_quantity_or_fail(transaction: BrokerTransaction) -> Decimal:
 # Amount difference can be caused by rounding errors in the price.
 # Schwab rounds down the price to 4 decimal places
 #  so that the error in amount can be more than $0.01.
-# Fox example:
+# For example:
 # 500 shares of FOO sold at $100.00016 with $1.23 fees.
 # "01/01/2024,"Sell","FOO","FOO","500","$100.0001","$1.23","$49,998.85"
 # calculated_amount = 500 * 100.0001 - 1.23 = 49998.82
@@ -733,7 +733,7 @@ class CapitalGainsCalculator:
         if acquisition.quantity > 0 and has_key(self.bnb_list, date_index, symbol):
             bnb_acquisition = self.bnb_list[date_index][symbol]
             assert bnb_acquisition.quantity <= acquisition.quantity
-            # Multiply by available_quantity before divide to avoid rounding errors from division
+            # Multiply by the B&B quantity before dividing to avoid rounding errors from division
             bnb_cost_basis = normalize_amount(
                 (bnb_acquisition.quantity * acquisition.amount) / acquisition.quantity
             )
@@ -803,9 +803,9 @@ class CapitalGainsCalculator:
             if date > date_index:
                 continue
             for spin_off in spin_offs:
-                # Up to the actual spin-off happening all the sales has to happen based
-                # on original cost basis, after spin-off we have to consider its impact
-                # for all future trades
+                # Up to the actual spin-off happening all the sales have to happen based
+                # on the original cost basis; after the spin-off we have to consider its
+                # impact for all future trades
                 amount = self.portfolio[spin_off.source].amount
                 quantity = self.portfolio[spin_off.source].quantity
                 new_amount = amount * spin_off.cost_proportion
@@ -827,8 +827,8 @@ class CapitalGainsCalculator:
                     amount=-amount,
                     new_quantity=quantity,
                     gain=None,
-                    # Fees, if any are already accounted on the acquisition of
-                    # spined off shares
+                    # Fees, if any, are already accounted for on the acquisition
+                    # of spun-off shares
                     fees=Decimal(0),
                     new_pool_cost=new_amount,
                     allowable_cost=new_amount,
@@ -906,13 +906,13 @@ class CapitalGainsCalculator:
                     effective_symbol, effective_symbol
                 )
 
-                # Check if there was any stock split, in which case we need to adjust the B&D quantity
+                # Check if there was any stock split, in which case we need to adjust the B&B quantity
                 split_multiplier *= self.split_list.get(
                     (effective_symbol, search_index), Decimal(1)
                 )
 
-                # ERI are distributed annually but when a fund close we might have
-                # multiple ERI distribution in close succession
+                # ERI is distributed annually, but when a fund closes we might have
+                # multiple ERI distributions in close succession
                 eri = self.get_eri(effective_symbol, search_index)
                 if eri:
                     eris.append(eri)
@@ -946,8 +946,8 @@ class CapitalGainsCalculator:
                         == 0
                     ):
                         continue
-                    # Splits are the only transaction that receive shares for free
-                    # they can't be part of a B&B
+                    # Splits are the only transactions that receive shares for free,
+                    # so they can't be part of a B&B
                     if acquisition.amount == 0:
                         LOGGER.warning(
                             "A split happened shortly after a disposal of %s, double check these transactions."
@@ -1065,7 +1065,7 @@ class CapitalGainsCalculator:
                         )
                     )
                     # If we completely matched the current disposal,
-                    # there's no need to keep looking for more B&D days
+                    # there's no need to keep looking for more B&B days
                     if disposal_quantity <= 0:
                         break
         if disposal_quantity > 0:
@@ -1556,7 +1556,6 @@ class CapitalGainsCalculator:
         self, symbol: str, quantity: Decimal, amount: Decimal
     ) -> PortfolioEntry:
         """Create a portfolio entry in the report."""
-        # (by calculating the unrealized gains)
         unrealized_gains = None
         if self.calc_unrealized_gains:
             current_price = (

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -78,7 +78,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_amount_or_fail(transaction: BrokerTransaction) -> Decimal:
-    """Return the transaction amount or throw an error."""
+    """Return the transaction amount or raise an error if missing."""
     amount = transaction.amount
     if amount is None:
         raise AmountMissingError(transaction)
@@ -86,7 +86,7 @@ def get_amount_or_fail(transaction: BrokerTransaction) -> Decimal:
 
 
 def get_symbol_or_fail(transaction: BrokerTransaction) -> str:
-    """Return the transaction symbol or throw an error."""
+    """Return the transaction symbol or raise an error if missing."""
     symbol = transaction.symbol
     if symbol is None:
         raise SymbolMissingError(transaction)
@@ -94,7 +94,7 @@ def get_symbol_or_fail(transaction: BrokerTransaction) -> str:
 
 
 def get_quantity_or_fail(transaction: BrokerTransaction) -> Decimal:
-    """Return the transaction quantity or throw an error."""
+    """Return the transaction quantity or raise an error if missing."""
     quantity = transaction.quantity
     if quantity is None:
         raise QuantityMissingError(transaction)
@@ -230,7 +230,7 @@ class CapitalGainsCalculator:
         self,
         transaction: BrokerTransaction,
     ) -> None:
-        """Add new acquisition to the given list."""
+        """Record an acquisition in the portfolio and the acquisition list."""
         symbol = get_symbol_or_fail(transaction)
         quantity = transaction.quantity
         price = transaction.price
@@ -281,7 +281,7 @@ class CapitalGainsCalculator:
     ) -> tuple[Decimal, Decimal]:
         """Handle spin off transaction.
 
-        Doc basing on SOLV spin off out of MMM.
+        Documentation based on the SOLV spin-off from MMM.
 
         # 1. Determine the Cost Basis (Acquisition Cost) of the SOLV Shares
         In the UK, the cost basis (or acquisition cost) of the new SOLV shares
@@ -364,7 +364,7 @@ class CapitalGainsCalculator:
         self,
         transaction: BrokerTransaction,
     ) -> None:
-        """Add new disposal to the given list."""
+        """Record a disposal in the portfolio and the disposal list."""
         symbol = get_symbol_or_fail(transaction)
         quantity = transaction.quantity
         if symbol not in self.portfolio:
@@ -1286,7 +1286,7 @@ class CapitalGainsCalculator:
         return DIVIDEND_CURRENCY_TO_COUNTRY.get(currency)
 
     def process_dividends(self) -> None:
-        """Process all dividends events and taxes.
+        """Process all dividend events and taxes.
 
         It updates the interest total for the year if needed.
         """

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -172,7 +172,7 @@ class CalculationType(Enum):
 
 @dataclass
 class BrokerTransaction:
-    """Broken transaction data."""
+    """Broker transaction data."""
 
     date: datetime.date
     action: ActionType
@@ -221,7 +221,7 @@ class Dividend:
 
     @property
     def tax_treaty_amount(self) -> Decimal:
-        """As title."""
+        """Dividend amount reclaimable under the tax treaty (0 if none)."""
         if self.tax_treaty is None:
             return Decimal(0)
         return self.amount * self.tax_treaty.treaty_rate
@@ -435,7 +435,10 @@ class CapitalGainsReport:
         return max(Decimal(0), self.total_gain() - self.capital_gain_allowance)
 
     def total_eri_amount(self, *, is_interest: bool) -> Decimal:
-        """Total dividends amount just from ERI."""
+        """Return the total ERI distribution amount.
+
+        Covers interest funds if is_interest is True, otherwise dividend funds.
+        """
         total = Decimal(0)
         for item in self._filter_calculation_log(
             self.calculation_log_yields, RuleType.EXCESS_REPORTED_INCOME_DISTRIBUTION
@@ -482,8 +485,8 @@ class CapitalGainsReport:
 
     @override
     def __repr__(self) -> str:
-        """Return string representation."""
-        return f"<CalculationEntry: {self!s}>"
+        """Return print representation."""
+        return f"<CapitalGainsReport: {self!s}>"
 
     @override
     def __str__(self) -> str:

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -25,7 +25,7 @@ class SpinOff:
     # Cost proportion to be applied to the cost of original shares from which
     # Spin-off originated
     cost_proportion: Decimal
-    # Source of the Spin-off, e.g MMM for SOLV
+    # Source of the Spin-off, e.g. MMM for SOLV
     source: str
     # Dest ticker to which SpinOff happened, e.g. SOLV for MMM
     dest: str
@@ -89,7 +89,7 @@ class HmrcTransactionData:
     fees: Decimal = Decimal(0)
     # This is a list to support Bed and Breakfast acquisitions that can cross multiple
     # ERI reports for the same fund. This can happen for example when a fund is
-    # liquidated close after its usual reporting data, requiring a new final reporting.
+    # liquidated shortly after its usual reporting date, requiring a new final report.
     eris: list[ExcessReportedIncome] = field(default_factory=list)
 
     def __add__(self, transaction: HmrcTransactionData) -> HmrcTransactionData:

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -124,19 +124,19 @@ class BaseSingleFileParser(BaseParser):
     def post_process_transactions(
         cls, transactions: list[BrokerTransaction]
     ) -> list[BrokerTransaction]:
-        """Do any required post processing after loading all the transactions in the dir."""
+        """Do any required post processing after loading the transactions."""
         return transactions
 
 
 class StandardCSVParser(BaseSingleFileParser):
-    """Parser for RAW format transaction files."""
+    """Base parser for CSV files with a fixed set of expected columns."""
 
     columns: ClassVar[set[str]]
     optional_columns: ClassVar[set[str]] = set()
 
     @classmethod
     def _validate_header(cls, header: Sequence[str], file_path: Path) -> None:
-        """Validate optional header row."""
+        """Validate the header has required columns and no unexpected ones."""
         header_set = set(header)
         missing = cls.columns - header_set
         extra = header_set - cls.columns - cls.optional_columns
@@ -162,7 +162,7 @@ class StandardCSVParser(BaseSingleFileParser):
     def read_transactions(
         cls, file: TextIO, file_path: Path
     ) -> list[BrokerTransaction]:
-        """Read Raw transactions from file."""
+        """Read transactions from a CSV file."""
         reader = csv.DictReader(cls.pre_reading(file, file_path))
         if reader.fieldnames is None:
             raise ParsingError(

--- a/cgt_calc/parsers/eri/__init__.py
+++ b/cgt_calc/parsers/eri/__init__.py
@@ -1,9 +1,9 @@
-"""Parse ERI input files.
+"""Parse ERI (Excess Reported Income) input files.
 
-Excess Reported Income are yearly report provided by offshore fund managers to HMRC for
-taxation purpsoes.
-They report for each fund the amount of excess income has to be reported for taxation
-perspective.
+Excess Reported Income is a yearly report provided by offshore fund managers to
+HMRC for taxation purposes.
+For each fund it lists the amount of excess income that has to be reported from
+a taxation perspective.
 
 Full list of reporting funds at: https://www.gov.uk/government/publications/offshore-funds-list-of-reporting-funds
 """

--- a/cgt_calc/parsers/eri/importer/__init__.py
+++ b/cgt_calc/parsers/eri/importer/__init__.py
@@ -1,5 +1,6 @@
 """Import ERI files into cgt_calc resources.
 
-ERI files can be various formats from the various brokers.
-This module provides importers for the various format in the RAW format used for parsing.
+ERI files can be in various formats from the various brokers.
+This module provides importers that convert those formats into the RAW format
+used for parsing.
 """

--- a/cgt_calc/parsers/eri/importer/invesco.py
+++ b/cgt_calc/parsers/eri/importer/invesco.py
@@ -35,7 +35,7 @@ INVESCO_ERI_FILENAME = "invesco_eri.csv"
 
 
 class InvescoImporter(ERIImporter):
-    """Parser for Invesco ERI spreadsheets."""
+    """Parser for Invesco ERI PDF reports."""
 
     def __init__(self) -> None:
         """Create a new Invesco Parser instance."""
@@ -211,7 +211,7 @@ class InvescoImporter(ERIImporter):
 
     @override
     def parse(self, file: Path) -> ERIImporterOutput | None:
-        """Parse a Invesco ERI file."""
+        """Parse an Invesco ERI file."""
         if not REPORT_FILE_REGEX.match(file.name):
             return None
 

--- a/cgt_calc/parsers/eri/importer/model.py
+++ b/cgt_calc/parsers/eri/importer/model.py
@@ -15,7 +15,7 @@ class ERIImporterOutput:
 
 
 class ERIImporter:
-    """Base class for all ERI Importer."""
+    """Base class for all ERI importers."""
 
     def __init__(self, name: str):
         """Create a new instance with the given name."""

--- a/cgt_calc/parsers/eri/model.py
+++ b/cgt_calc/parsers/eri/model.py
@@ -7,7 +7,7 @@ from cgt_calc.model import ActionType, BrokerTransaction
 
 
 class ERITransaction(BrokerTransaction):
-    """Eri transaction data."""
+    """ERI transaction data."""
 
     def __init__(
         self,
@@ -16,7 +16,7 @@ class ERITransaction(BrokerTransaction):
         price: Decimal,
         currency: str,
     ) -> None:
-        """Create an Eri transaction."""
+        """Create an ERI transaction."""
 
         super().__init__(
             date=date,

--- a/cgt_calc/parsers/eri/raw.py
+++ b/cgt_calc/parsers/eri/raw.py
@@ -1,4 +1,4 @@
-"""Raw transaction parser."""
+"""ERI raw data CSV parser."""
 
 from __future__ import annotations
 
@@ -70,7 +70,7 @@ class ERIRaw(ERITransaction):
 
 
 class ERIRawParser(BaseSingleFileParser):
-    """Parser for RAW format transaction files."""
+    """Parser for ERI (Excess Reported Income) CSV data files."""
 
     arg_name = "eri-raw"
     pretty_name = "Historical Excess Reported Income data"

--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -126,7 +126,7 @@ class FreetradeTransaction(BrokerTransaction):
                 file, BROKER_NAME, row[FreetradeColumn.ACCOUNT_CURRENCY]
             )
 
-        # Convert all numbers in GBP using Freetrade rates
+        # Convert all numbers to GBP using Freetrade rates
         if action in [ActionType.SELL, ActionType.BUY]:
             quantity = _parse_decimal(row, FreetradeColumn.QUANTITY)
             price = _parse_decimal(row, FreetradeColumn.PRICE_PER_SHARE)

--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -173,7 +173,7 @@ class HargreavesLansdownParser(StandardCSVParser, BaseDirParser):
             Decimal(amount_str) if amount_str and amount_str != "n/a" else Decimal(0)
         )
 
-        # Live PDF lookup only when needed for buy/sell actions[cite: 1]
+        # Live PDF lookup only when needed for buy/sell actions
         if action_type in [ActionType.BUY, ActionType.SELL]:
             matching_pdfs = list(file_path.parent.glob(f"{reference}_*.pdf"))
             if matching_pdfs:

--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -99,7 +99,7 @@ class HargreavesLansdownParser(StandardCSVParser, BaseDirParser):
         # separated by any whitespace or optional pipes
         values_match = VALUES_REGEX.search(text)
 
-        # 3. Tolerate any characters between "Dealing charge" and its numeric value
+        # 3. Tolerate any non-digit characters between "Dealing charge" and its numeric value
         fees_match = FEES_REGEX.search(text)
 
         date_str = date_match.group(1) if date_match else None

--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -123,7 +123,7 @@ def _parse_decimal(row: dict[str, str], column: str) -> Decimal | None:
 
 
 class InteractiveBrokersTransaction(BrokerTransaction):
-    """Interactive Brokers Transaction parser."""
+    """Represents a single Interactive Brokers transaction."""
 
     def __init__(
         self,

--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -1,6 +1,6 @@
 """Morgan Stanley parser.
 
-Note, that I only had access to an Alphabet export. I have no idea how it looks like
+Note: I only had access to an Alphabet export. I have no idea what it looks like
 for another company, or for a full profile.
 """
 
@@ -115,7 +115,7 @@ class MSSBParser(StandardCSVParser, BaseDirParser):
     @classmethod
     @override
     def pre_reading(cls, file: TextIO, file_path: Path) -> Iterable[str]:
-        """Do any preprocessing of the file before parsing the csv."""
+        """Select the expected column set based on the report filename."""
         if file_path.name == WITHDRAWALS_REPORT_FILENAME:
             cls.columns = set(COLUMNS_WITHDRAWAL)
         else:

--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -174,8 +174,8 @@ class MSSBParser(StandardCSVParser, BaseDirParser):
             broker=BROKER_NAME,
         )
 
-    # Morgan Stanley decided to put a notice in the end of the withdrawal report that looks
-    # like that:
+    # Morgan Stanley decided to put a notice at the end of the withdrawal report that looks
+    # like this:
     # "Please note that any Alphabet share sales, transfers, or deposits that occurred on
     # or prior to the July 15, 2022 stock split are reflected in pre-split. Any sales,
     # transfers, or deposits that occurred after July 15, 2022 are in post-split values.

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -74,7 +74,7 @@ class AwardPrices:
 
     def get(self, date: datetime.date, symbol: str) -> tuple[datetime.date, Decimal]:
         """Get initial stock price at given date."""
-        # Award dates may go back for few days, depending on
+        # Award dates may go back a few days, depending on
         # holidays or weekends, so we do a linear search
         # in the past to find the award price
         symbol = TICKER_RENAMES.get(symbol, symbol)
@@ -267,9 +267,9 @@ class SchwabTransaction(BrokerTransaction):
             symbol = transaction.symbol
             if symbol is None:
                 raise SymbolMissingError(transaction)
-            # Schwab transaction list contains sometimes incorrect date
-            # for awards which don't match the PDF statements.
-            # We want to make sure to match date and price form the awards
+            # The Schwab transaction list sometimes contains an incorrect date
+            # for awards which doesn't match the PDF statements.
+            # We want to make sure to match date and price from the awards
             # spreadsheet.
             try:
                 _vest_date, transaction.price = awards_prices.get(

--- a/cgt_calc/parsers/schwab_cusip_bonds.py
+++ b/cgt_calc/parsers/schwab_cusip_bonds.py
@@ -20,7 +20,8 @@ MAX_ACCRUED_INTEREST_BUY: Final = Decimal("0.01")
 MAX_ACCRUED_INTEREST_SELL: Final = Decimal(100)
 BOND_PRICE_TOLERANCE_RATIO: Final = Decimal("0.5")
 
-# Valid CUSIP characters for positions 7-8 (letters + special chars for fixed income)
+# Valid non-digit CUSIP characters (letters valid anywhere; *@# are specific to
+# fixed-income issues in positions 7-8)
 CUSIP_ALPHA_CHARS: Final = "ABCDEFGHIJKLMNOPQRSTUVWXYZ*@#"
 
 

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -671,7 +671,7 @@ class SchwabTransaction(BrokerTransaction):
                 date = datetime.datetime.strptime(
                     details[names.vest_date], "%m/%d/%Y"
                 ).date()
-                # Schwab only provide this one as string:
+                # Schwab only provides this one as a string:
                 price = _decimal_from_str(details[names.vest_fair_market_value])
                 if amount == Decimal(0):
                     amount = price * quantity

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -859,7 +859,7 @@ class SchwabEquityAwardsJSONParser(BaseSingleFileParser):
     def read_transactions(
         cls, file: TextIO, file_path: Path
     ) -> list[BrokerTransaction]:
-        """Schwab Equity Awards transactions from JSON."""
+        """Read Schwab Equity Awards transactions from JSON."""
         try:
             data = json.load(file, parse_float=Decimal, parse_int=Decimal)
         except json.decoder.JSONDecodeError as exception:

--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -399,7 +399,7 @@ class SharesightParser(BaseDirParser):
             # - Amount is negative when selling, and positive when buying
             #   (as it tracks portfolio value, not account balance)
             # - Value provided is always in GBP
-            # - Foreign exchange transactions are show as BUY and SELL
+            # - Foreign exchange transactions are shown as BUY and SELL
 
             if market == "FX":
                 # While Sharesight provides an exchange rate, it is not precise enough

--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -171,7 +171,7 @@ class SharesightParser(BaseDirParser):
     def post_process_transactions(
         cls, transactions: list[BrokerTransaction]
     ) -> list[BrokerTransaction]:
-        """Sort."""
+        """Sort transactions by date."""
         transactions.sort(key=lambda t: t.date)
         return transactions
 

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -80,7 +80,10 @@ LOGGER = logging.getLogger(__name__)
 def decimal_or_none(
     row: dict[Trading212Column, str], column: Trading212Column
 ) -> Decimal | None:
-    """Convert a column value to Decimal or return None when blank."""
+    """Convert a column value to Decimal.
+
+    Return None when the value is blank, missing, or "Not available".
+    """
 
     value = row.get(column)
     if value is None or value in ("", "Not available"):
@@ -154,7 +157,7 @@ def action_from_str(label: str, file: Path) -> ActionType:
 
 
 class Trading212Transaction(BrokerTransaction):
-    """Represent single Trading 212 transaction."""
+    """Represents a single Trading 212 transaction."""
 
     def __init__(self, header: list[str], row_raw: list[str], file: Path) -> None:
         """Create transaction from CSV row."""

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -264,7 +264,8 @@ def _make_transaction_from_investment(
         row[InvestmentColumn.QUANTITY], InvestmentColumn.QUANTITY.value
     )
     if not details and quantity != 0:
-        # Infer investment/quantity for pre ~Oct 2021 rows without TransactionDetails
+        # Infer action (from the quantity sign) and symbol (from InvestmentName)
+        # for pre ~Oct 2021 rows without TransactionDetails
         action = ActionType.BUY if quantity > 0 else ActionType.SELL
         symbol = _symbol_from_investment_name(row[InvestmentColumn.INVESTMENT_NAME])
     else:

--- a/cgt_calc/spin_off_handler.py
+++ b/cgt_calc/spin_off_handler.py
@@ -1,4 +1,4 @@
-"""Convert currencies to GBP using rate history."""
+"""Handle stock spin-offs."""
 
 from __future__ import annotations
 
@@ -29,7 +29,7 @@ class SpinOffHandler:
         self,
         spin_offs_file: Path | None = None,
     ):
-        """Load data from spin_offs_file and optionally from initial_data."""
+        """Load data from spin_offs_file."""
         self.spin_offs_file = spin_offs_file
         self.cache = self._read_spin_offs_file()
 

--- a/cgt_calc/util.py
+++ b/cgt_calc/util.py
@@ -36,7 +36,7 @@ def strip_zeros(value: Decimal) -> str:
 
 
 def luhn_check_digit(payload: str) -> int:
-    """Return the check digit given a string of numbers given the Luhn Algorithm.
+    """Return the check digit for a string of digits using the Luhn algorithm.
 
     Reference: https://en.wikipedia.org/wiki/Luhn_algorithm
     """
@@ -77,11 +77,11 @@ def is_isin(isin: str) -> bool:
 def approx_equal(
     val_a: Decimal, val_b: Decimal, approx_quantity: Decimal = Decimal("0.01")
 ) -> bool:
-    """Calculate if two decimal are the same within approx_quantity input.
+    """Check if two decimals are equal within approx_quantity.
 
     It is not clear how Schwab or other brokers round the dollar value,
-    so assume the values are equal if they are within approx_quantity input.
-    Defaults to 0.01
+    so assume the values are equal if they are within approx_quantity.
+    Defaults to 0.01.
     """
     return abs(val_a - val_b) < approx_quantity
 

--- a/cgt_calc/util.py
+++ b/cgt_calc/util.py
@@ -56,7 +56,7 @@ def luhn_check_digit(payload: str) -> int:
 
     return (
         10 - (checksum % 10)
-    ) % 10  # using mod operator twice asserts the check digit is < 10
+    ) % 10  # using mod operator twice ensures the check digit is < 10
 
 
 def is_isin(isin: str) -> bool:

--- a/docs/excess_reported_income_sources.md
+++ b/docs/excess_reported_income_sources.md
@@ -6,6 +6,8 @@ tool. Currently bundled data:
 - [Vanguard Funds 2018-2024](../cgt_calc/resources/eri/vanguard_eri.csv)
 - [Blackrock Funds 2019-2024](../cgt_calc/resources/eri/blackrock_eri.csv)
 - [iShares Funds 2018-2024](../cgt_calc/resources/eri/ishares_eri.csv)
+- [Invesco Funds 2018-2024](../cgt_calc/resources/eri/invesco_eri.csv)
+- [Xtrackers Funds 2024](../cgt_calc/resources/eri/xtrackers_eri.csv)
 
 <details>
     <summary>🏦 Instructions for ERI_RAW format</summary>
@@ -36,21 +38,22 @@ Note this tool **already includes** Vanguard Funds ERI data from 2018 to 2024.
 
 To contribute new data to the tool please run the
 [import_eri_reports.py](../scripts/import_eri_reports.py) script pointing to either the file or the
-folder containing the ERI reports for Blackrock or iShares. The tool will recognize the funds
-provider from the filename and import the data in the resource CSV for
+folder containing the ERI reports for Vanguard. The tool will recognize the funds provider from the
+filename and import the data in the resource CSV for
 [vanguard](../cgt_calc/resources/eri/vanguard_eri.csv).
 
 - **ISIN:** same name column
 - **Fund Reporting Period End Date:** End date in the Reporting Period column
 - **Currency:** Share Class Currency column
-- **Excess of reporting income over distribution:** same name column The tool also record any new
-  ISIN translation to the resource CSV for
-  [ISIN](../cgt_calc/resources/initial_isin_translation.csv)
+- **Excess of reporting income over distribution:** same name column
+
+The tool also records any new ISIN translation to the resource CSV for
+[ISIN](../cgt_calc/resources/initial_isin_translation.csv).
 
 To contribute new data to the tool please add it at the bottom of the
 [ERI RAW file](../cgt_calc/resources/eri/vanguard_eri.csv) for Vanguard. Then run the tool once to
 generate any new ISIN translations (if needed) and copy them from your own isin translation file
-(default `isin_translation.csv`) into the
+(default `out/isin_translation.csv`) into the
 [tool one](../cgt_calc/resources/initial_isin_translation.csv). Create a pull request with both
 files in GitHub adjusting the README and this file with the updated bundled data.
 
@@ -76,8 +79,8 @@ provider from the filename and import the data in the resource CSV for
 [blackrock](../cgt_calc/resources/eri/blackrock_eri.csv) or
 [ishares](../cgt_calc/resources/eri/ishares_eri.csv).
 
-The tool also record any new ISIN translation to the resource CSV for
-[ISIN](../cgt_calc/resources/initial_isin_translation.csv)
+The tool also records any new ISIN translation to the resource CSV for
+[ISIN](../cgt_calc/resources/initial_isin_translation.csv).
 
 Create a pull request with all the files in GitHub adjusting the README and this file with the
 updated bundled data.
@@ -120,8 +123,6 @@ Columns mapping to ERI_RAW:
 Amundi UK publishes the Reportable Income yearly report at the bottom of this page:
 https://www.amundietf.co.uk/en/individual/resources/document-library?documentType=uktaxcalculation
 
-They are split XTrackers (stocks ETF), XTrackers II (bonds ETF) and XTrackers IE (other stocks ETF).
-
 Columns mapping to ERI_RAW:
 
 - **ISIN:** same name column
@@ -158,7 +159,7 @@ Columns mapping to ERI_RAW:
 To contribute new data to the tool please add it at the bottom of the
 [ERI RAW file](../cgt_calc/resources/eri/invesco_eri.csv) for Invesco. Then run the tool once to
 generate any new ISIN translations (if needed) and copy them from your own isin translation file
-(default `isin_translation.csv`) into the
+(default `out/isin_translation.csv`) into the
 [tool one](../cgt_calc/resources/initial_isin_translation.csv). Create a pull request with both
 files in GitHub adjusting the README and this file with the updated bundled data.
 

--- a/tests/general/calc_test_data.py
+++ b/tests/general/calc_test_data.py
@@ -1286,7 +1286,7 @@ calc_basic_data = [
                 symbol="FOO",
                 quantity=2,
                 price=6,
-                amount=12,  # 2.00 gain
+                amount=12,  # 2.00 gain before B&B matching; realised result is -3.00
                 fees=0,
             ),
             split_transaction(
@@ -1299,7 +1299,7 @@ calc_basic_data = [
                 symbol="FOO",
                 quantity=2,
                 price=5,
-                amount=-10,  # 5.00 gain
+                amount=-10,  # B&B matched against the 10 May sell
                 fees=0,
             ),
         ],

--- a/tests/general/calc_test_data.py
+++ b/tests/general/calc_test_data.py
@@ -1,4 +1,4 @@
-"""Additional tests for calc."""
+"""Test data for calc tests."""
 
 from __future__ import annotations
 
@@ -153,7 +153,7 @@ def split_transaction(
     symbol: str,
     quantity: float,
 ) -> BrokerTransaction:
-    """Create sell transaction."""
+    """Create stock split transaction."""
     return BrokerTransaction(
         date,
         ActionType.STOCK_SPLIT,

--- a/tests/general/calc_test_data_2.py
+++ b/tests/general/calc_test_data_2.py
@@ -1,4 +1,4 @@
-"""Additional tests for calc."""
+"""Additional test data for calc tests."""
 
 from __future__ import annotations
 

--- a/tests/general/test_warning_scope.py
+++ b/tests/general/test_warning_scope.py
@@ -26,8 +26,8 @@ from .calc_test_data import (
 if TYPE_CHECKING:
     from cgt_calc.model import BrokerTransaction
 
-# Both the tax year computed by the tests below and an earlier one, so that a
-# transaction can be placed inside or outside the reported year.
+# The tax year under test, plus one date inside it and one in an earlier year,
+# so that a transaction can be placed inside or outside the reported year.
 TAX_YEAR = 2024
 IN_YEAR_DATE = datetime.date(2024, 6, 3)
 EARLIER_DATE = datetime.date(2022, 6, 3)

--- a/tests/hl/test_hl.py
+++ b/tests/hl/test_hl.py
@@ -84,7 +84,6 @@ def _create_sell_pdf(filename: str) -> None:
 def _prepare_pdf_test_data() -> str:
     test_dir = Path(__file__).resolve().parent
 
-    # Set your source file path
     source_file = Path(test_dir / "data" / "inputs" / "hl-transaction-summary.csv")
 
     # Use a stable repo-relative directory: its path is echoed in the parsing

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -48,7 +48,7 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
     )
 
     def test_single_buy(self, tmp_path: Path) -> None:
-        """Test that bond buy price is divided by 100 for CUSIP symbols."""
+        """Test parsing a single buy transaction."""
         csv_file = tmp_path / "transactions.csv"
         csv_file.write_text(
             self.base_header

--- a/tests/schwab/test_schwab_bond_pricing.py
+++ b/tests/schwab/test_schwab_bond_pricing.py
@@ -197,14 +197,13 @@ class TestBondPricing:
         # accrued_interest = 3967408 - 3966908 - 0 = 500
         assert adjusted_fees == Decimal("500.00")
 
-    def test_bond_small_accrued_interest_not_added(self) -> None:
-        """Test that very small accrued interest (<=0.01) is not added to fees."""
+    def test_bond_no_accrued_interest_fees_unchanged(self) -> None:
+        """Test that fees stay zero when the amount implies no accrued interest."""
         symbol = "91282CMF5"
         price = Decimal("10000.00")
         quantity = Decimal(100)
         fees = Decimal(0)
 
-        # Amount includes only $0.005 accrued interest (rounds to 0.01 threshold)
         amount = Decimal("-10000.00")  # Exactly quantity * (price/100), no accrued
 
         adjusted_price, adjusted_fees = adjust_cusip_bond_price(

--- a/tests/schwab/test_schwab_bond_pricing.py
+++ b/tests/schwab/test_schwab_bond_pricing.py
@@ -108,7 +108,7 @@ class TestBondPricing:
                 Decimal(0),
                 True,
             ),
-            # Valid bond sell with small accrued interest
+            # Valid bond sell with fees and no accrued interest
             (
                 Decimal("10076.95"),
                 Decimal(50000),

--- a/tests/schwab/test_schwab_equity_award_json.py
+++ b/tests/schwab/test_schwab_equity_award_json.py
@@ -53,7 +53,7 @@ def test_decimal_from_number_or_str_empty_string() -> None:
 
 
 def test_decimal_from_number_or_str_float_custom_suffix() -> None:
-    """Test _decimal_from_number_or_str_default_suffix() on float.
+    """Test _decimal_from_number_or_str() on float.
 
     With a custom suffix.
     """

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -192,10 +192,10 @@ def test_disposal_price_comes_from_the_money(
     assert sale.quantity == Decimal(500)
 
 
-def test_a_commission_free_disposal_has_zero_fees(
+def test_disposal_fees_are_preserved(
     transactions: list[BrokerTransaction],
 ) -> None:
-    """Schwab writes an empty string for the fees rather than a zero."""
+    """A populated Schwab fee like "$0.02" is parsed and kept on the disposal."""
     sale = on(transactions, datetime.date(2023, 1, 23), ActionType.SELL)
 
     assert sale.fees == Decimal("0.02")

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -245,8 +245,8 @@ def test_dual_table_enriches_sell_with_investment_data() -> None:
     assert bar_sells[0].price == Decimal("104.06")
 
 
-def test_dual_table_enriches_amount_from_investment_cost() -> None:
-    """Enriched amount equals quantity * price from investment table."""
+def test_dual_table_keeps_cash_table_amount() -> None:
+    """The cash-table amount is preserved when a buy is enriched."""
     transactions = VanguardParser().load_from_file(
         INVESTMENT_DATA_DIR / "cash_investment_report.csv"
     )


### PR DESCRIPTION
Cleanup pass over all docstrings, inline comments, and Markdown docs:

- Fix docstrings that were wrong or copy-pasted from other classes; rename three tests whose names described scenarios they don't exercise
- Fix inline comments that contradict the adjacent code, plus grammar and typos
- Update docs: current `--schwab-file`/`--schwab-award-file` flags in examples, add missing entries to the supported sources and bundled ERI data lists, fix copy-pasted broker names in the ERI guide, correct the default ISIN translation path
- Fix `CapitalGainsReport.__repr__` printing `CalculationEntry`