### PR TITLE
Add an Isin value type in place of bare ISIN strings

### DIFF
--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -22,8 +22,9 @@ from .exceptions import (
     ParsingError,
     UnexpectedColumnCountError,
 )
+from .model import Isin
 from .resources import RESOURCES_PACKAGE
-from .util import is_isin, open_with_parents
+from .util import open_with_parents
 
 if TYPE_CHECKING:
     from importlib.resources.abc import Traversable
@@ -39,16 +40,17 @@ LOGGER = logging.getLogger(__name__)
 class IsinTranslationEntry:
     """Entry from ISIN Translation file."""
 
-    isin: str
+    isin: Isin
     symbols: set[str]
 
     def __init__(self, row: list[str], file: Path):
         """Create entry from CSV row."""
         if len(row) < ISIN_TRANSLATION_COLUMNS_NUM:
             raise UnexpectedColumnCountError(row, ISIN_TRANSLATION_COLUMNS_NUM, file)
-        self.isin = row[0]
-        if not is_isin(self.isin):
-            raise ParsingError(file, f"Row contains invalid ISIN '{self.isin}'")
+        isin = Isin.parse(row[0])
+        if isin is None:
+            raise ParsingError(file, f"Row contains invalid ISIN '{row[0]}'")
+        self.isin = isin
         self.symbols = set(row[1:])
 
     @override
@@ -71,20 +73,16 @@ class IsinConverter:
         )
         self.session = RateLimitedRequestsSession(limiter)
         self.isin_translation_file = isin_translation_file
-        self.data: dict[str, set[str]] = {}
-        self.write_data: dict[str, set[str]] = {}
+        self.data: dict[Isin, set[str]] = {}
+        self.write_data: dict[Isin, set[str]] = {}
         self._read_isin_translation_data()
         self.validate_data()
 
     def validate_data(self) -> None:
         """Validate the current ISIN translation data."""
 
-        reverse_cache: dict[str, str] = {}
+        reverse_cache: dict[str, Isin] = {}
         for isin, symbols in self.data.items():
-            if not is_isin(isin):
-                raise IsinTranslationError(
-                    f"Invalid ISIN found in translation data: {isin}"
-                )
             if symbols == {""}:
                 continue
             for symbol in symbols:
@@ -103,11 +101,6 @@ class IsinConverter:
     def add_from_transaction(self, transaction: BrokerTransaction) -> None:
         """Add the ISIN to symbol mapping from an existing transaction."""
         if transaction.symbol and transaction.isin:
-            if not is_isin(transaction.isin):
-                raise InvalidTransactionError(
-                    transaction,
-                    f"Transaction uses invalid ISIN {transaction.isin}",
-                )
             current_symbols = self.data.get(transaction.isin)
             if current_symbols and transaction.symbol not in current_symbols:
                 raise InvalidTransactionError(
@@ -123,7 +116,7 @@ class IsinConverter:
                 )
                 self._write_isin_translation_file()
 
-    def get_symbols(self, isin: str) -> set[str]:
+    def get_symbols(self, isin: Isin) -> set[str]:
         """Return the set of symbols associated with the input ISIN (may be empty)."""
         result = self.data.get(isin)
         if result is None:
@@ -134,7 +127,7 @@ class IsinConverter:
                 self._write_isin_translation_file()
         return result
 
-    def get_symbol_to_isin_map(self) -> dict[str, str]:
+    def get_symbol_to_isin_map(self) -> dict[str, Isin]:
         """Return a map from symbols to ISINs."""
         symbol_to_isin = {}
         for isin, symbols in self.data.items():
@@ -145,7 +138,7 @@ class IsinConverter:
     def _read_isin_translation_data(self) -> None:
         """Read ISIN translation data from bundled and user-provided sources."""
 
-        def load(source: Traversable | Path) -> dict[str, set[str]]:
+        def load(source: Traversable | Path) -> dict[Isin, set[str]]:
             """Load ISIN translation data from a CSV source."""
             file_label = (
                 source if isinstance(source, Path) else Path("resources") / source.name
@@ -162,7 +155,7 @@ class IsinConverter:
                     f"expected {ISIN_TRANSLATION_HEADER}, found {header}",
                     row_index=1,
                 )
-            entries: dict[str, set[str]] = {}
+            entries: dict[Isin, set[str]] = {}
             for index, row in enumerate(lines[1:], start=2):
                 try:
                     entry = IsinTranslationEntry(row, file_label)
@@ -195,7 +188,7 @@ class IsinConverter:
             writer = csv.writer(fout)
             writer.writerows([ISIN_TRANSLATION_HEADER, *data_rows])
 
-    def _fetch_live(self, isin: str) -> set[str]:
+    def _fetch_live(self, isin: Isin) -> set[str]:
         LOGGER.info("Looking up ISIN %s via OpenFIGI...", isin)
         url = "https://api.openfigi.com/v3/mapping"
         headers = {"Content-type": "application/json"}

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -6,16 +6,55 @@ from dataclasses import dataclass, field
 import datetime
 from decimal import Decimal
 from enum import Enum
+import re
 import sys
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, Final, Self, override
 
 from colorama import Style
 
 from .logging import bullet, style_text
