### PR TITLE
Support current Sharesight report exports

### DIFF
--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -126,8 +126,8 @@ REQUIRED_TRADE_COLUMNS: Final[tuple[TradeColumn, ...]] = (
 )
 
 # Sharesight has changed the spreadsheet headings over time. Keep one internal
-# vocabulary so that both the legacy report and the newer Combined sheet are
-# interpreted identically.
+# vocabulary so that the legacy and newer export generations are interpreted
+# identically.
 TRADE_COLUMN_ALIASES: Final[dict[str, TradeColumn]] = {
     "Market": TradeColumn.MARKET,
     "Market Code": TradeColumn.MARKET,

--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -109,9 +109,40 @@ class TradeColumn(StrEnum):
     PRICE = "Price *"
     BROKERAGE = "Brokerage *"
     CURRENCY = "Currency"
+    BROKERAGE_CURRENCY = "Brokerage Currency"
     EXCHANGE_RATE = "Exchange Rate"
     VALUE = "Value"
     COMMENTS = "Comments"
+
+
+REQUIRED_TRADE_COLUMNS: Final[tuple[TradeColumn, ...]] = tuple(
+    column for column in TradeColumn if column is not TradeColumn.BROKERAGE_CURRENCY
+)
+
+# Sharesight has changed the spreadsheet headings over time. Keep one internal
+# vocabulary so that both the legacy report and the newer Combined sheet are
+# interpreted identically.
+TRADE_COLUMN_ALIASES: Final[dict[str, TradeColumn]] = {
+    "Market": TradeColumn.MARKET,
+    "Market Code": TradeColumn.MARKET,
+    "Code": TradeColumn.CODE,
+    "Name": TradeColumn.NAME,
+    "Type": TradeColumn.TYPE,
+    "Date": TradeColumn.DATE,
+    "Quantity": TradeColumn.QUANTITY,
+    "Qty": TradeColumn.QUANTITY,
+    "Price *": TradeColumn.PRICE,
+    "Price": TradeColumn.PRICE,
+    "Brokerage *": TradeColumn.BROKERAGE,
+    "Brokerage": TradeColumn.BROKERAGE,
+    "Currency": TradeColumn.CURRENCY,
+    "Instrument Currency": TradeColumn.CURRENCY,
+    "Brokerage Currency": TradeColumn.BROKERAGE_CURRENCY,
+    "Exchange Rate": TradeColumn.EXCHANGE_RATE,
+    "Exch. Rate": TradeColumn.EXCHANGE_RATE,
+    "Value": TradeColumn.VALUE,
+    "Comments": TradeColumn.COMMENTS,
+}
 
 
 class SharesightTransaction(BrokerTransaction):
@@ -221,6 +252,23 @@ class SharesightParser(BaseDirParser):
                 f"Missing expected columns in {section}: {', '.join(sorted(missing))}",
             )
 
+    @staticmethod
+    def _trade_header_columns(header: list[str]) -> list[TradeColumn | None]:
+        """Map the known All Trades headings to their internal columns."""
+        columns = [TRADE_COLUMN_ALIASES.get(column) for column in header]
+
+        # One export generation replaced `Currency` with `Brokerage Currency`.
+        # Treat it as the transaction currency only when the report does not
+        # provide the newer, unambiguous `Instrument Currency` column as well.
+        if (
+            TradeColumn.CURRENCY not in columns
+            and TradeColumn.BROKERAGE_CURRENCY in columns
+        ):
+            columns[columns.index(TradeColumn.BROKERAGE_CURRENCY)] = (
+                TradeColumn.CURRENCY
+            )
+        return columns
+
     @classmethod
     def _parse_dividend_payments(
         cls,
@@ -248,11 +296,17 @@ class SharesightParser(BaseDirParser):
             if len(row) != len(header):
                 raise UnexpectedColumnCountError(row, len(header), file)
 
-            row_dict = {
-                DividendColumn(column): value
-                for column, value in zip(header, row, strict=True)
-                if column
-            }
+            row_dict: dict[DividendColumn, str] = {}
+            for column, value in zip(header, row, strict=True):
+                try:
+                    dividend_column = DividendColumn(column)
+                except ValueError:
+                    # Sharesight may append informational columns such as the
+                    # income country or type. Required calculation fields were
+                    # already checked above, so unrelated additions are safe to
+                    # ignore.
+                    continue
+                row_dict[dividend_column] = value
 
             dividend_date = cls._parse_date(row_dict[DividendColumn.DATE_PAID])
             symbol = row_dict[DividendColumn.CODE]
@@ -354,9 +408,10 @@ class SharesightParser(BaseDirParser):
         cls, header: list[str], rows: Iterator[list[str]], file: Path
     ) -> Iterable[SharesightTransaction]:
         """Parse content in All Trades Report from Sharesight."""
+        header_columns = cls._trade_header_columns(header)
         cls._validate_header(
-            header,
-            TradeColumn,
+            [column.value if column is not None else "" for column in header_columns],
+            REQUIRED_TRADE_COLUMNS,
             file=file,
             section="Sharesight trades header",
         )
@@ -370,9 +425,9 @@ class SharesightParser(BaseDirParser):
                 raise UnexpectedColumnCountError(row, len(header), file)
 
             row_dict = {
-                TradeColumn(column): value
-                for column, value in zip(header, row, strict=True)
-                if column
+                column: value
+                for column, value in zip(header_columns, row, strict=True)
+                if column is not None
             }
 
             trade_type = row_dict[TradeColumn.TYPE]
