### PR TITLE
Clarify calculator scope in docs and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,23 @@
 
 # <img src="docs/assets/logo.svg" alt="" width="34" valign="middle"> UK Capital Gains Calculator
 
-Easily calculate **UK Capital Gains Tax** from your investment transaction history.
+Prepare **UK tax figures** from your investment transaction history and generate a detailed
+calculation report. cgt-calc is intended for UK individual investors working from supported broker
+exports.
 
 Supported sources include **Charles Schwab**, **Freetrade**, **Hargreaves Lansdown**, **Interactive
 Brokers**, **Morgan Stanley**, **Sharesight**, **Trading 212**, **Vanguard**, or a custom **RAW**
 format.
 
-The tool generates a detailed **PDF report** with all calculations.
+For supported transactions, the tool converts prices to **GBP** and applies the UK **same-day**,
+**30-day (“bed and breakfast”)**, and **Section 104 holding** rules. It summarizes disposal
+proceeds, allowable costs, gains, losses, dividends, and interest in the terminal and a detailed
+**PDF report**.
 
-All prices are automatically converted to **GBP**, and all **HMRC rules** are applied — including
-the **same-day**, **bed and breakfast**, and **Section 104 holding** rules.
+cgt-calc does **not** calculate your final tax bill or submit a tax return. Some investment
+scenarios are not supported; check the relevant [broker guide](https://cgt-calc.uk/brokers/) and the
+[offshore funds limitations](https://cgt-calc.uk/offshore-funds/#unsupported-functionality) before
+relying on the result.
 
 ## 📊 Example Report
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # <img src="docs/assets/logo.svg" alt="" width="34" valign="middle"> UK Capital Gains Calculator
 
-Prepare **UK tax figures** from your investment transaction history and generate a detailed
+Calculate your **UK capital gains** from your investment transaction history and generate a detailed
 calculation report. cgt-calc is intended for UK individual investors working from supported broker
 exports.
 
@@ -13,12 +13,15 @@ Brokers**, **Morgan Stanley**, **Sharesight**, **Trading 212**, **Vanguard**, or
 format.
 
 For supported transactions, the tool converts prices to **GBP** and applies the UK **same-day**,
-**30-day (“bed and breakfast”)**, and **Section 104 holding** rules. It summarizes disposal
-proceeds, allowable costs, gains, losses, dividends, and interest in the terminal and a detailed
-**PDF report**.
+**30-day ("bed and breakfast")**, and **Section 104 holding** rules. It prints a summary of disposal
+proceeds, allowable costs, gains, losses, dividends, and interest to the terminal and writes the
+full calculations to a **PDF report**.
 
-cgt-calc does **not** calculate your final tax bill or submit a tax return. Some investment
-scenarios are not supported; check the relevant [broker guide](https://cgt-calc.uk/brokers/) and the
+cgt-calc reports the net gain from the transactions you supply and, for supported tax years,
+estimates the amount remaining after the annual exempt amount. It does **not** account for gains or
+losses outside those inputs, apply tax rates, work out your final tax bill, or submit a tax return.
+Some investment scenarios are not supported; check the relevant
+[broker guide](https://cgt-calc.uk/brokers/) and the
 [offshore funds limitations](https://cgt-calc.uk/offshore-funds/#unsupported-functionality) before
 relying on the result.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,22 @@
 # UK Capital Gains Calculator
 
-Easily calculate **UK Capital Gains Tax** from your investment transaction history.
+Prepare **UK tax figures** from your investment transaction history and generate a detailed
+calculation report. cgt-calc is intended for UK individual investors working from supported broker
+exports.
 
 Supported sources include **Charles Schwab**, **Freetrade**, **Hargreaves Lansdown**, **Interactive
 Brokers**, **Morgan Stanley**, **Sharesight**, **Trading 212**, **Vanguard**, or a custom **RAW**
 format.
 
-The tool generates a detailed **PDF report** with all calculations.
+For supported transactions, the tool converts prices to **GBP** and applies the UK **same-day**,
+**30-day (“bed and breakfast”)**, and **Section 104 holding** rules. It summarizes disposal
+proceeds, allowable costs, gains, losses, dividends, and interest in the terminal and a detailed
+**PDF report**.
 
-All prices are automatically converted to **GBP**, and all **HMRC rules** are applied — including
-the **same-day**, **bed and breakfast**, and **Section 104 holding** rules.
+cgt-calc does **not** calculate your final tax bill or submit a tax return. Some investment
+scenarios are not supported; check the relevant [broker guide](brokers/index.md) and the
+[offshore funds limitations](offshore-funds.md#unsupported-functionality) before relying on the
+result.
 
 The PDF report includes separate **Capital Gains** and **Interest and Dividends** sections, with a
 summary at the end. Interest is grouped **monthly per broker** to keep reports concise, even for

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # UK Capital Gains Calculator
 
-Prepare **UK tax figures** from your investment transaction history and generate a detailed
+Calculate your **UK capital gains** from your investment transaction history and generate a detailed
 calculation report. cgt-calc is intended for UK individual investors working from supported broker
 exports.
 
@@ -9,13 +9,15 @@ Brokers**, **Morgan Stanley**, **Sharesight**, **Trading 212**, **Vanguard**, or
 format.
 
 For supported transactions, the tool converts prices to **GBP** and applies the UK **same-day**,
-**30-day (“bed and breakfast”)**, and **Section 104 holding** rules. It summarizes disposal
-proceeds, allowable costs, gains, losses, dividends, and interest in the terminal and a detailed
-**PDF report**.
+**30-day ("bed and breakfast")**, and **Section 104 holding** rules. It prints a summary of disposal
+proceeds, allowable costs, gains, losses, dividends, and interest to the terminal and writes the
+full calculations to a **PDF report**.
 
-cgt-calc does **not** calculate your final tax bill or submit a tax return. Some investment
-scenarios are not supported; check the relevant [broker guide](brokers/index.md) and the
-[offshore funds limitations](offshore-funds.md#unsupported-functionality) before relying on the
+cgt-calc reports the net gain from the transactions you supply and, for supported tax years,
+estimates the amount remaining after the annual exempt amount. It does **not** account for gains or
+losses outside those inputs, apply tax rates, work out your final tax bill, or submit a tax return.
+Some investment scenarios are not supported; check the relevant [broker guide](brokers/index.md) and
+the [offshore funds limitations](offshore-funds.md#unsupported-functionality) before relying on the
 result.
 
 The PDF report includes separate **Capital Gains** and **Interest and Dividends** sections, with a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "uv_build"
 [project]
 name = "cgt-calc"
 version = "0.0.0"
-description = "Calculate UK capital gains tax from broker exports — supports Charles Schwab, Trading 212, Morgan Stanley, Sharesight, Hargreaves Lansdown and Vanguard."
+description = "Calculate UK capital gains from broker exports — supports Charles Schwab, Freetrade, Hargreaves Lansdown, Interactive Brokers, Morgan Stanley, Sharesight, Trading 212, Vanguard and a custom RAW format."
 authors = [{ name = "Ruslan Sayfutdinov", email = "ruslan@sayfutdinov.com" }]
 readme = "README.md"
 license = { text = "MIT" }

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,7 +1,7 @@
 [project]
 site_name = "UK Capital Gains Calculator"
 site_url = "https://cgt-calc.uk/"
-site_description = "Calculate UK Capital Gains Tax from your investment transaction history and generate a detailed PDF report."
+site_description = "Calculate UK capital gains from your investment transaction history and generate a detailed PDF report."
 site_author = "Ruslan Sayfutdinov"
 repo_url = "https://github.com/KapJI/capital-gains-calculator"
 repo_name = "KapJI/capital-gains-calculator"


### PR DESCRIPTION
The README and docs landing page claimed "all HMRC rules are applied". Replace that with what the tool actually does — the matching rules it applies, what it reports, and where it stops (no tax rates, no gains or losses outside the supplied transactions, no return) — and link the broker guides and offshore-funds limitations. Align the PyPI and site descriptions with the same wording and complete the PyPI broker list.