-from .util import approx_equal, is_currency, normalize_amount, round_decimal
+from .util import (
+    approx_equal,
+    is_currency,
+    luhn_check_digit,
+    normalize_amount,
+    round_decimal,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+
+_ISIN_REGEX: Final = re.compile(r"^[A-Z]{2}[A-Z0-9]{9}[0-9]$")
+_ISIN_CHARS: Final = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+class Isin(str):
+    """ISIN (ISO 6166) security identifier.
+
+    Validated and normalised on construction, so every instance is a
+    well-formed identifier with a correct check digit.
+    """
+
+    __slots__ = ()
+
+    def __new__(cls, value: str) -> Self:
+        """Normalise and validate the identifier."""
+        normalised = value.strip().upper()
+        if not _ISIN_REGEX.match(normalised):
+            raise ValueError(f"Invalid ISIN: {value!r}")
+        payload = "".join(str(_ISIN_CHARS.index(char)) for char in normalised[:11])
+        if luhn_check_digit(payload) != int(normalised[11]):
+            raise ValueError(f"Invalid ISIN checksum: {value!r}")
+        return super().__new__(cls, normalised)
+
+    @classmethod
+    def parse(cls, value: str) -> Self | None:
+        """Return the identifier, or None when the value is not an ISIN."""
+        try:
+            return cls(value)
+        except ValueError:
+            return None
 
 
 @dataclass
@@ -184,7 +223,7 @@ class BrokerTransaction:
     amount: Decimal | None
     currency: str
     broker: str
-    isin: str | None = None
+    isin: Isin | None = None
     # Fees paid in currencies other than `currency`, keyed by their own
     # currency. Converted and folded into `fees` by the calculation engine.
     foreign_fees: dict[str, Decimal] = field(default_factory=dict)
@@ -194,6 +233,10 @@ class BrokerTransaction:
         assert is_currency(self.currency), (
             f"Invalid Currency {self.currency} for transaction {self}"
         )
+        # Callers that bypass the type checker still get a validated value;
+        # to mypy the annotation already rules this out.
+        if self.isin is not None and not isinstance(self.isin, Isin):
+            self.isin = Isin(self.isin)  # type: ignore[unreachable]
 
 
 class RuleType(Enum):

--- a/cgt_calc/parsers/eri/importer/blackrock.py
+++ b/cgt_calc/parsers/eri/importer/blackrock.py
@@ -10,7 +10,8 @@ import dateutil.parser as date_parser
 import pandas as pd
 
 from cgt_calc.exceptions import ParsingError
-from cgt_calc.util import is_currency, is_isin, round_decimal
+from cgt_calc.model import Isin
+from cgt_calc.util import is_currency, round_decimal
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -109,10 +110,10 @@ class BlackrockImporter(ERIImporter):
                     )
 
         for _, row in cleaned_df.iterrows():
-            isin = row[ISIN_COLUMN]
-            if not isinstance(isin, str) or not is_isin(isin.upper()):
-                raise ParsingError(file, f"Not valid ISIN {isin}")
-            isin = isin.upper()
+            isin_raw = row[ISIN_COLUMN]
+            isin = Isin.parse(isin_raw) if isinstance(isin_raw, str) else None
+            if isin is None:
+                raise ParsingError(file, f"Not valid ISIN {isin_raw}")
 
             currency = row[CURRENCY_COLUMN]
             if not isinstance(currency, str):

--- a/cgt_calc/parsers/eri/importer/invesco.py
+++ b/cgt_calc/parsers/eri/importer/invesco.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING, override
 import dateutil.parser as date_parser
 import pdfplumber
 
-from cgt_calc.util import is_isin, round_decimal
+from cgt_calc.model import Isin
+from cgt_calc.util import round_decimal
 
 if TYPE_CHECKING:
     import datetime
@@ -124,15 +125,16 @@ class InvescoImporter(ERIImporter):
             row = {}
             for col, pos in colmap.items():
                 row[col] = (raw_row[pos] or "").strip()
-            isin = row[ISIN_COLUMN]
-            if not isin:
+            isin_raw = row[ISIN_COLUMN]
+            if not isin_raw:
                 # probably a subrow
                 continue
             if re.match(r"(\*\*? Distribution|Note 1).*", raw_row[0] or ""):
                 # not part of the table
                 continue