@@ -390,6 +445,15 @@ class SharesightParser(BaseDirParser):
             price = cls._parse_decimal(row_dict, TradeColumn.PRICE)
             fees = cls._maybe_decimal(row_dict, TradeColumn.BROKERAGE) or Decimal(0)
             currency = CurrencyCode(row_dict[TradeColumn.CURRENCY])
+            brokerage_currency = row_dict.get(
+                TradeColumn.BROKERAGE_CURRENCY, currency
+            ).strip()
+            if fees and brokerage_currency and brokerage_currency != currency:
+                raise ValueError(
+                    "Brokerage Currency "
+                    f"{brokerage_currency!r} differs from transaction currency "
+                    f"{currency!r}; fees in another currency are not supported"
+                )
             description = row_dict[TradeColumn.COMMENTS]
             broker = "Sharesight"
             gbp_value = cls._maybe_decimal(row_dict, TradeColumn.VALUE)
@@ -455,7 +519,11 @@ class SharesightParser(BaseDirParser):
         rows_iter = RowIterator(rows)
         for row in rows_iter:
             # Skip everything until we find the header
-            if row[0] == "Market":
+            if (
+                "Code" in row
+                and "Type" in row
+                and ("Market" in row or "Market Code" in row)
+            ):
                 header = row
                 try:
                     yield from cls._parse_trades(header, rows_iter, file_path)

--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -445,15 +445,6 @@ class SharesightParser(BaseDirParser):
             price = cls._parse_decimal(row_dict, TradeColumn.PRICE)
             fees = cls._maybe_decimal(row_dict, TradeColumn.BROKERAGE) or Decimal(0)
             currency = CurrencyCode(row_dict[TradeColumn.CURRENCY])
-            brokerage_currency = row_dict.get(
-                TradeColumn.BROKERAGE_CURRENCY, currency
-            ).strip()
-            if fees and brokerage_currency and brokerage_currency != currency:
-                raise ValueError(
-                    "Brokerage Currency "
-                    f"{brokerage_currency!r} differs from transaction currency "
-                    f"{currency!r}; fees in another currency are not supported"
-                )
             description = row_dict[TradeColumn.COMMENTS]
             broker = "Sharesight"
             gbp_value = cls._maybe_decimal(row_dict, TradeColumn.VALUE)
@@ -474,6 +465,18 @@ class SharesightParser(BaseDirParser):
 
                 price = abs(gbp_value / quantity)
                 currency = CurrencyCode("GBP")
+
+            # Checked after the FX override so the fee is compared with the
+            # currency the transaction is actually recorded in.
+            brokerage_currency = row_dict.get(
+                TradeColumn.BROKERAGE_CURRENCY, currency
+            ).strip()
+            if fees and brokerage_currency and brokerage_currency != currency:
+                raise ValueError(
+                    "Brokerage Currency "
+                    f"{brokerage_currency!r} differs from transaction currency "
+                    f"{currency!r}; fees in another currency are not supported"
+                )
 
             # Make amount positive on sell and negative on buy
             amount = -(quantity * price) - fees

--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -115,8 +115,14 @@ class TradeColumn(StrEnum):
     COMMENTS = "Comments"
 
 
-REQUIRED_TRADE_COLUMNS: Final[tuple[TradeColumn, ...]] = tuple(
-    column for column in TradeColumn if column is not TradeColumn.BROKERAGE_CURRENCY
+REQUIRED_TRADE_COLUMNS: Final[tuple[TradeColumn, ...]] = (
+    TradeColumn.MARKET,
+    TradeColumn.CODE,
+    TradeColumn.TYPE,
+    TradeColumn.DATE,
+    TradeColumn.QUANTITY,
+    TradeColumn.PRICE,
+    TradeColumn.CURRENCY,
 )
 
 # Sharesight has changed the spreadsheet headings over time. Keep one internal
@@ -415,6 +421,11 @@ class SharesightParser(BaseDirParser):
             file=file,
             section="Sharesight trades header",
         )
+        if TradeColumn.COMMENTS not in header_columns:
+            LOGGER.warning(
+                "Sharesight trades report has no Comments column; "
+                "Stock Activity markers cannot be detected"
+            )
 
         for row in rows:
             if not any(row):
@@ -445,7 +456,7 @@ class SharesightParser(BaseDirParser):
             price = cls._parse_decimal(row_dict, TradeColumn.PRICE)
             fees = cls._maybe_decimal(row_dict, TradeColumn.BROKERAGE) or Decimal(0)
             currency = CurrencyCode(row_dict[TradeColumn.CURRENCY])
