### PR TITLE
Make the test calculator state its tax year and balance check

### DIFF
--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -67,9 +67,13 @@ def get_report(
 
 
 def create_calculator(
-    tax_year: int = 2024, balance_check: bool = False
+    *, tax_year: int, balance_check: bool = True
 ) -> CapitalGainsCalculator:
-    """Create a calculator with standard test configuration."""
+    """Create a calculator with standard test configuration.
+
+    Mirrors the command line: the tax year has to be given, by name, and
+    the balance check is on unless a test turns it off.
+    """
     currency_converter = CurrencyConverter(None, {})
     price_fetcher = CurrentPriceFetcher(currency_converter, {}, {})
     return CapitalGainsCalculator(
@@ -197,7 +201,7 @@ def test_eri_duplicate_report_within_tolerance_is_skipped(
     overlapping input files) and simply skipped with a warning.
     """
     date = datetime.date(2024, 6, 30)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     calculator.isin_converter.data[ERI_ISIN] = {"VWRL"}
 
     transactions: list[BrokerTransaction] = [
@@ -235,7 +239,7 @@ def test_eri_conflicting_report_raises_invalid_transaction_error() -> None:
     one.
     """
     date = datetime.date(2024, 6, 30)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     calculator.isin_converter.data[ERI_ISIN] = {"VWRL"}
 
     transactions: list[BrokerTransaction] = [
@@ -497,7 +501,7 @@ def test_proportional_disposal_no_rounding_error() -> None:
     (quantity * amount) / total, which ensures exact cancellation when
     disposing all shares: (total * amount) / total = amount.
     """
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     symbol = "TEST"
 
     # Create scenario that would trigger rounding errors:
@@ -559,7 +563,7 @@ def test_high_precision_amount_no_rounding_error() -> None:
     Without the fix (28-digit precision), this fails with:
     AssertionError: current amount 2E-23
     """
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     symbol = "ACME"
 
     transactions: list[BrokerTransaction] = [
@@ -616,7 +620,7 @@ def test_high_precision_amount_no_rounding_error() -> None:
 
 def test_same_day_rule_all_shares_disposed_no_rounding_error() -> None:
     """Test that same day rule disposing ALL shares doesn't cause rounding errors."""
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     symbol = "TEST"
     same_day = datetime.date(2024, 5, 1)
 
@@ -686,7 +690,7 @@ def _rename_transaction(date: datetime.date, old: str, new: str) -> BrokerTransa
 
 def test_rename_transfers_pool_to_new_ticker() -> None:
     """RENAME moves pool cost and quantity from old to new ticker; logs a RENAME entry."""
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     rename_date = datetime.date(2024, 5, 10)
     transactions: list[BrokerTransaction] = [
         BrokerTransaction(
@@ -724,7 +728,7 @@ def test_rename_transfers_pool_to_new_ticker() -> None:
 
 def test_section_104_disposal_uses_renamed_pool_cost() -> None:
     """After a rename, S104 disposal under NEW uses the pool cost carried from OLD."""
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     sell_date = datetime.date(2024, 6, 1)
     transactions: list[BrokerTransaction] = [
         BrokerTransaction(
@@ -787,7 +791,7 @@ def test_section_104_disposal_uses_renamed_pool_cost() -> None:
 
 def test_bed_and_breakfast_matches_across_rename() -> None:
     """Sell of OLD is B&B-matched against a buy of NEW after a rename within 30 days."""
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     transactions: list[BrokerTransaction] = [
         BrokerTransaction(
             date=datetime.date(2024, 5, 1),
@@ -872,11 +876,12 @@ def test_same_day_vest_ordered_before_sale() -> None:
 
     # Raw order (sale before vest) fails the ownership check.
     with pytest.raises(InvalidTransactionError):
-        get_report(create_calculator(), [sale, vest])
+        get_report(create_calculator(tax_year=2024, balance_check=False), [sale, vest])
 
     # The registry sort orders the vest first, so the sale succeeds.
     report = get_report(
-        create_calculator(), sorted([sale, vest], key=_transaction_sort_key)
+        create_calculator(tax_year=2024, balance_check=False),
+        sorted([sale, vest], key=_transaction_sort_key),
     )
     assert report.total_gain() == Decimal(50)  # 5 * (20 - 10)
 
@@ -922,7 +927,7 @@ def test_same_day_sale_funding_purchase_survives_sort() -> None:
     ]
 
     report = get_report(
-        create_calculator(balance_check=True),
+        create_calculator(tax_year=2024),
         sorted(transactions, key=_transaction_sort_key),
     )
     assert report.total_gain() == Decimal(50)  # 5 * (20 - 10)
@@ -961,7 +966,7 @@ def test_disposal_debug_log_keeps_fractional_quantity(
     ]
 
     with caplog.at_level(logging.DEBUG, logger="cgt_calc.main"):
-        get_report(create_calculator(), transactions)
+        get_report(create_calculator(tax_year=2024, balance_check=False), transactions)
 
     disposal_logs = [
         record.getMessage()
@@ -1048,7 +1053,7 @@ def test_negative_balance_error_trims_long_history() -> None:
         transfer_transaction(start + datetime.timedelta(days=day), -1.0)
         for day in range(1, 15)
     ]
-    calculator = create_calculator(balance_check=True)
+    calculator = create_calculator(tax_year=2024)
 
     with pytest.raises(CalculationError) as excinfo:
         calculator.convert_to_hmrc_transactions(transactions)
@@ -1062,7 +1067,7 @@ def test_negative_balance_error_trims_long_history() -> None:
 def test_negative_balance_error_shows_short_history_in_full() -> None:
     """A dump that fits within the limit is shown without omissions."""
     transactions = [transfer_transaction(datetime.date(2024, 5, 1), -1.0)]
-    calculator = create_calculator(balance_check=True)
+    calculator = create_calculator(tax_year=2024)
 
     with pytest.raises(CalculationError) as excinfo:
         calculator.convert_to_hmrc_transactions(transactions)
@@ -1096,7 +1101,7 @@ def test_negative_balance_error_shows_only_relevant_transactions() -> None:
         ),
         transfer_transaction(day + datetime.timedelta(days=4), -91.0),
     ]
-    calculator = create_calculator(balance_check=True)
+    calculator = create_calculator(tax_year=2024)
 
     with pytest.raises(CalculationError) as excinfo:
         calculator.convert_to_hmrc_transactions(transactions)
@@ -1312,7 +1317,7 @@ def test_multiple_foreign_fee_currencies_on_sell() -> None:
 
 def test_calculate_capital_gain_runs_once() -> None:
     """A second run would count the first pass's estimates and B&B claims twice."""
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     get_report(
         calculator,
         [

--- a/tests/general/test_report_rendering.py
+++ b/tests/general/test_report_rendering.py
@@ -59,7 +59,9 @@ def money(text: str) -> Decimal:
 
 def render(tmp_path: Path) -> str:
     """Render the scenario to LaTeX source, flattened to one line per block."""
-    report = get_report(create_calculator(), TRANSACTIONS)
+    report = get_report(
+        create_calculator(tax_year=2024, balance_check=False), TRANSACTIONS
+    )
     render_pdf(report, tmp_path / "report.pdf", skip_pdflatex=True)
     source = (tmp_path / "report.tex").read_text(encoding="utf-8")
     # Line breaks and \mbox{} only shape the typesetting.

--- a/tests/general/test_transfer_to_spouse.py
+++ b/tests/general/test_transfer_to_spouse.py
@@ -47,7 +47,7 @@ def test_transfer_to_spouse_from_pool_is_no_gain_no_loss() -> None:
     """A transfer to spouse leaves the Section 104 pool at base cost with nil gain."""
     buy_day = datetime.date(2024, 6, 1)
     transfer_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -94,7 +94,7 @@ def test_transfer_to_spouse_matches_repurchase_within_30_days() -> None:
     buy_day = datetime.date(2024, 6, 1)
     transfer_day = datetime.date(2024, 6, 10)
     rebuy_day = datetime.date(2024, 6, 15)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -121,7 +121,7 @@ def test_transfer_to_spouse_entire_holding_empties_pool() -> None:
     """Transferring the whole holding removes it from the portfolio with nil gain."""
     buy_day = datetime.date(2024, 6, 1)
     transfer_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -146,7 +146,7 @@ def test_transfer_to_spouse_matches_same_day_acquisition() -> None:
     """
     buy_day = datetime.date(2024, 6, 1)
     transfer_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -182,7 +182,7 @@ def test_transfer_to_spouse_same_day_as_sale_is_rejected(
     """A sale and a transfer competing for the same acquisitions is unsupported."""
     buy_day = datetime.date(2024, 6, 1)
     event_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     with pytest.raises(CalculationError, match="does not say how to split") as err:
         get_report(
             calculator,
@@ -221,7 +221,7 @@ def test_transfer_to_spouse_same_day_as_sale_from_pool_is_allowed() -> None:
     """
     buy_day = datetime.date(2024, 6, 1)
     event_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -251,7 +251,7 @@ def test_transfer_to_spouse_more_than_owned_is_rejected() -> None:
     """Transferring more units than held is refused."""
     buy_day = datetime.date(2024, 6, 1)
     transfer_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     with pytest.raises(InvalidTransactionError, match="more than the available"):
         get_report(
             calculator,
@@ -266,7 +266,7 @@ def test_transfer_to_spouse_more_than_owned_is_rejected() -> None:
 
 def test_transfer_to_spouse_of_not_owned_symbol_is_rejected() -> None:
     """Transferring a symbol that was never acquired is refused."""
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     with pytest.raises(InvalidTransactionError, match="not owned symbol"):
         get_report(
             calculator,
@@ -280,7 +280,7 @@ def test_transfer_to_spouse_warns_about_the_ignored_price(
     """A gift has no consideration, so any price on the row is ignored."""
     buy_day = datetime.date(2024, 6, 1)
     transfer_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
         report = get_report(
             calculator,
@@ -316,7 +316,7 @@ def test_transfer_to_spouse_fee_is_added_to_the_base_cost() -> None:
     """
     buy_day = datetime.date(2024, 6, 1)
     transfer_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -350,7 +350,7 @@ def test_transfer_to_spouse_shown_in_report() -> None:
     """The text report lists each transfer with the base cost passed on."""
     buy_day = datetime.date(2024, 6, 1)
     transfer_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -371,7 +371,7 @@ def test_unclassified_gift_is_rejected_with_instructions() -> None:
     """A broker gift with no classification refuses and says how to fix it."""
     buy_day = datetime.date(2024, 6, 1)
     gift_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     with pytest.raises(UnclassifiedGiftError) as err:
         get_report(
             calculator,
@@ -397,7 +397,7 @@ def test_gift_matched_by_transfer_to_spouse_is_accounted_for() -> None:
     """A matching transfer row classifies the gift, which is then not counted twice."""
     buy_day = datetime.date(2024, 6, 1)
     gift_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -423,7 +423,7 @@ def test_gift_with_mismatched_transfer_is_rejected() -> None:
     """A transfer row that does not match the gift does not classify it."""
     buy_day = datetime.date(2024, 6, 1)
     gift_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     with pytest.raises(UnclassifiedGiftError):
         get_report(
             calculator,
@@ -443,7 +443,7 @@ def test_gift_with_mismatched_transfer_is_rejected() -> None:
 def test_transfer_to_spouse_without_quantity_is_rejected() -> None:
     """A transfer row has to say how many units moved."""
     buy_day = datetime.date(2024, 6, 1)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     with pytest.raises(QuantityNotPositiveError):
         get_report(
             calculator,
@@ -458,7 +458,7 @@ def test_transfer_to_spouse_without_quantity_is_rejected() -> None:
 
 def test_gift_without_quantity_is_rejected() -> None:
     """A gift row with no quantity is refused before asking who received it."""
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     with pytest.raises(QuantityNotPositiveError):
         get_report(
             calculator,
@@ -484,7 +484,7 @@ def test_transfer_to_spouse_reserves_its_share_of_a_same_day_acquisition() -> No
     buy_day = datetime.date(2024, 6, 1)
     sell_day = datetime.date(2024, 6, 10)
     rebuy_day = datetime.date(2024, 6, 15)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -579,7 +579,7 @@ def test_transfer_to_spouse_before_the_tax_year_still_reduces_the_pool() -> None
     buy_day = datetime.date(2022, 5, 1)
     transfer_day = datetime.date(2022, 6, 10)
     sell_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -608,7 +608,7 @@ def test_disposal_is_not_matched_against_a_same_day_split() -> None:
     """
     buy_day = datetime.date(2024, 6, 1)
     split_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -634,7 +634,7 @@ def test_transfer_to_spouse_is_not_matched_against_a_same_day_split() -> None:
     """The same, for a transfer: the recipient must not inherit a nil base cost."""
     buy_day = datetime.date(2024, 6, 1)
     split_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -673,7 +673,7 @@ def test_either_reading_of_an_ambiguous_gift_settles_it(confirmed: Decimal) -> N
         broker="Testing",
         ambiguous_quantity=Decimal(40),
     )
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -714,7 +714,7 @@ def test_ambiguous_gift_error_offers_both_readings() -> None:
         ambiguous_quantity=Decimal(40),
     )
     with pytest.raises(UnclassifiedGiftError) as err:
-        get_report(create_calculator(), [gift])
+        get_report(create_calculator(tax_year=2024, balance_check=False), [gift])
 
     message = str(err.value)
     assert "2024-06-10,TRANSFER_TO_SPOUSE,FOO,2,0.00,0.00,GBP" in message
@@ -745,7 +745,7 @@ def test_a_certain_gift_is_not_stranded_by_an_uncertain_one() -> None:
             ambiguous_quantity=ambiguous,
         )
 
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -796,7 +796,7 @@ def test_two_uncertain_gifts_are_read_the_way_that_fits_both() -> None:
     the 1-or-20 gift is stranded, although 400 and 20 fit them perfectly.
     """
     gift_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -826,7 +826,7 @@ def test_gifts_no_reading_can_satisfy_still_name_the_one_left_out() -> None:
     gift_day = datetime.date(2024, 6, 10)
     with pytest.raises(UnclassifiedGiftError) as err:
         get_report(
-            create_calculator(),
+            create_calculator(tax_year=2024, balance_check=False),
             [
                 transaction(
                     datetime.date(2024, 6, 1),
@@ -854,7 +854,7 @@ def test_each_gift_needs_its_own_classification() -> None:
     """Two gifts of the same shares on one day are not settled by one row."""
     buy_day = datetime.date(2024, 6, 1)
     gift_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     with pytest.raises(UnclassifiedGiftError):
         get_report(
             calculator,
@@ -877,7 +877,7 @@ def test_two_gifts_are_settled_by_two_classifications() -> None:
     """Matching one row per gift accounts for both."""
     buy_day = datetime.date(2024, 6, 1)
     gift_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -914,7 +914,7 @@ def test_transfer_to_spouse_sorts_after_a_same_day_acquisition() -> None:
 
     # Worst case: the transfer is read first, as a RAW file would give it.
     report = get_report(
-        create_calculator(),
+        create_calculator(tax_year=2024, balance_check=False),
         sorted([transfer, buy], key=_transaction_sort_key),
     )
 
@@ -931,7 +931,7 @@ def test_management_fee_is_not_a_contended_acquisition() -> None:
     buy_day = datetime.date(2024, 6, 1)
     event_day = datetime.date(2024, 6, 10)
     fee_day = datetime.date(2024, 6, 20)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -958,7 +958,7 @@ def test_fractional_transfer_keeps_its_units_in_the_report() -> None:
     buy_day = datetime.date(2024, 6, 1)
     transfer_day = datetime.date(2024, 6, 10)
     report = get_report(
-        create_calculator(),
+        create_calculator(tax_year=2024, balance_check=False),
         [
             transaction(
                 buy_day, ActionType.BUY, "FOO", 10, 10, 0, -100, CurrencyCode(GBP)
@@ -977,7 +977,7 @@ def test_split_shares_do_not_dilute_a_same_day_purchase() -> None:
     acquisition prices the purchase across shares that cost nothing.
     """
     day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -1012,7 +1012,7 @@ def test_transfer_reservation_survives_a_split_before_the_repurchase() -> None:
     counted differently; subtracting one from the other unconverted drove the
     available quantity negative.
     """
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -1060,7 +1060,7 @@ def test_fully_matched_acquisition_is_not_contended() -> None:
     buy_day = datetime.date(2024, 6, 1)
     event_day = datetime.date(2024, 6, 10)
     later = datetime.date(2024, 6, 15)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -1090,7 +1090,7 @@ def test_acquisition_an_earlier_disposal_took_is_not_contended() -> None:
     The 5 June sale takes the whole 15 June purchase, so neither the sale nor
     the transfer on 10 June can reach it and both fall to the pool.
     """
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -1155,7 +1155,7 @@ def test_same_day_sale_and_transfer_after_a_split_is_allowed() -> None:
     buy_day = datetime.date(2024, 6, 1)
     event_day = datetime.date(2024, 6, 10)
     split_day = datetime.date(2024, 6, 15)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     report = get_report(
         calculator,
         [
@@ -1179,7 +1179,7 @@ def test_same_day_sale_and_transfer_message_caps_the_dates_it_lists() -> None:
     """Too many contended acquisitions are summarised rather than all listed."""
     buy_day = datetime.date(2024, 6, 1)
     event_day = datetime.date(2024, 6, 10)
-    calculator = create_calculator()
+    calculator = create_calculator(tax_year=2024, balance_check=False)
     rebuys = [
         transaction(
             event_day + datetime.timedelta(days=offset),
@@ -1232,7 +1232,7 @@ def test_transfer_fee_does_not_move_the_cash_balance() -> None:
         currency=CurrencyCode(GBP),
         broker="Unknown",
     )
-    calculator = create_calculator(balance_check=True)
+    calculator = create_calculator(tax_year=2024)
     report = get_report(
         calculator,
         [
@@ -1266,7 +1266,7 @@ def test_transfer_from_spouse_enters_the_pool_at_the_given_cost() -> None:
     """
     arrival = datetime.date(2024, 6, 15)
     sale = datetime.date(2024, 9, 1)
-    calculator = create_calculator(balance_check=True)
+    calculator = create_calculator(tax_year=2024)
     report = get_report(
         calculator,
         [
@@ -1296,7 +1296,7 @@ def test_transfer_from_spouse_needs_the_cost() -> None:
     """The price column is the whole point of the row; it cannot be blank."""
     with pytest.raises(PriceMissingError):
         get_report(
-            create_calculator(),
+            create_calculator(tax_year=2024, balance_check=False),
             [
                 transaction(
                     datetime.date(2024, 6, 15),
@@ -1328,7 +1328,8 @@ def test_transfer_from_spouse_sorts_before_a_same_day_sale() -> None:
     )
 
     report = get_report(
-        create_calculator(), sorted([sale, arrival], key=_transaction_sort_key)
+        create_calculator(tax_year=2024, balance_check=False),
+        sorted([sale, arrival], key=_transaction_sort_key),
     )
 
     assert report.total_gain() == Decimal(400)
@@ -1339,7 +1340,7 @@ def test_transferor_report_hands_over_the_recipients_row() -> None:
     buy_day = datetime.date(2024, 6, 1)
     transfer_day = datetime.date(2024, 6, 10)
     report = get_report(
-        create_calculator(),
+        create_calculator(tax_year=2024, balance_check=False),
         [
             transaction(
                 buy_day, ActionType.BUY, "FOO", 1000, 10, 0, -10000, CurrencyCode(GBP)
@@ -1360,7 +1361,7 @@ def test_hand_over_row_round_trips_through_the_raw_parser(tmp_path: Path) -> Non
     """
     transfer_day = datetime.date(2024, 6, 10)
     sender = get_report(
-        create_calculator(),
+        create_calculator(tax_year=2024, balance_check=False),
         [
             transaction(
                 datetime.date(2024, 6, 1),
@@ -1395,7 +1396,7 @@ def test_hand_over_row_round_trips_through_the_raw_parser(tmp_path: Path) -> Non
 
     (arrival,) = RawParser().load_from_file(raw_file)
     recipient = get_report(
-        create_calculator(balance_check=True),
+        create_calculator(tax_year=2024),
         [
             arrival,
             transaction(


### PR DESCRIPTION
`create_calculator()` defaulted to a 2024 tax year with the balance check off, so a test read as if it ran on the tool's defaults when it did the opposite. It now mirrors the command line: the tax year is always given, by name, and the balance check is on unless a test turns it off. Both arguments are keyword-only, so a bare number can't creep back in.

Every call states which. The seven that already asked for the check use the new default; the other 53 turn it off explicitly, as they always effectively did. No test's behaviour changes.

Suggested by @vmartinv in [review of #924](https://github.com/KapJI/capital-gains-calculator/pull/924#discussion_r3835875235); keyword-only goes one step further than the suggestion there, to match `--year` on the command line.