-            assert is_isin(isin), (
-                f"Bad ISIN in page {page_num}, row {row_num}: {row[ISIN_COLUMN]}"
+            isin = Isin.parse(isin_raw)
+            assert isin is not None, (
+                f"Bad ISIN in page {page_num}, row {row_num}: {isin_raw}"
             )
             currency = row[CURRENCY_COLUMN].replace("JPN", "JPY")
             assert re.match(CURRENCY_REGEX, currency), (

--- a/cgt_calc/parsers/eri/importer/vanguard.py
+++ b/cgt_calc/parsers/eri/importer/vanguard.py
@@ -10,7 +10,8 @@ import dateutil.parser as date_parser
 import pandas as pd
 
 from cgt_calc.exceptions import ParsingError
-from cgt_calc.util import is_currency, is_isin, round_decimal
+from cgt_calc.model import Isin
+from cgt_calc.util import is_currency, round_decimal
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -104,10 +105,10 @@ class VanguardImporter(ERIImporter):
                     )
 
         for _, row in cleaned_df.iterrows():
-            isin = row[ISIN_COLUMN]
-            if not isinstance(isin, str) or not is_isin(isin.upper()):
-                raise ParsingError(file, f"Not valid ISIN {isin}")
-            isin = isin.upper()
+            isin_raw = row[ISIN_COLUMN]
+            isin = Isin.parse(isin_raw) if isinstance(isin_raw, str) else None
+            if isin is None:
+                raise ParsingError(file, f"Not valid ISIN {isin_raw}")
 
             currency = row[CURRENCY_COLUMN]
             if not isinstance(currency, str):

--- a/cgt_calc/parsers/eri/importer/xtrackers.py
+++ b/cgt_calc/parsers/eri/importer/xtrackers.py
@@ -10,8 +10,9 @@ from typing import TYPE_CHECKING, override
 import dateutil.parser as date_parser
 import pdfplumber
 
+from cgt_calc.model import Isin
 from cgt_calc.parsers.eri.model import ERITransaction
-from cgt_calc.util import is_isin, round_decimal
+from cgt_calc.util import round_decimal
 
 from .model import ERIImporter, ERIImporterOutput
 
@@ -159,9 +160,10 @@ class XtrackersImporter(ERIImporter):
             for col, pos in colmap.items():
                 row[col] = (raw_row[pos] or "").strip() if pos < len(raw_row) else ""
 
-            isin = row[ISIN_COLUMN]
-            assert is_isin(isin), (
-                f"Bad ISIN in page {page_num}, row {row_num}: {isin!r}"
+            isin_raw = row[ISIN_COLUMN]
+            isin = Isin.parse(isin_raw)
+            assert isin is not None, (
+                f"Bad ISIN in page {page_num}, row {row_num}: {isin_raw!r}"
             )
             currency = row[CURRENCY_COLUMN].replace("JPN", "JPY")
             assert re.match(CURRENCY_REGEX, currency), (

--- a/cgt_calc/parsers/eri/model.py
+++ b/cgt_calc/parsers/eri/model.py
@@ -3,7 +3,7 @@
 import datetime
 from decimal import Decimal
 
-from cgt_calc.model import ActionType, BrokerTransaction
+from cgt_calc.model import ActionType, BrokerTransaction, Isin
 
 
 class ERITransaction(BrokerTransaction):
@@ -12,7 +12,7 @@ class ERITransaction(BrokerTransaction):
     def __init__(
         self,
         date: datetime.date,
-        isin: str,
+        isin: Isin,
         price: Decimal,
         currency: str,
     ) -> None:

--- a/cgt_calc/parsers/eri/raw.py
+++ b/cgt_calc/parsers/eri/raw.py
@@ -17,9 +17,9 @@ if TYPE_CHECKING:
 
 from cgt_calc.const import ERI_RESOURCE_FOLDER
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
+from cgt_calc.model import Isin
 from cgt_calc.parsers.base_parsers import BaseSingleFileParser
 from cgt_calc.resources import RESOURCES_PACKAGE
-from cgt_calc.util import is_isin
 
 from .model import ERITransaction
 
@@ -44,9 +44,10 @@ class ERIRaw(ERITransaction):
 
         row = dict(zip(header, row_raw, strict=True))
 
-        isin = row["ISIN"]
-        if not is_isin(isin):
-            raise ParsingError(file, f"Invalid ISIN value '{isin}' in ERI data")
+        isin_raw = row["ISIN"]
+        isin = Isin.parse(isin_raw)
+        if isin is None:
+            raise ParsingError(file, f"Invalid ISIN value '{isin_raw}' in ERI data")
         date_str = row["Fund Reporting Period End Date"]
         try:
             date = datetime.datetime.strptime(date_str, RAW_DATE_FORMAT).date()

--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -14,7 +14,7 @@ from cgt_calc.exceptions import (
     UnsupportedBrokerActionError,
     UnsupportedBrokerCurrencyError,
 )
-from cgt_calc.model import ActionType, BrokerTransaction
+from cgt_calc.model import ActionType, BrokerTransaction, Isin
 
 from .base_parsers import BaseSingleFileParser
 
@@ -166,7 +166,8 @@ class FreetradeTransaction(BrokerTransaction):
         if amount_negative:
             amount *= -1
 
-        isin = row.get(FreetradeColumn.ISIN) or None
+        isin_raw = row.get(FreetradeColumn.ISIN)
+        isin = Isin(isin_raw) if isin_raw else None
 
         super().__init__(
             date=datetime.fromisoformat(row[FreetradeColumn.TIMESTAMP]).date(),

--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -11,7 +11,7 @@ from typing import ClassVar, TextIO, override
 import pdfplumber
 
 from cgt_calc.exceptions import ParsingError
-from cgt_calc.model import ActionType, BrokerTransaction
+from cgt_calc.model import ActionType, BrokerTransaction, Isin
 from cgt_calc.parsers.base_parsers import BaseDirParser, StandardCSVParser
 
 # PDF parser regexes
@@ -34,7 +34,7 @@ class HLPdfData:
     date: date | None
     action: str | None
     ticker: str | None
-    isin: str | None
+    isin: Isin | None
     quantity: Decimal
     price: Decimal
     consideration: Decimal
@@ -114,12 +114,21 @@ class HargreavesLansdownParser(StandardCSVParser, BaseDirParser):
             Decimal(fees_match.group(1).replace(",", "")) if fees_match else Decimal(0)
         )
 
+        isin = None
+        if isin_ticker_match:
+            isin = Isin.parse(isin_ticker_match.group(1))
+            if isin is None:
+                raise ParsingError(
+                    pdf_path,
+                    f"Invalid ISIN in contract note: {isin_ticker_match.group(1)!r}",
+                )
+
         return HLPdfData(
             file_name=pdf_path.name,
             date=datetime.strptime(date_str, "%d/%m/%Y").date() if date_str else None,
             action=action_match.group(1).lower() if action_match else None,
             ticker=isin_ticker_match.group(2) if isin_ticker_match else None,
-            isin=isin_ticker_match.group(1) if isin_ticker_match else None,
+            isin=isin,
             quantity=quantity,
             price=price,
             consideration=consideration,

--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -12,8 +12,7 @@ from typing import TYPE_CHECKING, ClassVar, Final, override
 
 from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import ParsingError
-from cgt_calc.model import ActionType, BrokerTransaction
-from cgt_calc.util import is_isin
+from cgt_calc.model import ActionType, BrokerTransaction, Isin
 
 from .base_parsers import StandardCSVParser
 
@@ -31,13 +30,12 @@ EXPECTED_COLS_IN_SUMMARY_SECTION: Final[int] = 4
 _ISIN_IN_DESCRIPTION_RE: Final = re.compile(r"^[^\s(]+\((?P<isin>[A-Z0-9]{12})\)")
 
 
-def _isin_from_description(description: str) -> str | None:
+def _isin_from_description(description: str) -> Isin | None:
     """Return the ISIN the description is prefixed with, if it has one."""
     match = _ISIN_IN_DESCRIPTION_RE.match(description)
     if match is None:
         return None
-    isin = match.group("isin")
-    return isin if is_isin(isin) else None
+    return Isin.parse(match.group("isin"))
 
 
 class InteractiveBrokersColumn(StrEnum):

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
 
 from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
-from cgt_calc.model import ActionType, BrokerTransaction
+from cgt_calc.model import ActionType, BrokerTransaction, Isin
 
 from .base_parsers import BaseDirParser
 
@@ -315,7 +315,8 @@ class Trading212Transaction(BrokerTransaction):
                         float(discrepancy),
                     )
 
-        isin = row[Trading212Column.ISIN]
+        isin_raw = row[Trading212Column.ISIN]
+        isin = Isin(isin_raw) if isin_raw else None
         self.transaction_id = row.get(Trading212Column.TRANSACTION_ID)
         self.notes = row.get(Trading212Column.NOTES)
         broker = "Trading212"

--- a/cgt_calc/util.py
+++ b/cgt_calc/util.py
@@ -3,7 +3,6 @@
 import decimal
 from decimal import Decimal
 from pathlib import Path
-import re
 from typing import TextIO
 
 import iso4217parse
@@ -57,21 +56,6 @@ def luhn_check_digit(payload: str) -> int:
     return (
         10 - (checksum % 10)
     ) % 10  # using mod operator twice ensures the check digit is < 10
-
-
-def is_isin(isin: str) -> bool:
-    """Validate if a string is a valid ISIN."""
-    # https://en.wikipedia.org/wiki/International_Securities_Identification_Number
-    isin_regex = r"^([A-Z]{2})([A-Z0-9]{9})([0-9])$"
-    isin_char_idxs = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-    if not re.match(isin_regex, isin):
-        return False
-    payload = isin[:11]
-    check_digit = int(isin[11])
-
-    payload = "".join(str(isin_char_idxs.index(c)) for c in list(payload))
-    return luhn_check_digit(payload) == check_digit
 
 
 def approx_equal(

--- a/tests/general/calc_test_data.py
+++ b/tests/general/calc_test_data.py
@@ -7,7 +7,13 @@ from decimal import Decimal
 
 import pytest
 
-from cgt_calc.model import ActionType, BrokerTransaction, CalculationEntry, RuleType
+from cgt_calc.model import (
+    ActionType,
+    BrokerTransaction,
+    CalculationEntry,
+    Isin,
+    RuleType,
+)
 from cgt_calc.util import round_decimal
 
 
@@ -56,7 +62,7 @@ def dividend_tax_transaction(
 
 def eri_transaction(
     date: datetime.date,
-    isin: str,
+    isin: Isin,
     price: float,
 ) -> BrokerTransaction:
     """Create excess reported income transaction."""
@@ -70,7 +76,7 @@ def buy_transaction(
     price: float,
     fees: float,
     amount: float,
-    isin: str | None = None,
+    isin: Isin | None = None,
 ) -> BrokerTransaction:
     """Create buy transaction."""
     return transaction(
@@ -92,7 +98,7 @@ def sell_transaction(
     price: float,
     fees: float,
     amount: float,
-    isin: str | None = None,
+    isin: Isin | None = None,
 ) -> BrokerTransaction:
     """Create sell transaction."""
     return transaction(
@@ -130,7 +136,7 @@ def transaction(
     fees: float = 0.0,
     amount: float | None = None,
     currency: str = "USD",
-    isin: str | None = None,
+    isin: Isin | None = None,
 ) -> BrokerTransaction:
     """Create transaction."""
     return BrokerTransaction(

--- a/tests/general/calc_test_data_2.py
+++ b/tests/general/calc_test_data_2.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 import pytest
 
-from cgt_calc.model import ActionType, CalculationEntry, RuleType, SpinOff
+from cgt_calc.model import ActionType, CalculationEntry, Isin, RuleType, SpinOff
 
 from .calc_test_data import (
     buy_transaction,
@@ -462,7 +462,7 @@ calc_basic_data_2 = [
                 price=101.1,
                 fees=1,
                 amount=-50551,
-                isin="USFOO0000006",
+                isin=Isin("USFOO0000006"),
             ),
             buy_transaction(
                 date=datetime.date(day=2, month=6, year=2023),
@@ -471,11 +471,11 @@ calc_basic_data_2 = [
                 price=102.1,
                 fees=1.0,
                 amount=-10211.0,
-                isin="USFOO0000006",
+                isin=Isin("USFOO0000006"),
             ),
             eri_transaction(
                 date=datetime.date(day=1, month=7, year=2023),
-                isin="USFOO0000006",
+                isin=Isin("USFOO0000006"),
                 price=2.1,
             ),
             sell_transaction(
@@ -485,7 +485,7 @@ calc_basic_data_2 = [
                 price=130,
                 fees=1,
                 amount=3899,
-                isin="USFOO0000006",
+                isin=Isin("USFOO0000006"),
             ),
         ],
         797.90,  # Expected capital gain/loss
@@ -584,7 +584,7 @@ calc_basic_data_2 = [
                 price=1.5,
                 fees=0,
                 amount=-14250,
-                isin="USMSP0000000",
+                isin=Isin("USMSP0000000"),
             ),
             sell_transaction(
                 date=datetime.date(day=30, month=8, year=2020),
@@ -593,16 +593,16 @@ calc_basic_data_2 = [
                 price=1.5,
                 fees=0,
                 amount=6000,
-                isin="USMSP0000000",
+                isin=Isin("USMSP0000000"),
             ),
             eri_transaction(
                 date=datetime.date(day=1, month=9, year=2020),
-                isin="USMSP0000000",
+                isin=Isin("USMSP0000000"),
                 price=0.4,
             ),
             eri_transaction(
                 date=datetime.date(day=10, month=9, year=2020),
-                isin="USMSP0000000",
+                isin=Isin("USMSP0000000"),
                 price=0.2,
             ),
             buy_transaction(
@@ -612,7 +612,7 @@ calc_basic_data_2 = [
                 price=1.7,
                 fees=0,
                 amount=-850,
-                isin="USMSP0000000",
+                isin=Isin("USMSP0000000"),
             ),
         ],
         -100.0,  # Expected capital gain/loss

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -19,7 +19,13 @@ from cgt_calc.exceptions import CalculationError, InvalidTransactionError
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.main import CapitalGainsCalculator, main
-from cgt_calc.model import ActionType, BrokerTransaction, CapitalGainsReport, RuleType
+from cgt_calc.model import (
+    ActionType,
+    BrokerTransaction,
+    CapitalGainsReport,
+    Isin,
+    RuleType,
+)
 from cgt_calc.parsers.broker_registry import _transaction_sort_key
 from cgt_calc.parsers.eri.model import ERITransaction
 from cgt_calc.spin_off_handler import SpinOffHandler
@@ -169,7 +175,7 @@ def test_interest_tax_reversals_cancel_across_months() -> None:
     assert report.total_interest_tax == Decimal(0)
 
 
-ERI_ISIN = "US5949181045"
+ERI_ISIN = Isin("US5949181045")
 
 
 def test_eri_duplicate_report_within_tolerance_is_skipped(

--- a/tests/general/test_dividend_source_country.py
+++ b/tests/general/test_dividend_source_country.py
@@ -12,7 +12,7 @@ from cgt_calc.current_price_fetcher import CurrentPriceFetcher
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.main import CapitalGainsCalculator
-from cgt_calc.model import ActionType, BrokerTransaction, RuleType
+from cgt_calc.model import ActionType, BrokerTransaction, Isin, RuleType
 from cgt_calc.spin_off_handler import SpinOffHandler
 
 if TYPE_CHECKING:
@@ -23,13 +23,13 @@ DATE = datetime.date(2024, 6, 3)
 
 # A US-domiciled security. Interactive Brokers reports its dividends in the
 # account's base currency, GBP for a UK account, while Schwab reports in USD.
-US_ISIN = "US9220427424"
+US_ISIN = Isin("US9220427424")
 US_WITHHOLDING_RATE = Decimal("0.15")
 
 
 def _dividend_pair(
     currency: str,
-    isin: str | None,
+    isin: Isin | None,
     withholding_rate: Decimal = US_WITHHOLDING_RATE,
 ) -> list[BrokerTransaction]:
     """Build a dividend of 100 and the tax withheld at source on it."""

--- a/tests/general/test_isin_converter.py
+++ b/tests/general/test_isin_converter.py
@@ -21,10 +21,10 @@ from cgt_calc.exceptions import (
 )
 import cgt_calc.isin_converter
 from cgt_calc.isin_converter import IsinConverter, IsinTranslationEntry
-from cgt_calc.model import ActionType, BrokerTransaction
+from cgt_calc.model import ActionType, BrokerTransaction, Isin
 
-# Deliberately not a real ISIN so it can't be in the bundled translation data.
-UNKNOWN_ISIN = "ZZ0000000000"
+# Well-formed but unassigned, so it cannot be in the bundled translation data.
+UNKNOWN_ISIN = Isin("ZZ0000000008")
 
 
 class OfflineSession:
@@ -55,8 +55,8 @@ def test_live_isin_lookup_announces_itself(
 
 
 # Real, valid ISINs that are not in the bundled translation data.
-ISIN_A = "US0378331005"
-ISIN_B = "US5949181045"
+ISIN_A = Isin("US0378331005")
+ISIN_B = Isin("US5949181045")
 
 FigiData = list[dict[str, str]]
 
@@ -94,7 +94,7 @@ class FakeSession:
         return FakeResponse(self._payload)
 
 
-def _transaction(isin: str, symbol: str | None) -> BrokerTransaction:
+def _transaction(isin: Isin, symbol: str | None) -> BrokerTransaction:
     """Create a minimal transaction with the given ISIN and symbol."""
     return BrokerTransaction(
         date=datetime.date(2023, 1, 1),
@@ -196,15 +196,6 @@ def test_fetch_live_no_match(monkeypatch: pytest.MonkeyPatch) -> None:
     assert converter.get_symbols(ISIN_A) == set()
 
 
-def test_validate_data_rejects_invalid_isin() -> None:
-    """Reject translation data with an invalid ISIN."""
-    converter = IsinConverter()
-    converter.data = {"NOTANISIN": {"FOO"}}
-
-    with pytest.raises(IsinTranslationError, match="Invalid ISIN"):
-        converter.validate_data()
-
-
 def test_validate_data_rejects_empty_symbol() -> None:
     """Reject ticker lists containing empty values."""
     converter = IsinConverter()
@@ -221,14 +212,6 @@ def test_validate_data_rejects_conflicting_symbols() -> None:
 
     with pytest.raises(IsinTranslationError, match="already linked"):
         converter.validate_data()
-
-
-def test_add_from_transaction_rejects_invalid_isin() -> None:
-    """Reject transactions with an invalid ISIN."""
-    converter = IsinConverter()
-
-    with pytest.raises(InvalidTransactionError, match="invalid ISIN"):
-        converter.add_from_transaction(_transaction("NOTANISIN", "FOO"))
 
 
 def test_add_from_transaction_rejects_mismatched_symbol() -> None:

--- a/tests/general/test_model.py
+++ b/tests/general/test_model.py
@@ -1,0 +1,105 @@
+"""Tests for the value types in cgt_calc.model."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+
+from cgt_calc.model import ActionType, BrokerTransaction, Isin
+
+# Apple, a real ISIN with a valid check digit.
+VALID_ISIN = "US0378331005"
+
+
+def test_isin_accepts_a_valid_identifier() -> None:
+    """A well-formed ISIN is preserved verbatim."""
+    assert Isin(VALID_ISIN) == VALID_ISIN
+
+
+def test_isin_normalises_case_and_whitespace() -> None:
+    """Lowercase input and stray whitespace are normalised away."""
+    assert Isin("  us0378331005 ") == VALID_ISIN
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "US037833100",  # too short
+        "US03783310055",  # too long
+        "US037833100X",  # check digit is not a digit
+        "0S0378331005",  # country code is not alphabetic
+    ],
+)
+def test_isin_rejects_malformed_identifiers(value: str) -> None:
+    """Anything that is not ISIN-shaped is refused."""
+    with pytest.raises(ValueError, match="Invalid ISIN"):
+        Isin(value)
+
+
+def test_isin_rejects_a_bad_check_digit() -> None:
+    """A correctly shaped identifier with a wrong checksum is refused."""
+    with pytest.raises(ValueError, match="Invalid ISIN checksum"):
+        Isin("US0378331006")
+
+
+def test_isin_is_usable_as_a_string() -> None:
+    """The type stays interchangeable with str for lookups and formatting."""
+    isin = Isin(VALID_ISIN)
+    assert isinstance(isin, str)
+    assert {VALID_ISIN: "AAPL"}[isin] == "AAPL"
+    assert f"{isin}" == VALID_ISIN
+
+
+def test_isin_rejects_attribute_assignment() -> None:
+    """The value type carries no instance dict."""
+    isin = Isin(VALID_ISIN)
+    with pytest.raises(AttributeError):
+        isin.symbol = "AAPL"  # type: ignore[attr-defined]
+
+
+def test_isin_parse_returns_none_for_invalid_input() -> None:
+    """The lenient constructor reports failure instead of raising."""
+    assert Isin.parse("not-an-isin") is None
+
+
+def test_isin_parse_normalises_valid_input() -> None:
+    """The lenient constructor normalises exactly like the strict one."""
+    assert Isin.parse("us0378331005") == Isin(VALID_ISIN)
+
+
+def _transaction(isin: Isin | None) -> BrokerTransaction:
+    return BrokerTransaction(
+        date=datetime.date(2023, 1, 1),
+        action=ActionType.BUY,
+        symbol="FOO",
+        description="test",
+        quantity=Decimal(1),
+        price=Decimal(1),
+        fees=Decimal(0),
+        amount=Decimal(-1),
+        currency="USD",
+        broker="Test",
+        isin=isin,
+    )
+
+
+def test_broker_transaction_rejects_a_bare_invalid_isin() -> None:
+    """A caller that skips the type still cannot smuggle in a bad ISIN."""
+    with pytest.raises(ValueError, match="Invalid ISIN"):
+        _transaction("NOTANISIN")  # type: ignore[arg-type]
+
+
+def test_broker_transaction_coerces_a_bare_valid_isin() -> None:
+    """A valid bare string is normalised into the value type."""
+    transaction = _transaction("us0378331005")  # type: ignore[arg-type]
+    assert isinstance(transaction.isin, Isin)
+    assert transaction.isin == VALID_ISIN
+
+
+def test_broker_transaction_keeps_an_isin_instance_as_is() -> None:
+    """An already-validated identifier passes through untouched."""
+    isin = Isin(VALID_ISIN)
+    assert _transaction(isin).isin is isin

--- a/tests/trading212/test_trading212.py
+++ b/tests/trading212/test_trading212.py
@@ -147,7 +147,7 @@ def test_read_trading212_transactions_supports_2020_export(tmp_path: Path) -> No
             {
                 Trading212Column.ACTION: "Market buy",
                 Trading212Column.TIME: "2020-06-24 14:33:50",
-                Trading212Column.ISIN: "US0000000001",
+                Trading212Column.ISIN: "US0000000010",
                 Trading212Column.TICKER: "FOO",
                 Trading212Column.NAME: "Foo Inc",
                 Trading212Column.NO_OF_SHARES: "2",
@@ -227,7 +227,7 @@ def test_read_trading212_transactions_supports_2024_export(tmp_path: Path) -> No
             {
                 Trading212Column.ACTION: "Market buy",
                 Trading212Column.TIME: "2024-01-01 16:10:05.175",
-                Trading212Column.ISIN: "US0000000003",
+                Trading212Column.ISIN: "US0000000036",
                 Trading212Column.TICKER: "BAZ",
                 Trading212Column.NAME: "Baz Corp",
                 Trading212Column.NO_OF_SHARES: "2",
@@ -246,7 +246,7 @@ def test_read_trading212_transactions_supports_2024_export(tmp_path: Path) -> No
             {
                 Trading212Column.ACTION: "Dividend (Dividend)",
                 Trading212Column.TIME: "2024-03-23 18:35:26",
-                Trading212Column.ISIN: "US0000000003",
+                Trading212Column.ISIN: "US0000000036",
                 Trading212Column.TICKER: "BAZ",
                 Trading212Column.NAME: "Baz Corp",
                 Trading212Column.NO_OF_SHARES: "2",
@@ -310,7 +310,7 @@ def test_read_trading212_transactions_supports_2026_export(tmp_path: Path) -> No
             {
                 Trading212Column.ACTION: "Market buy",
                 Trading212Column.TIME: "2025-04-08 10:10:05.175",
-                Trading212Column.ISIN: "US0000000004",
+                Trading212Column.ISIN: "US0000000044",
                 Trading212Column.TICKER: "QUX",
                 Trading212Column.NAME: "Qux Ltd",
                 Trading212Column.NO_OF_SHARES: "4",
@@ -335,7 +335,7 @@ def test_read_trading212_transactions_supports_2026_export(tmp_path: Path) -> No
             {
                 Trading212Column.ACTION: "Market sell",
                 Trading212Column.TIME: "2025-04-08 15:05:00",
-                Trading212Column.ISIN: "US0000000004",
+                Trading212Column.ISIN: "US0000000044",
                 Trading212Column.TICKER: "QUX",
                 Trading212Column.NAME: "Qux Ltd",
                 Trading212Column.NO_OF_SHARES: "2",
@@ -524,7 +524,7 @@ def test_read_trading212_transactions_supports_2025_bare_columns(
             {
                 Trading212Column.ACTION: "Market buy",
                 Trading212Column.TIME: "2025-04-02 10:30:00",
-                Trading212Column.ISIN: "GB0000000001",
+                Trading212Column.ISIN: "GB0000000017",
                 Trading212Column.TICKER: "WID",
                 Trading212Column.NAME: "Widget plc",
                 Trading212Column.NO_OF_SHARES: "50",
@@ -573,7 +573,7 @@ def test_read_trading212_transactions_supports_2025_bare_columns(
             {
                 Trading212Column.ACTION: "Dividend (Interest)",
                 Trading212Column.TIME: "2025-04-05 12:00:00",
-                Trading212Column.ISIN: "IE0000000003",
+                Trading212Column.ISIN: "IE0000000038",
                 Trading212Column.TICKER: "BOND",
                 Trading212Column.NAME: "Bond Fund",
                 Trading212Column.TOTAL: "0.08",
@@ -586,7 +586,7 @@ def test_read_trading212_transactions_supports_2025_bare_columns(
             {
                 Trading212Column.ACTION: "Dividend (Property income distribution)",
                 Trading212Column.TIME: "2025-04-06 12:00:00",
-                Trading212Column.ISIN: "GB0000000004",
+                Trading212Column.ISIN: "GB0000000041",
                 Trading212Column.TICKER: "REIT",
                 Trading212Column.NAME: "Property Trust",
                 Trading212Column.TOTAL: "3.20",
@@ -599,7 +599,7 @@ def test_read_trading212_transactions_supports_2025_bare_columns(
             {
                 Trading212Column.ACTION: "Dividend adjustment",
                 Trading212Column.TIME: "2025-04-07 12:00:00",
-                Trading212Column.ISIN: "GB0000000004",
+                Trading212Column.ISIN: "GB0000000041",
                 Trading212Column.TICKER: "REIT",
                 Trading212Column.NAME: "Property Trust",
                 Trading212Column.TOTAL: "-0.02",
@@ -612,7 +612,7 @@ def test_read_trading212_transactions_supports_2025_bare_columns(
             {
                 Trading212Column.ACTION: "Spin off",
                 Trading212Column.TIME: "2025-04-08 06:00:00",
-                Trading212Column.ISIN: "US0000000005",
+                Trading212Column.ISIN: "US0000000051",
                 Trading212Column.TICKER: "NEWCO",
                 Trading212Column.NAME: "NewCo Inc",
                 Trading212Column.NO_OF_SHARES: "5",
@@ -726,7 +726,7 @@ def test_read_trading212_transactions_non_gbp_stamp_duty(tmp_path: Path) -> None
             {
                 Trading212Column.ACTION: "Market buy",
                 Trading212Column.TIME: "2025-04-02 10:30:00",
-                Trading212Column.ISIN: "GB0000000001",
+                Trading212Column.ISIN: "GB0000000017",
                 Trading212Column.TICKER: "WID",
                 Trading212Column.NAME: "Widget plc",
                 Trading212Column.NO_OF_SHARES: "50",
@@ -761,7 +761,7 @@ def test_read_trading212_transactions_mixed_fee_currencies(tmp_path: Path) -> No
             {
                 Trading212Column.ACTION: "Market buy",
                 Trading212Column.TIME: "2024-01-01 16:10:05",
-                Trading212Column.ISIN: "US0000000003",
+                Trading212Column.ISIN: "US0000000036",
                 Trading212Column.TICKER: "BAZ",
                 Trading212Column.NAME: "Baz Corp",
                 Trading212Column.NO_OF_SHARES: "2",
@@ -800,7 +800,7 @@ def test_read_trading212_transactions_missing_fee_currency(tmp_path: Path) -> No
             {
                 Trading212Column.ACTION: "Market buy",
                 Trading212Column.TIME: "2024-01-01 16:10:05",
-                Trading212Column.ISIN: "US0000000003",
+                Trading212Column.ISIN: "US0000000036",
                 Trading212Column.TICKER: "BAZ",
                 Trading212Column.NAME: "Baz Corp",
                 Trading212Column.NO_OF_SHARES: "2",
@@ -834,7 +834,7 @@ def test_read_trading212_transactions_blank_tax_currency(tmp_path: Path) -> None
             {
                 Trading212Column.ACTION: "Market buy",
                 Trading212Column.TIME: "2025-04-02 10:30:00",
-                Trading212Column.ISIN: "IE0000000009",
+                Trading212Column.ISIN: "IE0000000095",
                 Trading212Column.TICKER: "EURX",
                 Trading212Column.NAME: "Euro plc",
                 Trading212Column.NO_OF_SHARES: "50",
@@ -866,7 +866,7 @@ def _make_usd_fee_buy_row(total: str) -> list[str]:
         {
             Trading212Column.ACTION: "Market buy",
             Trading212Column.TIME: "2024-01-01 16:10:05",
-            Trading212Column.ISIN: "US0000000003",
+            Trading212Column.ISIN: "US0000000036",
             Trading212Column.TICKER: "BAZ",
             Trading212Column.NAME: "Baz Corp",
             Trading212Column.NO_OF_SHARES: "2",
@@ -920,7 +920,7 @@ def test_read_trading212_transactions_unconvertible_fee_skips_price_check(
             {
                 Trading212Column.ACTION: "Market buy",
                 Trading212Column.TIME: "2025-04-03 11:00:00",
-                Trading212Column.ISIN: "US0000000003",
+                Trading212Column.ISIN: "US0000000036",
                 Trading212Column.TICKER: "BAZ",
                 Trading212Column.NAME: "Baz Corp",
                 Trading212Column.NO_OF_SHARES: "2",
@@ -953,7 +953,7 @@ def test_read_trading212_transactions_invalid_decimal(tmp_path: Path) -> None:
             {
                 Trading212Column.ACTION: "Market buy",
                 Trading212Column.TIME: "2024-01-01 10:00:00",
-                Trading212Column.ISIN: "US0000000001",
+                Trading212Column.ISIN: "US0000000010",
                 Trading212Column.TICKER: "FOO",
                 Trading212Column.NAME: "Foo Inc",
                 Trading212Column.NO_OF_SHARES: "2",


### PR DESCRIPTION
`BrokerTransaction.isin` and everything downstream now carry a validated, normalised `Isin` instead of `str`.

- Validation happens once, at construction, and raises `ValueError`, so the parsers' existing handlers report the location:
  `While parsing transactions.csv, row 3: Invalid ISIN checksum: 'US0000000001'`
- Trading 212, Freetrade and HL did no ISIN validation before; a malformed ISIN silently failed ERI matching and dropped the excess reported income. It is now a parsing error.
- The ten scattered `is_isin` call sites, with four different failure modes, collapse into the type and `is_isin` is removed. Interactive Brokers keeps its best-effort lookup via `Isin.parse`.
- `BrokerTransaction.__post_init__` coerces a bare string, so callers that skip the type checker still get a validated value.
- The Trading 212 test placeholders had invalid check digits and are replaced with valid, distinct ones.

`CurrencyCode` follows the same pattern in a separate PR.