-            description = row_dict[TradeColumn.COMMENTS]
+            description = row_dict.get(TradeColumn.COMMENTS, "")
             broker = "Sharesight"
             gbp_value = cls._maybe_decimal(row_dict, TradeColumn.VALUE)
 

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -93,9 +93,10 @@ these markers.
 - [`Opening Balance`](https://help.sharesight.com/opening-balance/) trades are not supported.
   Sharesight uses them when the original buy and sell records are unavailable, but cgt-calc needs
   the original acquisition dates and costs for UK share matching.
-- `Split`, `Consolidation` and `Bonus` rows are not supported. They stop the import with an unknown
-  action error. Do not delete such a row to make the calculation run: later quantities and gains
-  could be wrong.
+- `Split`, `Consolidation` and `Bonus` rows are not supported
+  ([#266](https://github.com/KapJI/capital-gains-calculator/issues/266)). They stop the import with
+  an unknown action error. Do not delete such a row to make the calculation run: later quantities
+  and gains could be wrong.
 - Cash deposits, withdrawals and balances are not imported, which is why `--no-balance-check` is
   required.
 - Taxable Income sections other than local and foreign dividend payments are not imported.
@@ -114,9 +115,8 @@ case-insensitively; additional text after `Report` and uppercase `.CSV` extensio
 
 ### `Missing expected columns`
 
-For All Trades, make sure you exported **Do not group (Holdings)** and converted the sheet
-containing the All Trades table without editing its headings. For Taxable Income, convert the report
-sheet rather than a summary or chart.
+cgt-calc found the report's header row but not every column it needs. This happens when headings
+were edited during conversion, or when Sharesight has changed the report format.
 
 First upgrade cgt-calc using the same method you used to install it and try again. If the error
 remains, open a [GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new) with:

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -1,25 +1,139 @@
 # Sharesight
 
-You will need:
+cgt-calc reads two Sharesight reports: **All Trades** for acquisitions and disposals, and **Taxable
+Income** for dividends and tax deducted from them. This is useful when Sharesight already combines
+activity from several brokers into one GBP portfolio.
 
-- **Exported transaction history from Sharesight.** Sharesight is a portfolio tracking tool with
-  support for multiple brokers.
-  - You will need the "All Trades" and "Taxable Income" reports since the beginning. Make sure to
-    select "Since Inception" for the period, and "Not Grouping".
-  - Export both reports to Excel or Google Sheets, save as CSV, and place them in the same folder.
-  - [See example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/sharesight/data/inputs).
+Use a Sharesight portfolio whose base currency is GBP. The importer treats local income and the
+portfolio value of foreign-exchange trades as GBP.
 
-Comments:
+## Export the reports
 
-- Sharesight aggregates transactions from multiple brokers, but doesn't necessarily have balance
-  information. Use the `--no-balance-check` flag to avoid spurious errors.
+Export enough history to cover the portfolio from its first transaction. Earlier acquisitions can
+still affect disposals in the tax year you are reporting; see
+[Before you start](../usage.md#before-you-start).
 
-- Since there is no direct support for equity grants, add `Stock Activity` as part of the comment
-  associated with any vesting transactions - making sure they have the grant price filled
-  ([see example](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/sharesight/data/inputs)).
+### All Trades
 
-Example usage for the tax year 2024/25:
+1. Open the portfolio's **All Trades Report**.
+2. Set the date range to **Since Inception**.
+3. Select **Do not group (Holdings)**.
+4. Export the report to a spreadsheet or Google Drive. Do not use the PDF export.
+5. Open the exported workbook and select the **Combined** worksheet.
+6. Save or download that worksheet as a CSV file.
+
+See Sharesight's current
+[All Trades Report instructions](https://help.sharesight.com/uk/trades_report/) for the report
+controls.
+
+### Taxable Income
+
+1. Open the portfolio's **Taxable Income Report**.
+2. Set a date range that covers the complete history you are importing.
+3. Export the report to a spreadsheet or Google Drive. Do not use the PDF export.
+4. Save or download the report worksheet as a CSV file.
+
+Sharesight recommends checking its income figures against your dividend statements because the
+report relies on third-party data. Its
+[Taxable Income Report instructions](https://help.sharesight.com/uk/taxable_income/) explain the
+available periods and exports.
+
+## Prepare the directory
+
+Keep both CSV files directly in one directory, for example:
+
+```text
+sharesight/
+├── All Trades Report.csv
+└── Taxable Income Report.csv
+```
+
+The filenames must start with `All Trades Report` and `Taxable Income Report`, respectively. The
+matching is case-insensitive, including the `.csv` extension, so suffixes added by Sharesight and
+uppercase `.CSV` extensions are accepted. cgt-calc does not read the original `.xlsx` files or
+search subdirectories.
+
+Do not rename or delete columns when converting the worksheets. cgt-calc accepts both the legacy
+Sharesight headings and newer headings such as `Market Code`, `Qty`, `Instrument Currency` and
+`Exch. Rate`. You can compare the structure with the
+[sanitised example reports](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/sharesight/data/inputs).
+
+## Generate the report
+
+For the 2024/25 tax year, run:
 
 ```shell
-cgt-calc --year 2024 --no-balance-check --sharesight-dir sharesight_trxs_dir/
+cgt-calc --year 2024 --sharesight-dir sharesight/ --no-balance-check
 ```
+
+`--year 2024` means 6 April 2024 to 5 April 2025. `--no-balance-check` is needed because these two
+reports do not contain the complete cash activity required to reconcile a broker balance. Follow
+[Generate Your First Report](../usage.md) to find and check the output.
+
+## Supported activity
+
+The Sharesight importer currently handles:
+
+| Report         | Included activity                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------------ |
+| All Trades     | `Buy` and `Sell` rows, including Sharesight foreign-exchange rows                                |
+| Taxable Income | Local and foreign dividend payments, including `Tax Deducted` and `Foreign Tax Deducted` amounts |
+| All Trades     | Equity grants entered as described below                                                         |
+
+### Equity grants
+
+Sharesight has no native equity-grant transaction for this importer. To identify a vest:
+
+1. Record it as a `Buy` in Sharesight.
+2. Enter the market value per share on the vest date as the price.
+3. Include `Stock Activity` anywhere in the trade comment.
+
+cgt-calc then treats the row as stock activity rather than a cash purchase. A `Sell` row carrying
+that marker is rejected.
+
+## Known limitations
+
+- `Split`, `Consolidation` and `Bonus` rows are not supported. They stop the import with an unknown
+  action error. Do not delete such a row to make the calculation run: later quantities and gains
+  could be wrong.
+- Cash deposits, withdrawals and balances are not imported, which is why `--no-balance-check` is
+  required.
+- Taxable Income sections other than local and foreign dividend payments are not imported.
+- If a newer All Trades report gives a non-zero brokerage charge in a currency different from the
+  instrument currency, the import stops. That fee cannot yet be represented exactly from this report
+  without risking an incorrect allowable cost.
+
+## Troubleshooting
+
+### No transactions are detected
+
+Check that you converted the spreadsheet worksheet to CSV: `.xlsx` files are not read. Confirm that
+both files are directly inside the directory passed to `--sharesight-dir`, and that their filenames
+start with `All Trades Report` and `Taxable Income Report`.
+
+### `Missing expected columns`
+
+For All Trades, make sure you exported **Do not group (Holdings)** and converted the **Combined**
+worksheet without editing its headings. For Taxable Income, convert the report worksheet rather than
+a summary or chart.
+
+First upgrade cgt-calc using the same method you used to install it and try again. If the error
+remains, open a [GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new) with:
+
+- your cgt-calc version from `cgt-calc --version`;
+- the complete error message; and
+- the CSV header and a sanitised failing row.
+
+Do not upload an unredacted report: it can contain holdings and other sensitive financial
+information.
+
+### `Unknown action`
+
+Compare the named action with [Known limitations](#known-limitations). Do not remove the row unless
+you replace it with an equivalent supported transaction whose UK tax treatment you have verified.
+
+### The portfolio or dividend totals look wrong
+
+Check that both exports cover the full intended period and came from the same GBP portfolio. Compare
+dividends and deducted tax with your broker statements, and review the terminal's final portfolio
+for missing or excessive holdings before relying on the tax report.

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -9,19 +9,17 @@ portfolio value of foreign-exchange trades as GBP.
 
 ## Export the reports
 
-Export enough history to cover the portfolio from its first transaction. Earlier acquisitions can
-still affect disposals in the tax year you are reporting; see
-[Before you start](../usage.md#before-you-start).
-
 ### All Trades
 
-1. Open the portfolio's **All Trades Report**.
-2. Set the date range to **Since Inception**.
+Export the portfolio from its first transaction. Earlier acquisitions can still affect disposals in
+the tax year you are reporting; see [Before you start](../usage.md#before-you-start).
+
+1. Open **Tax** and select **All Trades Report**.
+2. Set the date range to **Since inception**.
 3. Select **Do not group (Holdings)**.
 4. Export the report to a spreadsheet or Google Drive. Do not use the PDF export.
-5. Open the exported workbook and select the worksheet containing all trades without grouping (named
-   **Combined** in current exports).
-6. Save or download that worksheet as a CSV file.
+5. Open the exported spreadsheet and save or download the sheet containing the All Trades table as a
+   CSV file.
 
 See Sharesight's current
 [All Trades Report instructions](https://help.sharesight.com/uk/trades_report/) for the report
@@ -30,9 +28,9 @@ controls.
 ### Taxable Income
 
 1. Open the portfolio's **Taxable Income Report**.
-2. Set a date range that covers the complete history you are importing.
+2. Set the date range to the tax year you are calculating.
 3. Export the report to a spreadsheet or Google Drive. Do not use the PDF export.
-4. Save or download the report worksheet as a CSV file.
+4. Open the exported spreadsheet and save or download the report sheet as a CSV file.
 
 Sharesight recommends checking its income figures against your dividend statements because the
 report relies on third-party data. Its
@@ -49,10 +47,8 @@ sharesight/
 └── Taxable Income Report.csv
 ```
 
-The filenames must start with `All Trades Report` and `Taxable Income Report`, respectively. The
-matching is case-insensitive, including the `.csv` extension, so suffixes added by Sharesight and
-uppercase `.CSV` extensions are accepted. cgt-calc does not read the original `.xlsx` files or
-search subdirectories.
+Use the filenames shown above when saving the CSV files. cgt-calc does not read the original `.xlsx`
+files or search subdirectories.
 
 Do not rename or delete columns when converting the worksheets. In addition to the legacy headings,
 cgt-calc accepts aliases including `Market Code`, `Qty`, `Instrument Currency` and `Exch. Rate`. You
@@ -113,13 +109,14 @@ these markers.
 
 Check that you converted the spreadsheet worksheet to CSV: `.xlsx` files are not read. Confirm that
 both files are directly inside the directory passed to `--sharesight-dir`, and that their filenames
-start with `All Trades Report` and `Taxable Income Report`.
+start with `All Trades Report` and `Taxable Income Report`. Filenames are matched
+case-insensitively; additional text after `Report` and uppercase `.CSV` extensions are accepted.
 
 ### `Missing expected columns`
 
-For All Trades, make sure you exported **Do not group (Holdings)** and converted the worksheet
-containing the combined trades without editing its headings. For Taxable Income, convert the report
-worksheet rather than a summary or chart.
+For All Trades, make sure you exported **Do not group (Holdings)** and converted the sheet
+containing the All Trades table without editing its headings. For Taxable Income, convert the report
+sheet rather than a summary or chart.
 
 First upgrade cgt-calc using the same method you used to install it and try again. If the error
 remains, open a [GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new) with:
@@ -138,6 +135,7 @@ you replace it with an equivalent supported transaction whose UK tax treatment y
 
 ### The portfolio or dividend totals look wrong
 
-Check that both exports cover the full intended period and came from the same GBP portfolio. Compare
+Check that the All Trades export starts at the portfolio's first transaction, the Taxable Income
+export covers the tax year being calculated, and both came from the same GBP portfolio. Compare
 dividends and deducted tax with your broker statements, and review the terminal's final portfolio
 for missing or excessive holdings before relying on the tax report.

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -89,7 +89,8 @@ Sharesight has no native equity-grant transaction for this importer. To identify
 3. Include `Stock Activity` anywhere in the trade comment.
 
 cgt-calc then treats the row as stock activity rather than a cash purchase. A `Sell` row carrying
-that marker is rejected.
+that marker is rejected. If the CSV has no `Comments` column, cgt-calc warns that it cannot detect
+these markers.
 
 ## Known limitations
 

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -19,7 +19,8 @@ still affect disposals in the tax year you are reporting; see
 2. Set the date range to **Since Inception**.
 3. Select **Do not group (Holdings)**.
 4. Export the report to a spreadsheet or Google Drive. Do not use the PDF export.
-5. Open the exported workbook and select the **Combined** worksheet.
+5. Open the exported workbook and select the worksheet containing all trades without grouping (named
+   **Combined** in current exports).
 6. Save or download that worksheet as a CSV file.
 
 See Sharesight's current
@@ -53,9 +54,9 @@ matching is case-insensitive, including the `.csv` extension, so suffixes added 
 uppercase `.CSV` extensions are accepted. cgt-calc does not read the original `.xlsx` files or
 search subdirectories.
 
-Do not rename or delete columns when converting the worksheets. cgt-calc accepts both the legacy
-Sharesight headings and newer headings such as `Market Code`, `Qty`, `Instrument Currency` and
-`Exch. Rate`. You can compare the structure with the
+Do not rename or delete columns when converting the worksheets. In addition to the legacy headings,
+cgt-calc accepts aliases including `Market Code`, `Qty`, `Instrument Currency` and `Exch. Rate`. You
+can compare the legacy structure with the
 [sanitised example reports](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/sharesight/data/inputs).
 
 ## Generate the report
@@ -92,6 +93,9 @@ that marker is rejected.
 
 ## Known limitations
 
+- [`Opening Balance`](https://help.sharesight.com/opening-balance/) trades are not supported.
+  Sharesight uses them when the original buy and sell records are unavailable, but cgt-calc needs
+  the original acquisition dates and costs for UK share matching.
 - `Split`, `Consolidation` and `Bonus` rows are not supported. They stop the import with an unknown
   action error. Do not delete such a row to make the calculation run: later quantities and gains
   could be wrong.
@@ -112,9 +116,9 @@ start with `All Trades Report` and `Taxable Income Report`.
 
 ### `Missing expected columns`
 
-For All Trades, make sure you exported **Do not group (Holdings)** and converted the **Combined**
-worksheet without editing its headings. For Taxable Income, convert the report worksheet rather than
-a summary or chart.
+For All Trades, make sure you exported **Do not group (Holdings)** and converted the worksheet
+containing the combined trades without editing its headings. For Taxable Income, convert the report
+worksheet rather than a summary or chart.
 
 First upgrade cgt-calc using the same method you used to install it and try again. If the error
 remains, open a [GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new) with:

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -11,8 +11,8 @@ portfolio value of foreign-exchange trades as GBP.
 
 ### All Trades
 
-Export the portfolio from its first transaction. Earlier acquisitions can still affect disposals in
-the tax year you are reporting; see [Before you start](../usage.md#before-you-start).
+Export all trades from the portfolio's first transaction. Earlier acquisitions can still affect
+disposals in the tax year you are reporting; see [Before you start](../usage.md#before-you-start).
 
 1. Open **Tax** and select **All Trades Report**.
 2. Set the date range to **Since inception**.
@@ -78,7 +78,7 @@ The Sharesight importer currently handles:
 
 ### Equity grants
 
-Sharesight has no native equity-grant transaction for this importer. To identify a vest:
+cgt-calc identifies an equity grant through the trade comment. To record a vest:
 
 1. Record it as a `Buy` in Sharesight.
 2. Enter the market value per share on the vest date as the price.

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -74,11 +74,10 @@ reports do not contain the complete cash activity required to reconcile a broker
 
 The Sharesight importer currently handles:
 
-| Report         | Included activity                                                                                |
-| -------------- | ------------------------------------------------------------------------------------------------ |
-| All Trades     | `Buy` and `Sell` rows, including Sharesight foreign-exchange rows                                |
-| Taxable Income | Local and foreign dividend payments, including `Tax Deducted` and `Foreign Tax Deducted` amounts |
-| All Trades     | Equity grants entered as described below                                                         |
+| Report         | Included activity                                                                                               |
+| -------------- | --------------------------------------------------------------------------------------------------------------- |
+| All Trades     | `Buy` and `Sell` rows, including Sharesight foreign-exchange rows, and equity grants entered as described below |
+| Taxable Income | Local and foreign dividend payments, including `Tax Deducted` and `Foreign Tax Deducted` amounts                |
 
 ### Equity grants
 
@@ -100,8 +99,8 @@ that marker is rejected.
   required.
 - Taxable Income sections other than local and foreign dividend payments are not imported.
 - If a newer All Trades report gives a non-zero brokerage charge in a currency different from the
-  instrument currency, the import stops. That fee cannot yet be represented exactly from this report
-  without risking an incorrect allowable cost.
+  trade currency (GBP for foreign-exchange rows), the import stops. That fee cannot yet be
+  represented exactly from this report without risking an incorrect allowable cost.
 
 ## Troubleshooting
 

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -93,10 +93,9 @@ these markers.
 - [`Opening Balance`](https://help.sharesight.com/opening-balance/) trades are not supported.
   Sharesight uses them when the original buy and sell records are unavailable, but cgt-calc needs
   the original acquisition dates and costs for UK share matching.
-- `Split`, `Consolidation` and `Bonus` rows are not supported
-  ([#266](https://github.com/KapJI/capital-gains-calculator/issues/266)). They stop the import with
-  an unknown action error. Do not delete such a row to make the calculation run: later quantities
-  and gains could be wrong.
+- `Split`, `Consolidation` and `Bonus` rows are not supported. They stop the import with an unknown
+  action error. Do not delete such a row to make the calculation run: later quantities and gains
+  could be wrong.
 - Cash deposits, withdrawals and balances are not imported, which is why `--no-balance-check` is
   required.
 - Taxable Income sections other than local and foreign dividend payments are not imported.

--- a/tests/sharesight/test_sharesight.py
+++ b/tests/sharesight/test_sharesight.py
@@ -233,10 +233,10 @@ TRADE_HEADER = [
     "Comments",
 ]
 
-# Sharesight's newer Combined worksheet uses these spellings and puts Code
-# before Market Code. Keep this list independent of the parser aliases so a
-# wrong mapping there fails the tests.
-COMBINED_TRADE_HEADER = [
+# Exercise the newer header aliases together. This is deliberately not labelled
+# as a verbatim export fixture; keep it independent of the parser mapping so a
+# wrong alias there fails the tests.
+ALIASED_TRADE_HEADER = [
     "Code",
     "Market Code",
     "Name",
@@ -519,12 +519,12 @@ def test_parse_trade_report_with_renamed_columns(tmp_path: Path) -> None:
     assert transaction.amount == Decimal(-21)
 
 
-def test_parse_combined_trade_report_with_extra_column(tmp_path: Path) -> None:
-    """Parse the newer Combined worksheet and ignore informational columns."""
+def test_parse_trade_report_with_newer_aliases(tmp_path: Path) -> None:
+    """Parse the newer aliases and ignore an unrelated report column."""
     _write_csv(
         tmp_path / "All Trades Report.csv",
         [
-            [*COMBINED_TRADE_HEADER, "Holding"],
+            [*ALIASED_TRADE_HEADER, "Unused report column"],
             [
                 "ABC",
                 "NASDAQ",
@@ -539,7 +539,7 @@ def test_parse_combined_trade_report_with_extra_column(tmp_path: Path) -> None:
                 "1.2",
                 "16.67",
                 "",
-                "Example holding",
+                "not used",
             ],
         ],
     )
@@ -554,12 +554,12 @@ def test_parse_combined_trade_report_with_extra_column(tmp_path: Path) -> None:
     assert transaction.amount == Decimal(19)
 
 
-def test_parse_combined_trade_report_with_foreign_brokerage(tmp_path: Path) -> None:
+def test_parse_trade_report_with_foreign_brokerage(tmp_path: Path) -> None:
     """Reject brokerage whose currency differs from the instrument currency."""
     _write_csv(
         tmp_path / "All Trades Report.csv",
         [
-            COMBINED_TRADE_HEADER,
+            ALIASED_TRADE_HEADER,
             [
                 "ABC",
                 "NASDAQ",
@@ -587,12 +587,12 @@ def test_parse_combined_trade_report_with_foreign_brokerage(tmp_path: Path) -> N
     assert excinfo.value.row_index == 2
 
 
-def test_parse_combined_fx_trade_with_gbp_brokerage(tmp_path: Path) -> None:
+def test_parse_fx_trade_with_gbp_brokerage(tmp_path: Path) -> None:
     """Accept an FX row whose brokerage is in GBP, the currency FX rows use."""
     _write_csv(
         tmp_path / "All Trades Report.csv",
         [
-            COMBINED_TRADE_HEADER,
+            ALIASED_TRADE_HEADER,
             [
                 "USDGBP",
                 "FX",

--- a/tests/sharesight/test_sharesight.py
+++ b/tests/sharesight/test_sharesight.py
@@ -142,10 +142,10 @@ def test_parse_trade_report_missing_column(tmp_path: Path) -> None:
                 "Type",
                 "Date",
                 "Quantity",
-                "Price *",
                 "Brokerage *",
                 "Currency",
                 "Exchange Rate",
+                "Value",
                 "Comments",
             ],
             [
@@ -155,10 +155,10 @@ def test_parse_trade_report_missing_column(tmp_path: Path) -> None:
                 "Buy",
                 "01/01/2020",
                 "1",
-                "100",
                 "0",
                 "USD",
                 "1.2",
+                "100",
                 "Note",
             ],
         ],
@@ -166,7 +166,7 @@ def test_parse_trade_report_missing_column(tmp_path: Path) -> None:
 
     with pytest.raises(
         ParsingError,
-        match="Missing expected columns in Sharesight trades header: Value",
+        match=r"Missing expected columns in Sharesight trades header: Price \*",
     ) as excinfo:
         list(SharesightParser().load_from_dir(tmp_path))
 
@@ -481,6 +481,27 @@ def test_parse_trade_report(tmp_path: Path) -> None:
     assert grant.amount is None
 
 
+def test_parse_trade_report_with_minimal_header(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Parse a trade without unused or conditionally required columns."""
+    _write_csv(
+        tmp_path / "All Trades Report.csv",
+        [
+            ["Market", "Code", "Type", "Date", "Quantity", "Price *", "Currency"],
+            ["LSE", "ABC", "Buy", "01/02/2023", "2", "10", "GBP"],
+        ],
+    )
+
+    [transaction] = SharesightParser().load_from_dir(tmp_path)
+
+    assert transaction.symbol == "LSE:ABC"
+    assert transaction.description == ""
+    assert transaction.fees == Decimal(0)
+    assert transaction.amount == Decimal(-20)
+    assert "Stock Activity markers cannot be detected" in caplog.text
+
+
 def test_parse_trade_report_with_renamed_columns(tmp_path: Path) -> None:
     """Parse the report generation that renamed three legacy headings."""
     renamed_header = [
@@ -670,6 +691,20 @@ def test_parse_trade_report_fx_without_value(tmp_path: Path) -> None:
                 "",
                 "fx",
             ],
+        ],
+    )
+
+    with pytest.raises(ParsingError, match="Missing Value in FX transaction"):
+        SharesightParser().load_from_dir(tmp_path)
+
+
+def test_parse_trade_report_fx_without_value_column(tmp_path: Path) -> None:
+    """Require the conditionally used Value column for an FX trade."""
+    _write_csv(
+        tmp_path / "All Trades Report.csv",
+        [
+            ["Market", "Code", "Type", "Date", "Quantity", "Price *", "Currency"],
+            ["FX", "USDGBP", "Sell", "03/02/2023", "-100", "1.25", "USD"],
         ],
     )
 

--- a/tests/sharesight/test_sharesight.py
+++ b/tests/sharesight/test_sharesight.py
@@ -233,6 +233,25 @@ TRADE_HEADER = [
     "Comments",
 ]
 
+# Sharesight's newer Combined worksheet uses these spellings and puts Code
+# before Market Code. Keep this list independent of the parser aliases so a
+# wrong mapping there fails the tests.
+COMBINED_TRADE_HEADER = [
+    "Code",
+    "Market Code",
+    "Name",
+    "Date",
+    "Type",
+    "Qty",
+    "Price",
+    "Instrument Currency",
+    "Brokerage",
+    "Brokerage Currency",
+    "Exch. Rate",
+    "Value",
+    "Comments",
+]
+
 LOCAL_DIVIDEND_HEADER = [
     "Code",
     "Name",
@@ -295,6 +314,42 @@ def test_parse_income_report_with_uppercase_csv_extension(tmp_path: Path) -> Non
         "GBP",
         "USD",
         "USD",
+    ]
+
+
+def test_parse_income_report_with_informational_columns(tmp_path: Path) -> None:
+    """Ignore newer Taxable Income columns not used by the calculation."""
+    _write_csv(
+        tmp_path / "Taxable Income Report.csv",
+        [
+            ["Foreign Income"],
+            [*FOREIGN_DIVIDEND_HEADER, "Country", "Income Type"],
+            [
+                "XYZ",
+                "X Corp",
+                "03/04/2023",
+                "1.2",
+                "USD",
+                "85",
+                "15",
+                "100",
+                "foreign",
+                "United States",
+                "Dividend",
+            ],
+            ["Total"],
+        ],
+    )
+
+    transactions = SharesightParser().load_from_dir(tmp_path)
+
+    assert [transaction.action for transaction in transactions] == [
+        ActionType.DIVIDEND,
+        ActionType.DIVIDEND_TAX,
+    ]
+    assert [transaction.amount for transaction in transactions] == [
+        Decimal(100),
+        Decimal(-15),
     ]
 
 
@@ -424,6 +479,112 @@ def test_parse_trade_report(tmp_path: Path) -> None:
 
     assert grant.action == ActionType.STOCK_ACTIVITY
     assert grant.amount is None
+
+
+def test_parse_trade_report_with_renamed_columns(tmp_path: Path) -> None:
+    """Parse the report generation that renamed three legacy headings."""
+    renamed_header = [
+        "Price" if column == "Price *" else column for column in TRADE_HEADER
+    ]
+    renamed_header[renamed_header.index("Brokerage *")] = "Brokerage"
+    renamed_header[renamed_header.index("Currency")] = "Brokerage Currency"
+    _write_csv(
+        tmp_path / "All Trades Report.csv",
+        [
+            renamed_header,
+            [
+                "LSE",
+                "ABC",
+                "Example",
+                "Buy",
+                "01/02/2023",
+                "2",
+                "10",
+                "1",
+                "GBP",
+                "1",
+                "20",
+                "",
+            ],
+        ],
+    )
+
+    [transaction] = SharesightParser().load_from_dir(tmp_path)
+
+    assert transaction.symbol == "LSE:ABC"
+    assert transaction.currency == "GBP"
+    assert transaction.quantity == Decimal(2)
+    assert transaction.price == Decimal(10)
+    assert transaction.fees == Decimal(1)
+    assert transaction.amount == Decimal(-21)
+
+
+def test_parse_combined_trade_report_with_extra_column(tmp_path: Path) -> None:
+    """Parse the newer Combined worksheet and ignore informational columns."""
+    _write_csv(
+        tmp_path / "All Trades Report.csv",
+        [
+            [*COMBINED_TRADE_HEADER, "Holding"],
+            [
+                "ABC",
+                "NASDAQ",
+                "Example",
+                "01/02/2023",
+                "Sell",
+                "-2",
+                "10",
+                "USD",
+                "1",
+                "USD",
+                "1.2",
+                "16.67",
+                "",
+                "Example holding",
+            ],
+        ],
+    )
+
+    [transaction] = SharesightParser().load_from_dir(tmp_path)
+
+    assert transaction.symbol == "NASDAQ:ABC"
+    assert transaction.currency == "USD"
+    assert transaction.quantity == Decimal(2)
+    assert transaction.price == Decimal(10)
+    assert transaction.fees == Decimal(1)
+    assert transaction.amount == Decimal(19)
+
+
+def test_parse_combined_trade_report_with_foreign_brokerage(tmp_path: Path) -> None:
+    """Reject brokerage whose currency differs from the instrument currency."""
+    _write_csv(
+        tmp_path / "All Trades Report.csv",
+        [
+            COMBINED_TRADE_HEADER,
+            [
+                "ABC",
+                "NASDAQ",
+                "Example",
+                "01/02/2023",
+                "Buy",
+                "2",
+                "10",
+                "USD",
+                "1",
+                "GBP",
+                "1.2",
+                "16.67",
+                "",
+            ],
+        ],
+    )
+
+    with pytest.raises(
+        ParsingError,
+        match="Brokerage Currency 'GBP' differs from transaction currency 'USD'",
+    ) as excinfo:
+        SharesightParser().load_from_dir(tmp_path)
+
+    assert excinfo.value.row_index == 2
 
 
 def test_parse_trade_report_unknown_action(tmp_path: Path) -> None:

--- a/tests/sharesight/test_sharesight.py
+++ b/tests/sharesight/test_sharesight.py
@@ -587,6 +587,40 @@ def test_parse_combined_trade_report_with_foreign_brokerage(tmp_path: Path) -> N
     assert excinfo.value.row_index == 2
 
 
+def test_parse_combined_fx_trade_with_gbp_brokerage(tmp_path: Path) -> None:
+    """Accept an FX row whose brokerage is in GBP, the currency FX rows use."""
+    _write_csv(
+        tmp_path / "All Trades Report.csv",
+        [
+            COMBINED_TRADE_HEADER,
+            [
+                "USDGBP",
+                "FX",
+                "FX trade",
+                "03/02/2023",
+                "Sell",
+                "-100",
+                "1.25",
+                "USD",
+                "1",
+                "GBP",
+                "1.25",
+                "80",
+                "fx",
+            ],
+        ],
+    )
+
+    [transaction] = SharesightParser().load_from_dir(tmp_path)
+
+    assert transaction.symbol == "FX:USDGBP"
+    assert transaction.currency == "GBP"
+    assert transaction.quantity == Decimal(100)
+    assert transaction.price == Decimal("0.8")
+    assert transaction.fees == Decimal(1)
+    assert transaction.amount == Decimal(79)
+
+
 def test_parse_trade_report_unknown_action(tmp_path: Path) -> None:
     """Raise on unknown trade types with row context."""
     _write_csv(


### PR DESCRIPTION
A Sharesight user reported that newer All Trades exports replaced `Price *`, `Brokerage *` and `Currency` with `Price`, `Brokerage` and `Brokerage Currency` (#263). This PR accepts those headings, maps the alternate `Market Code`, `Qty`, `Instrument Currency` and `Exch. Rate` spellings onto the same internal columns, and preserves support for the original format.

All Trades validation now requires only the seven fields needed for every trade. Brokerage and comments are optional, while `Value` remains required for FX rows. Additional columns are ignored, missing comments produce a warning because `Stock Activity` markers cannot be detected, and non-zero brokerage in a different currency is rejected rather than miscalculated.

The Sharesight guide now explains how to export and convert the All Trades and Taxable Income reports, identifies the required filenames, documents equity grants, and lists unsupported activity including Opening Balance trades, splits, consolidations, bonuses, cash activity and cross-currency brokerage.