### PR TITLE
Fix Freetrade dividend FX direction, fees and withholding tax

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -981,7 +981,11 @@ class CapitalGainsCalculator:
             print(style_text("Dividends", colour=Style.BRIGHT, emoji="💵"))
             for (symbol, currency), amount in dividends.items():
                 tax = dividends_tax[(symbol, currency)]
-                tax_str = f", excluding {-tax} taxed at source" if tax < 0 else ""
+                tax_str = (
+                    f", excluding {round_decimal(-tax, 2)} taxed at source"
+                    if tax < 0
+                    else ""
+                )
                 print(
                     f"{bul}{symbol}: {round_decimal(amount, 2)}{tax_str} ({currency})"
                 )

--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -73,6 +73,12 @@ COLUMN_ALIASES: Final[dict[str, str]] = {
 # fails as an unknown type.
 STOCK_SPLIT_PREFIX: Final = "Stock Split "
 
+# These Activity Feed rows point to documents rather than cash or security
+# transactions. Freetrade includes them in an All Activity export.
+IGNORED_TYPES: Final[frozenset[str]] = frozenset(
+    {"MONTHLY_STATEMENT", "TAX_CERTIFICATE"}
+)
+
 
 def _parse_decimal(row: dict[str, str], column: FreetradeColumn) -> Decimal:
     """Parse Decimal value for column, raising ValueError with context on failure."""
@@ -83,6 +89,25 @@ def _parse_decimal(row: dict[str, str], column: FreetradeColumn) -> Decimal:
         raise ValueError(
             f"Invalid decimal in column '{column.value}': {value!r}"
         ) from err
+
+
+def _parse_optional_decimal(row: dict[str, str], column: FreetradeColumn) -> Decimal:
+    """Parse a decimal that Freetrade leaves blank when it does not apply."""
+    if row[column] == "":
+        return Decimal(0)
+    return _parse_decimal(row, column)
+
+
+def _dividend_amount_in_gbp(row: dict[str, str], column: FreetradeColumn) -> Decimal:
+    """Convert a dividend field from instrument currency to account currency."""
+    amount = _parse_decimal(row, column)
+    if amount != 0:
+        instrument_currency = CurrencyCode(row[FreetradeColumn.INSTRUMENT_CURRENCY])
+        if instrument_currency != "GBP":
+            # Dividend exports express Base FX Rate as GBP per unit of the
+            # instrument currency (unlike the trade-only FX Rate column).
+            amount *= _parse_decimal(row, FreetradeColumn.BASE_FX_RATE)
+    return amount
 
 
 def _action_from_str(action_type: str, buy_sell: str, file: Path) -> ActionType:
@@ -120,32 +145,30 @@ class FreetradeTransaction(BrokerTransaction):
         if symbol is None and action not in [ActionType.TRANSFER, ActionType.INTEREST]:
             raise ParsingError(file, f"No symbol for action: {action}")
 
-        # I believe GIA account at Freetrade can be only in GBP
+        # The importer and calculation path below use the exported GBP account
+        # currency fields. Reject another account currency rather than
+        # silently treating it as sterling.
         if row[FreetradeColumn.ACCOUNT_CURRENCY] != "GBP":
             raise UnsupportedBrokerCurrencyError(
                 file, BROKER_NAME, row[FreetradeColumn.ACCOUNT_CURRENCY]
             )
 
-        # Convert all numbers to GBP using Freetrade rates
+        fees = Decimal(0)
         if action in [ActionType.SELL, ActionType.BUY]:
             quantity = _parse_decimal(row, FreetradeColumn.QUANTITY)
-            price = _parse_decimal(row, FreetradeColumn.PRICE_PER_SHARE)
-            amount = _parse_decimal(row, FreetradeColumn.TOTAL_SHARES_AMOUNT)
-            currency = CurrencyCode(row[FreetradeColumn.INSTRUMENT_CURRENCY])
-            if currency != "GBP":
-                fx_rate = _parse_decimal(row, FreetradeColumn.FX_RATE)
-                price /= fx_rate
-                amount /= fx_rate
+            # These two fields are already in account currency. Total Amount
+            # is the cash movement after fees, while the account-currency unit
+            # price excludes them, so retaining the exported fee fields keeps
+            # all three values mutually consistent.
+            price = _parse_decimal(row, FreetradeColumn.PRICE_PER_SHARE_ACCOUNT)
+            amount = _parse_decimal(row, FreetradeColumn.TOTAL_AMOUNT)
+            fees = _parse_optional_decimal(
+                row, FreetradeColumn.STAMP_DUTY
+            ) + _parse_optional_decimal(row, FreetradeColumn.FX_FEE_AMOUNT)
             currency = CurrencyCode("GBP")
         elif action == ActionType.DIVIDEND:
-            # Total amount before US tax withholding
-            amount = _parse_decimal(row, FreetradeColumn.DIVIDEND_GROSS_AMOUNT)
+            amount = _dividend_amount_in_gbp(row, FreetradeColumn.DIVIDEND_GROSS_AMOUNT)
             quantity, price = None, None
-            currency = CurrencyCode(row[FreetradeColumn.INSTRUMENT_CURRENCY])
-            if currency != "GBP":
-                # FX Rate is not defined for dividends,
-                # but we can use base one as there's no fee
-                amount /= _parse_decimal(row, FreetradeColumn.BASE_FX_RATE)
             currency = CurrencyCode("GBP")
         elif action in [ActionType.TRANSFER, ActionType.INTEREST]:
             amount = _parse_decimal(row, FreetradeColumn.TOTAL_AMOUNT)
@@ -159,6 +182,7 @@ class FreetradeTransaction(BrokerTransaction):
         if row[FreetradeColumn.TYPE] == "FREESHARE_ORDER":
             price = Decimal(0)
             amount = Decimal(0)
+            fees = Decimal(0)
 
         amount_negative = (
             action == ActionType.BUY or row[FreetradeColumn.TYPE] == "WITHDRAWAL"
@@ -176,12 +200,43 @@ class FreetradeTransaction(BrokerTransaction):
             description=f"{row[FreetradeColumn.TITLE]} {action}",
             quantity=quantity,
             price=price,
-            fees=Decimal(0),  # not implemented
+            fees=fees,
             amount=amount,
             currency=currency,
             broker=BROKER_NAME,
             isin=isin,
         )
+
+
+def _dividend_tax_transaction(
+    transaction: FreetradeTransaction,
+    header: list[str],
+    row_raw: list[str],
+) -> BrokerTransaction | None:
+    """Create the tax-at-source cash movement carried on a dividend row."""
+    if transaction.action is not ActionType.DIVIDEND:
+        return None
+
+    row = dict(zip(header, row_raw, strict=False))
+    if row[FreetradeColumn.DIVIDEND_WITHHELD_AMOUNT] == "":
+        return None
+    amount = _dividend_amount_in_gbp(row, FreetradeColumn.DIVIDEND_WITHHELD_AMOUNT)
+    if amount == 0:
+        return None
+
+    return BrokerTransaction(
+        date=transaction.date,
+        action=ActionType.DIVIDEND_TAX,
+        symbol=transaction.symbol,
+        description=f"{row[FreetradeColumn.TITLE]} {ActionType.DIVIDEND_TAX}",
+        quantity=None,
+        price=None,
+        fees=Decimal(0),
+        amount=-amount,
+        currency=CurrencyCode("GBP"),
+        broker=BROKER_NAME,
+        isin=transaction.isin,
+    )
 
 
 class FreetradeParser(BaseSingleFileParser):
@@ -210,8 +265,21 @@ class FreetradeParser(BaseSingleFileParser):
         indexed_rows.reverse()
         transactions: list[BrokerTransaction] = []
         for index, row in indexed_rows:
+            row_values = dict(zip(header, row, strict=False))
+            action_type = row_values.get(FreetradeColumn.TYPE)
+            if action_type in IGNORED_TYPES:
+                LOGGER.debug(
+                    "Skipping non-transaction Freetrade row %d (%s)",
+                    index,
+                    action_type,
+                )
+                continue
             try:
-                transactions.append(FreetradeTransaction(header, row, file_path))
+                transaction = FreetradeTransaction(header, row, file_path)
+                transactions.append(transaction)
+                dividend_tax = _dividend_tax_transaction(transaction, header, row)
+                if dividend_tax is not None:
+                    transactions.append(dividend_tax)
             except ParsingError as err:
                 err.add_row_context(index)
                 raise

--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -132,9 +132,8 @@ def _action_from_str(action_type: str, buy_sell: str, file: Path) -> ActionType:
 class FreetradeTransaction(BrokerTransaction):
     """Represents a single Freetrade transaction."""
 
-    def __init__(self, header: list[str], row_raw: list[str], file: Path) -> None:
-        """Create transaction from CSV row."""
-        row = dict(zip(header, row_raw, strict=False))
+    def __init__(self, row: dict[str, str], file: Path) -> None:
+        """Create transaction from a CSV row keyed by column name."""
         action = _action_from_str(
             row[FreetradeColumn.TYPE], row[FreetradeColumn.BUY_SELL], file
         )
@@ -209,15 +208,12 @@ class FreetradeTransaction(BrokerTransaction):
 
 
 def _dividend_tax_transaction(
-    transaction: FreetradeTransaction,
-    header: list[str],
-    row_raw: list[str],
+    transaction: FreetradeTransaction, row: dict[str, str]
 ) -> BrokerTransaction | None:
     """Create the tax-at-source cash movement carried on a dividend row."""
     if transaction.action is not ActionType.DIVIDEND:
         return None
 
-    row = dict(zip(header, row_raw, strict=False))
     if row[FreetradeColumn.DIVIDEND_WITHHELD_AMOUNT] == "":
         return None
     amount = _dividend_amount_in_gbp(row, FreetradeColumn.DIVIDEND_WITHHELD_AMOUNT)
@@ -264,9 +260,9 @@ class FreetradeParser(BaseSingleFileParser):
         # the proper fix would be to use datetime in BrokerTransaction
         indexed_rows.reverse()
         transactions: list[BrokerTransaction] = []
-        for index, row in indexed_rows:
-            row_values = dict(zip(header, row, strict=False))
-            action_type = row_values.get(FreetradeColumn.TYPE)
+        for index, row_raw in indexed_rows:
+            row = dict(zip(header, row_raw, strict=False))
+            action_type = row.get(FreetradeColumn.TYPE)
             if action_type in IGNORED_TYPES:
                 LOGGER.debug(
                     "Skipping non-transaction Freetrade row %d (%s)",
@@ -275,9 +271,9 @@ class FreetradeParser(BaseSingleFileParser):
                 )
                 continue
             try:
-                transaction = FreetradeTransaction(header, row, file_path)
+                transaction = FreetradeTransaction(row, file_path)
                 transactions.append(transaction)
-                dividend_tax = _dividend_tax_transaction(transaction, header, row)
+                dividend_tax = _dividend_tax_transaction(transaction, row)
                 if dividend_tax is not None:
                     transactions.append(dividend_tax)
             except ParsingError as err:

--- a/tests/freetrade/data/expected_output.txt
+++ b/tests/freetrade/data/expected_output.txt
@@ -4,18 +4,18 @@ Final portfolio
   TSLA: 1.45
 
 Final balance
-  Freetrade: 8946.79 (GBP)
+  Freetrade: 8945.12 (GBP)
 
 Dividends
-  NDAQ: 1.78 (GBP)
+  NDAQ: 1.10, excluding 0.16 taxed at source (GBP)
 
 Interest
   Freetrade: 9.02 (GBP)
 
 Portfolio at the end of 2023/2024 tax year
-  GOOGL: 0.14, £279.58
-  NDAQ: 2.12, £279.58
-  TSLA: 1.45, £944.86
+  GOOGL: 0.14, £279.59
+  NDAQ: 2.12, £279.59
+  TSLA: 1.45, £944.88
 
 Tax summary for 2023/2024
 
@@ -29,7 +29,7 @@ Capital gains
   Taxable gain:           £0.00
 
 Dividends
-  Proceeds:               £1.78
+  Proceeds:               £1.10
   Tax-free allowance: £1,000.00
   Taxable proceeds:       £0.00
 

--- a/tests/freetrade/test_freetrade.py
+++ b/tests/freetrade/test_freetrade.py
@@ -2,6 +2,7 @@
 
 import csv
 from decimal import Decimal
+import logging
 from pathlib import Path
 import subprocess
 
@@ -233,9 +234,110 @@ def test_read_freetrade_transactions_success(tmp_path: Path) -> None:
     assert transaction.symbol == "AAPL"
     assert transaction.quantity == Decimal(1)
     assert transaction.price == Decimal(100)
+    assert transaction.fees == Decimal(0)
     assert transaction.amount == Decimal(-100)
     assert transaction.currency == "GBP"
     assert transaction.isin == "US0378331005"
+
+
+@pytest.mark.parametrize("document_type", ["MONTHLY_STATEMENT", "TAX_CERTIFICATE"])
+def test_read_freetrade_ignores_document_rows(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    document_type: str,
+) -> None:
+    """Document links in an All Activity export are not transactions."""
+    values = dict.fromkeys(COLUMNS, "")
+    values.update(
+        {
+            FreetradeColumn.TITLE.value: "Account document",
+            FreetradeColumn.TYPE.value: document_type,
+            FreetradeColumn.TIMESTAMP.value: "2024-01-02T10:00:00",
+        }
+    )
+    document_row = [values[column] for column in COLUMNS]
+    path = _write_csv(tmp_path, COLUMNS, [_default_row(), document_row])
+    caplog.set_level(logging.DEBUG, logger="cgt_calc.parsers.freetrade")
+
+    transactions = FreetradeParser().load_from_file(path)
+
+    assert len(transactions) == 1
+    assert transactions[0].action is ActionType.BUY
+    assert (
+        f"Skipping non-transaction Freetrade row 3 ({document_type})" in caplog.messages
+    )
+
+
+@pytest.mark.parametrize(
+    ("buy_sell", "total_amount", "expected_amount"),
+    [
+        ("BUY", "100.75", Decimal("-100.75")),
+        ("SELL", "99.25", Decimal("99.25")),
+    ],
+)
+def test_read_freetrade_trade_uses_account_amount_and_fees(
+    tmp_path: Path,
+    buy_sell: str,
+    total_amount: str,
+    expected_amount: Decimal,
+) -> None:
+    """GBP cash, price, stamp duty and FX fees come from their direct fields."""
+    overrides = {
+        FreetradeColumn.TOTAL_AMOUNT.value: total_amount,
+        FreetradeColumn.BUY_SELL.value: buy_sell,
+        FreetradeColumn.PRICE_PER_SHARE_ACCOUNT.value: "100",
+        FreetradeColumn.STAMP_DUTY.value: "0.50",
+        FreetradeColumn.INSTRUMENT_CURRENCY.value: "USD",
+        FreetradeColumn.TOTAL_SHARES_AMOUNT.value: "125",
+        FreetradeColumn.PRICE_PER_SHARE.value: "125",
+        FreetradeColumn.FX_RATE.value: "1.25",
+        FreetradeColumn.FX_FEE_AMOUNT.value: "0.25",
+    }
+    path = _write_csv(tmp_path, COLUMNS, [_default_row(overrides)])
+
+    transactions = FreetradeParser().load_from_file(path)
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert transaction.action is (
+        ActionType.BUY if buy_sell == "BUY" else ActionType.SELL
+    )
+    assert transaction.price == Decimal(100)
+    assert transaction.fees == Decimal("0.75")
+    assert transaction.amount == expected_amount
+    assert transaction.currency == "GBP"
+
+
+def test_read_freetrade_foreign_dividend_and_withholding_tax(
+    tmp_path: Path,
+) -> None:
+    """Foreign dividend gross income and withholding use GBP-per-unit base FX."""
+    overrides = {
+        FreetradeColumn.TITLE.value: "Nasdaq",
+        FreetradeColumn.TYPE.value: "DIVIDEND",
+        FreetradeColumn.TOTAL_AMOUNT.value: "0.93",
+        FreetradeColumn.BUY_SELL.value: "",
+        FreetradeColumn.TICKER.value: "NDAQ",
+        FreetradeColumn.ISIN.value: "US6311031081",
+        FreetradeColumn.INSTRUMENT_CURRENCY.value: "USD",
+        FreetradeColumn.BASE_FX_RATE.value: "0.78491703",
+        FreetradeColumn.DIVIDEND_GROSS_AMOUNT.value: "1.40",
+        FreetradeColumn.DIVIDEND_NET_AMOUNT.value: "1.19",
+        FreetradeColumn.DIVIDEND_WITHHELD_PERCENTAGE.value: "15",
+        FreetradeColumn.DIVIDEND_WITHHELD_AMOUNT.value: "0.21",
+    }
+    path = _write_csv(tmp_path, COLUMNS, [_default_row(overrides)])
+
+    dividend, tax = FreetradeParser().load_from_file(path)
+
+    assert dividend.action is ActionType.DIVIDEND
+    assert dividend.amount == Decimal("1.40") * Decimal("0.78491703")
+    assert dividend.currency == "GBP"
+    assert tax.action is ActionType.DIVIDEND_TAX
+    assert tax.amount == Decimal("-0.21") * Decimal("0.78491703")
+    assert tax.currency == "GBP"
+    assert tax.symbol == dividend.symbol
+    assert tax.isin == dividend.isin
 
 
 def test_read_freetrade_transactions_new_header_success(tmp_path: Path) -> None:

--- a/tests/freetrade/test_freetrade.py
+++ b/tests/freetrade/test_freetrade.py
@@ -402,4 +402,4 @@ def test_freetrade_transaction_unsupported_action(
         UnsupportedBrokerActionError,
         match="Unsupported Freetrade action 'ADJUSTMENT'",
     ):
-        FreetradeTransaction(COLUMNS, row, dummy_file)
+        FreetradeTransaction(dict(zip(COLUMNS, row, strict=True)), dummy_file)

--- a/tests/interactive_brokers/data/expected_output.txt
+++ b/tests/interactive_brokers/data/expected_output.txt
@@ -6,7 +6,7 @@ Final balance
 
 Dividends
   IBKR: 1.00, excluding 0.15 taxed at source (GBP)
-  VT: 20.00, excluding 3.0 taxed at source (GBP)
+  VT: 20.00, excluding 3.00 taxed at source (GBP)
 
 Portfolio at the end of 2025/2026 tax year
   CNX1: 2.00, £2,007.77


### PR DESCRIPTION
The Freetrade parser divided foreign dividends by `Base FX Rate`, but that column is GBP per unit of the instrument currency, so every USD dividend was overstated by roughly 60%: the fixture's 1.40 USD NASDAQ dividend came out as £1.78 instead of £1.10. The withholding recorded on the same row was ignored, and stamp duty and the Freetrade FX fee were hard-coded to zero, so allowable costs and the cash balance were both off.

Trades now take the unit price and net cash movement from the account-currency columns and record stamp duty and FX fee as fees; the three values reconcile on every row of the fixture. Dividends are multiplied by `Base FX Rate`, and a non-zero `Dividend Withheld Tax Amount` becomes a dividend-tax transaction in GBP carrying the row's ISIN, so the US treaty applies as it does for other brokers. `MONTHLY_STATEMENT` and `TAX_CERTIFICATE` rows, which Freetrade includes in an All Activity export and classifies as non-transactions, are skipped instead of stopping the import.

The dividends summary printed the tax at source as a raw Decimal, which the FX-converted Freetrade figure made visible (`0.1648325763`); it is now rounded to two decimal places like the amount beside it.