### PR TITLE
Accept report filenames case-insensitively

### DIFF
--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -259,7 +259,7 @@ class BaseDirParser(BaseSingleFileParser):
     def load_from_dir(cls, dir_path: Path) -> list[BrokerTransaction]:
         """Load broker data from dir path."""
         transactions: list[BrokerTransaction] = []
-        for file_path in sorted(dir_path.glob(cls.glob_dir)):
+        for file_path in sorted(dir_path.glob(cls.glob_dir, case_sensitive=False)):
             if cls.file_path_filter(file_path):
                 transactions += cls.load_from_file(file_path, warn_on_empty=False)
         if not transactions:

--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -184,7 +184,12 @@ class HargreavesLansdownParser(StandardCSVParser, BaseDirParser):
 
         # Live PDF lookup only when needed for buy/sell actions
         if action_type in [ActionType.BUY, ActionType.SELL]:
-            matching_pdfs = list(file_path.parent.glob(f"{reference}_*.pdf"))
+            matching_pdfs = list(
+                file_path.parent.glob(
+                    f"{reference}_*.pdf",
+                    case_sensitive=False,
+                )
+            )
             if matching_pdfs:
                 pdf = cls._parse_pdf(matching_pdfs[0])
                 symbol = pdf.ticker

--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -103,20 +103,25 @@ class MSSBParser(StandardCSVParser, BaseDirParser):
     glob_dir = "*.csv"
     deprecated_flags: ClassVar[list[str]] = ["--mssb"]
 
+    @staticmethod
+    def _is_withdrawals_report(file_path: Path) -> bool:
+        """Return whether the path is a withdrawals report."""
+        return file_path.name.casefold() == WITHDRAWALS_REPORT_FILENAME.casefold()
+
     @classmethod
     @override
     def file_path_filter(cls, file_path: Path) -> bool:
         """Choose which files to parse."""
-        return file_path.name in [
-            WITHDRAWALS_REPORT_FILENAME,
-            RELEASES_REPORT_FILENAME,
-        ]
+        return file_path.name.casefold() in {
+            WITHDRAWALS_REPORT_FILENAME.casefold(),
+            RELEASES_REPORT_FILENAME.casefold(),
+        }
 
     @classmethod
     @override
     def pre_reading(cls, file: TextIO, file_path: Path) -> Iterable[str]:
         """Select the expected column set based on the report filename."""
-        if file_path.name == WITHDRAWALS_REPORT_FILENAME:
+        if cls._is_withdrawals_report(file_path):
             cls.columns = set(COLUMNS_WITHDRAWAL)
         else:
             cls.columns = set(COLUMNS_RELEASE)
@@ -126,7 +131,7 @@ class MSSBParser(StandardCSVParser, BaseDirParser):
     @override
     def read_row(cls, row: dict[str, str], file_path: Path) -> BrokerTransaction | None:
         """Read a single transaction from a row in the CSV."""
-        if file_path.name == WITHDRAWALS_REPORT_FILENAME:
+        if cls._is_withdrawals_report(file_path):
             return cls._init_from_withdrawal_report(row, file_path)
         return cls._init_from_release_report(row, file_path)
 

--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -159,10 +159,10 @@ class SharesightParser(BaseDirParser):
         cls, file: TextIO, file_path: Path
     ) -> list[BrokerTransaction]:
         """Parse Sharesight transactions from reports."""
-        if file_path.match("Taxable Income Report*.csv"):
+        if file_path.match("Taxable Income Report*.csv", case_sensitive=False):
             return list(cls._parse_income_report(file, file_path))
 
-        if file_path.match("All Trades Report*.csv"):
+        if file_path.match("All Trades Report*.csv", case_sensitive=False):
             return list(cls._parse_trade_report(file, file_path))
         return []
 

