### PR TITLE
Let GitHub autolink the commit in the docs preview comment

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -122,7 +122,7 @@ jobs:
             --jq ".[] | select(.body | startswith(\"${COMMENT_MARKER}\")) | .id" | head -1)
           if [ -n "${ID}" ]; then
             UPDATED=$(TZ='Europe/London' date '+%Y-%m-%d %H:%M %Z')
-            BODY=$(printf '%s\n📖 No rendered changes — this PR matches the live docs at https://cgt-calc.uk/\n\n_Checked `%s` · updated %s_' \
+            BODY=$(printf '%s\n📖 No rendered changes — this PR matches the live docs at https://cgt-calc.uk/\n\n_Checked %s · updated %s_' \
               "${COMMENT_MARKER}" "${HEAD_SHA:0:7}" "${UPDATED}")
             gh api --method PATCH "repos/${GH_REPO}/issues/comments/${ID}" -f body="${BODY}"
           fi
@@ -174,7 +174,7 @@ jobs:
             # Editing an existing comment — note when it was refreshed.
             FRESHNESS=" · updated ${UPDATED}"
           fi
-          BODY=$(printf '%s\n📖 **Docs preview:** %s\n\n_Built from `%s`%s_' \
+          BODY=$(printf '%s\n📖 **Docs preview:** %s\n\n_Built from %s%s_' \
             "${COMMENT_MARKER}" "${URL}" "${SHORT_SHA}" "${FRESHNESS}")
           if [ -n "${ID}" ]; then
             gh api --method PATCH "repos/${GH_REPO}/issues/comments/${ID}" -f body="${BODY}"


### PR DESCRIPTION
The short sha in the footer was wrapped in code quoting, which stops GitHub from turning it into a link to the commit. Plain text lets the autolink through.