### PR TITLE
Sort the broker lists by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 Easily calculate **UK Capital Gains Tax** from your investment transaction history.
 
-Supported sources include **Charles Schwab**, **Trading 212**, **Morgan Stanley**, **Sharesight**,
-**Hargreaves Lansdown**, **Vanguard**, **Freetrade**, **Interactive Brokers**, or a custom **RAW**
+Supported sources include **Charles Schwab**, **Freetrade**, **Hargreaves Lansdown**, **Interactive
+Brokers**, **Morgan Stanley**, **Sharesight**, **Trading 212**, **Vanguard**, or a custom **RAW**
 format.
 
 The tool generates a detailed **PDF report** with all calculations.

--- a/cgt_calc/parsers/broker_registry.py
+++ b/cgt_calc/parsers/broker_registry.py
@@ -55,18 +55,19 @@ def _transaction_sort_key(
 class BrokerRegistry:
     """Registry for all broker parsers."""
 
+    # Ordered by pretty name, matching the docs, with the generic RAW format
+    # last. Add new brokers in their sorted place.
     _BROKERS: ClassVar[list[type[BaseParser]]] = [
-        FreetradeParser,
-        RawParser,
         SchwabParser,
         SchwabEquityAwardsJSONParser,
+        FreetradeParser,
+        HargreavesLansdownParser,
+        InteractiveBrokersParser,
+        MSSBParser,
         SharesightParser,
         Trading212Parser,
-        MSSBParser,
         VanguardParser,
-        InteractiveBrokersParser,
-        HargreavesLansdownParser,
-        # Add new brokers here
+        RawParser,
     ]
 
     @staticmethod

--- a/docs/brokers/index.md
+++ b/docs/brokers/index.md
@@ -7,13 +7,13 @@ export instructions.
 | Broker                                        | CLI option                             | Notes                                |
 | --------------------------------------------- | -------------------------------------- | ------------------------------------ |
 | [Charles Schwab](schwab.md)                   | `--schwab-file`, `--schwab-award-file` | Equity awards supported              |
-| [Trading 212](trading212.md)                  | `--trading212-dir`                     | Folder of yearly exports             |
+| [Freetrade](freetrade.md)                     | `--freetrade-file`                     | Activity CSV export                  |
+| [Hargreaves Lansdown](hargreaves-lansdown.md) | `--hl-dir`                             | CSVs plus contract-note PDFs         |
+| [Interactive Brokers](interactive-brokers.md) | `--interactive-brokers-file`           | Transaction history CSV              |
 | [Morgan Stanley](morgan-stanley.md)           | `--mssb-dir`                           | Folder from the report download page |
 | [Sharesight](sharesight.md)                   | `--sharesight-dir`                     | Multi-broker portfolio tracker       |
-| [Hargreaves Lansdown](hargreaves-lansdown.md) | `--hl-dir`                             | CSVs plus contract-note PDFs         |
+| [Trading 212](trading212.md)                  | `--trading212-dir`                     | Folder of yearly exports             |
 | [Vanguard](vanguard.md)                       | `--vanguard-file`                      | Excel export tab saved as CSV        |
-| [Freetrade](freetrade.md)                     | `--freetrade-file`                     | Activity CSV export                  |
-| [Interactive Brokers](interactive-brokers.md) | `--interactive-brokers-file`           | Transaction history CSV              |
 | [RAW format](raw.md)                          | `--raw-file`                           | Generic fallback for other brokers   |
 
 If your broker is not listed, try the [RAW format](raw.md). Contributions for new brokers are very

--- a/docs/development/adding-a-broker.md
+++ b/docs/development/adding-a-broker.md
@@ -6,5 +6,6 @@
    [`cgt_calc/parsers/broker_registry.py`](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/parsers/broker_registry.py)
 3. Add tests in `tests/`
 4. Add a docs page under `docs/brokers/` and a nav entry in `zensical.toml`, and add the broker to
-   the table in [Brokers](../brokers/index.md)
+   the table in [Brokers](../brokers/index.md) and the list in the README. All three are sorted by
+   broker name, with the RAW format left last
 5. Submit a pull request describing your changes

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 
 Easily calculate **UK Capital Gains Tax** from your investment transaction history.
 
-Supported sources include **Charles Schwab**, **Trading 212**, **Morgan Stanley**, **Sharesight**,
-**Hargreaves Lansdown**, **Vanguard**, **Freetrade**, **Interactive Brokers**, or a custom **RAW**
+Supported sources include **Charles Schwab**, **Freetrade**, **Hargreaves Lansdown**, **Interactive
+Brokers**, **Morgan Stanley**, **Sharesight**, **Trading 212**, **Vanguard**, or a custom **RAW**
 format.
 
 The tool generates a detailed **PDF report** with all calculations.

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -961,11 +961,11 @@ def test_run_with_example_files() -> None:
     assert stderr_lines[:-2] == [
         "Parsing tests/schwab/data/schwab_transactions.csv...",
         "Loaded 13 transactions from Charles Schwab",
-        "Parsing tests/trading212/data/2020/from_2020-09-11_to_2021-04-02.csv...",
-        "Loaded 8 transactions from Trading 212",
         "Parsing tests/morgan_stanley/data/Releases Report.csv...",
         "Parsing tests/morgan_stanley/data/Withdrawals Report.csv...",
         "Loaded 6 transactions from Morgan Stanley",
+        "Parsing tests/trading212/data/2020/from_2020-09-11_to_2021-04-02.csv...",
+        "Loaded 8 transactions from Trading 212",
         "Found 27 broker transactions",
         "First pass complete",
         "Bed & breakfast match: VUAG disposed 2020-06-03, re-acquired 2020-07-02",

--- a/zensical.toml
+++ b/zensical.toml
@@ -18,13 +18,14 @@ nav = [
     { "Brokers" = [
       "brokers/index.md",
       { "Charles Schwab" = "brokers/schwab.md" },
-      { "Trading 212" = "brokers/trading212.md" },
+      { "Freetrade" = "brokers/freetrade.md" },
+      { "Hargreaves Lansdown" = "brokers/hargreaves-lansdown.md" },
+      { "Interactive Brokers" = "brokers/interactive-brokers.md" },
       { "Morgan Stanley" = "brokers/morgan-stanley.md" },
       { "Sharesight" = "brokers/sharesight.md" },
-      { "Hargreaves Lansdown" = "brokers/hargreaves-lansdown.md" },
+      { "Trading 212" = "brokers/trading212.md" },
       { "Vanguard" = "brokers/vanguard.md" },
-      { "Freetrade" = "brokers/freetrade.md" },
-      { "Interactive Brokers" = "brokers/interactive-brokers.md" },
+      # The generic fallback belongs after the named brokers.
       { "RAW format" = "brokers/raw.md" },
     ] },
     { "Offshore funds (ERI)" = "offshore-funds.md" },


### PR DESCRIPTION
The nav, the brokers table, both intro paragraphs, and the parser registry each carried the order the old README's collapsible sections happened to use. All five are now sorted by broker name, with the RAW fallback last so it isn't mistaken for another provider.

The registry order decides how transactions from different brokers interleave, since the date sort that follows is stable. The example report and its LaTeX are byte-identical either way; only the order of the progress lines the integration test asserts on moves.