--- a/docs/brokers/trading212.md
+++ b/docs/brokers/trading212.md
@@ -36,8 +36,8 @@ trading212/
 └── from_2024-04-06_to_2025-04-05.csv
 ```
 
-The filenames do not matter. cgt-calc reads every `.csv` file directly inside the directory, but it
-does not search subdirectories. Do not add unrelated CSV files, and make sure there are no gaps
+The base filenames do not matter. cgt-calc reads every CSV file directly inside the directory, but
+it does not search subdirectories. Do not add unrelated CSV files, and make sure there are no gaps
 between date ranges. Overlaps are safe: exact repeated transactions are removed using their Trading
 212 transaction ID.
 
@@ -100,9 +100,9 @@ information.
 
 ### No transactions are detected
 
-Check that the directory contains files ending in lower-case `.csv` directly, rather than `.CSV`
-files or files inside another directory. Also check that you passed the directory itself to
-`--trading212-dir`, not the path to one CSV file.
+Check that the directory contains CSV files directly, rather than inside another directory. The file
+extension is matched case-insensitively, so `.csv`, `.CSV` and mixed-case variants all work. Also
+check that you passed the directory itself to `--trading212-dir`, not the path to one CSV file.
 
 ### The balance or portfolio looks wrong
 

--- a/tests/hl/test_hl.py
+++ b/tests/hl/test_hl.py
@@ -194,6 +194,22 @@ def test_hl_blank_reference_skipped(tmp_path: Path) -> None:
     assert transactions == []
 
 
+def test_load_from_dir_accepts_uppercase_csv_extension(tmp_path: Path) -> None:
+    """Discover an HL transaction report whose CSV extension is uppercase."""
+    csv_file = tmp_path / "hl-transaction-summary.CSV"
+    csv_file.write_text(
+        HL_CSV_HEADER
+        + '"01/03/2026","01/03/2026","Interest","Gross interest","n/a","n/a","12.34"\n',
+        encoding="windows-1252",
+    )
+
+    transactions = HargreavesLansdownParser.load_from_dir(tmp_path)
+
+    assert len(transactions) == 1
+    assert transactions[0].action == ActionType.INTEREST
+    assert transactions[0].amount == Decimal("12.34")
+
+
 # The tests below call the parser directly: the end-to-end tests above
 # run in a subprocess, which is invisible to coverage.
 
@@ -252,9 +268,9 @@ def test_read_row_invalid_date() -> None:
         HargreavesLansdownParser.read_row(row, Path("statement.csv"))
 
 
-def test_read_row_buy_with_contract_note(tmp_path: Path) -> None:
-    """Cross-reference a buy row with its contract note PDF."""
-    _create_buy_pdf(str(tmp_path / "B123_contract.pdf"))
+def test_read_row_buy_with_uppercase_contract_note_extension(tmp_path: Path) -> None:
+    """Cross-reference a buy row with an uppercase PDF extension."""
+    _create_buy_pdf(str(tmp_path / "B123_contract.PDF"))
     row = {
         "Reference": "B123",
         "Description": "Buy VHVG",

--- a/tests/morgan_stanley/test_mssb.py
+++ b/tests/morgan_stanley/test_mssb.py
@@ -108,6 +108,33 @@ def test_read_mssb_withdrawal_skips_notice(tmp_path: Path) -> None:
     assert transaction.fees == Decimal(0)
 
 
+def test_read_mssb_withdrawal_with_uppercase_csv_extension(tmp_path: Path) -> None:
+    """Parse a withdrawals report whose CSV extension is uppercase."""
+    withdrawal_file = tmp_path / WITHDRAWALS_REPORT_FILENAME.replace(".csv", ".CSV")
+    rows = [
+        COLUMNS_WITHDRAWAL,
+        [
+            "02-Apr-2021",
+            "ORDER-UPPERCASE",
+            "Cash",
+            "Sale",
+            "Complete",
+            "$1.00",
+            "-100.00",
+            "$100.00",
+            "0",
+            "N/A",
+        ],
+    ]
+    _write_csv(withdrawal_file, rows)
+
+    transactions = MSSBParser.load_from_dir(tmp_path)
+
+    assert len(transactions) == 1
+    assert transactions[0].action == ActionType.TRANSFER
+    assert transactions[0].amount == Decimal("-100.00")
+
+
 def test_read_mssb_withdrawal_goog_sale_before_split_window(tmp_path: Path) -> None:
     """Ensure a GOOG sale shortly before the July 15, 2022 split is adjusted.
 

--- a/tests/sharesight/test_sharesight.py
+++ b/tests/sharesight/test_sharesight.py
@@ -257,10 +257,10 @@ FOREIGN_DIVIDEND_HEADER = [
 ]
 
 
-def test_parse_income_report(tmp_path: Path) -> None:
-    """Parse local and foreign dividends with their taxes."""
+def test_parse_income_report_with_uppercase_csv_extension(tmp_path: Path) -> None:
+    """Parse an income report whose CSV extension is uppercase."""
     _write_csv(
-        tmp_path / "Taxable Income Report.csv",
+        tmp_path / "Taxable Income Report.CSV",
         [
             ["Taxable Income Report"],
             ["Local Income"],

--- a/tests/trading212/test_trading212.py
+++ b/tests/trading212/test_trading212.py
@@ -127,6 +127,30 @@ def _prepare_file(tmp_path: Path, rows: list[list[str]]) -> Path:
     return folder
 
 
+def test_load_from_dir_accepts_uppercase_csv_extension(tmp_path: Path) -> None:
+    """Discover a Trading 212 export whose CSV extension is uppercase."""
+    rows = [
+        HEADER_2024,
+        _make_row(
+            HEADER_2024,
+            {
+                Trading212Column.ACTION: "Deposit",
+                Trading212Column.TIME: "2024-01-01 00:15:20.149",
+                Trading212Column.TOTAL: "100.00",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.TRANSACTION_ID: "uppercase-extension",
+            },
+        ),
+    ]
+    folder = _prepare_file(tmp_path, rows)
+    (folder / "trading212.csv").rename(folder / "trading212.CSV")
+
+    transactions = Trading212Parser.load_from_dir(folder)
+
+    assert len(transactions) == 1
+    assert transactions[0].amount == Decimal("100.00")
+
+
 def test_read_trading212_transactions_supports_2020_export(tmp_path: Path) -> None:
     """Parse transactions using the legacy 2020 column set."""
 


### PR DESCRIPTION
Directory importers matched report files by exact name, so an export saved with a `.CSV` or mixed-case extension — or a Sharesight or Morgan Stanley report whose name differed only in case — was silently skipped and the run ended with "No transactions detected". Every directory scan now matches the extension case-insensitively, the Sharesight and Morgan Stanley report-name checks do the same, and the Hargreaves Lansdown contract-note PDF lookup accepts upper- and mixed-case `.pdf`. Single-file options are unchanged: they open the exact path supplied.

The Trading 212 guide drops the lower-case `.csv` caveat it gained in #931.