### PR TITLE
Treat Alphabet sales on the split date as pre-split

### DIFF
--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -70,10 +70,17 @@ KNOWN_SYMBOL_DICT: Final[dict[str, str]] = {
 
 @dataclass
 class StockSplit:
-    """Info about stock split."""
+    """A split whose earlier sales the withdrawal report leaves in old units."""
 
     symbol: str
     date: datetime.date
+    """Last day on which the report prints sales in pre-split units.
+
+    Morgan Stanley's notice puts sales "on or prior to" the split date in
+    pre-split values, so this is the split date itself rather than the first
+    day of split-adjusted trading that the Schwab parser's ``SPLITS`` table
+    uses.
+    """
     factor: int
 
 

--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -1,7 +1,8 @@
-"""Morgan Stanley parser.
+"""Parse the Morgan Stanley at Work report format used for Alphabet awards.
 
-Note: I only had access to an Alphabet export. I have no idea what it looks like
-for another company, or for a full profile.
+The importer has only been validated against an Alphabet ``GSU Class C``
+export. It is not a general parser for other employers or Morgan Stanley
+brokerage accounts.
 """
 
 from __future__ import annotations
@@ -249,7 +250,7 @@ class MSSBParser(StandardCSVParser, BaseDirParser):
             if (
                 transaction.symbol == split.symbol
                 and transaction.action == ActionType.SELL
-                and transaction.date < split.date
+                and transaction.date <= split.date
             ):
                 if transaction.quantity:
                     transaction.quantity *= split.factor

--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -78,8 +78,7 @@ class StockSplit:
 
     Morgan Stanley's notice puts sales "on or prior to" the split date in
     pre-split values, so this is the split date itself rather than the first
-    day of split-adjusted trading that the Schwab parser's ``SPLITS`` table
-    uses.
+    date treated as post-split by the Schwab parser's ``SPLITS`` table.
     """
     factor: int
 

--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -234,12 +234,13 @@ class MSSBParser(StandardCSVParser, BaseDirParser):
         else:
             action = ActionType.SELL
 
+        symbol = KNOWN_SYMBOL_DICT[plan]
         transaction = BrokerTransaction(
             date=datetime.datetime.strptime(
                 row[WithdrawalColumn.EXECUTION_DATE], "%d-%b-%Y"
             ).date(),
             action=action,
-            symbol=KNOWN_SYMBOL_DICT[plan],
+            symbol=symbol,
             description=plan,
             quantity=quantity,
             price=price,
@@ -249,7 +250,10 @@ class MSSBParser(StandardCSVParser, BaseDirParser):
             broker=BROKER_NAME,
         )
 
-        return MSSBParser._handle_stock_split(transaction)
+        # Splits are keyed by the symbol the report uses, so rename afterwards.
+        transaction = MSSBParser._handle_stock_split(transaction)
+        transaction.symbol = TICKER_RENAMES.get(symbol, symbol)
+        return transaction
 
     @staticmethod
     def _handle_stock_split(transaction: BrokerTransaction) -> BrokerTransaction:

--- a/tests/morgan_stanley/test_mssb.py
+++ b/tests/morgan_stanley/test_mssb.py
@@ -135,27 +135,39 @@ def test_read_mssb_withdrawal_with_uppercase_csv_extension(tmp_path: Path) -> No
     assert transactions[0].amount == Decimal("-100.00")
 
 
-def test_read_mssb_withdrawal_goog_sale_before_split_window(tmp_path: Path) -> None:
-    """Ensure a GOOG sale shortly before the July 15, 2022 split is adjusted.
+@pytest.mark.parametrize(
+    ("execution_date", "price", "quantity"),
+    [
+        # The window that went unadjusted while STOCK_SPLIT_INFO dated the
+        # split 15 June 2022 instead of 15 July.
+        pytest.param("01-Jul-2022", "$2,240.00", "-2.00", id="before-split"),
+        # The report notice says sales "on or prior to" 15 July are pre-split.
+        pytest.param("15-Jul-2022", "$2,240.00", "-2.00", id="on-split-date"),
+        # Later sales are already exported in post-split values.
+        pytest.param("18-Jul-2022", "$112.00", "-40.00", id="after-split"),
+    ],
+)
+def test_read_mssb_withdrawal_goog_sale_split_adjustment(
+    tmp_path: Path, execution_date: str, price: str, quantity: str
+) -> None:
+    """Normalise GOOG sales either side of 15 July 2022 to post-split units.
 
-    Morgan Stanley's own notice states that sales occurring "on or prior to
-    the July 15, 2022 stock split are reflected in pre-split" values. This
-    covers the previously mishandled window (2022-06-15 to 2022-07-14) where
-    a bug in STOCK_SPLIT_INFO used June 15 instead of July 15, causing these
-    sales to be skipped for the 20x split adjustment.
+    Morgan Stanley's notice states that sales "on or prior to the July 15,
+    2022 stock split are reflected in pre-split" values and later sales in
+    post-split values, so only the former are scaled by the split factor.
     """
 
     withdrawal_file = tmp_path / WITHDRAWALS_REPORT_FILENAME
     rows = [
         COLUMNS_WITHDRAWAL,
         [
-            "01-Jul-2022",
+            execution_date,
             "ORDER-4",
             "GSU Class C",
             "Sale",
             "Complete",
-            "$2,240.00",
-            "-2.00",
+            price,
+            quantity,
             "$4,479.90",
             "0",
             "N/A",
@@ -168,73 +180,7 @@ def test_read_mssb_withdrawal_goog_sale_before_split_window(tmp_path: Path) -> N
     assert len(transactions) == 1
     transaction = transactions[0]
     assert transaction.action == ActionType.SELL
-    expected_symbol = TICKER_RENAMES.get("GOOG", "GOOG")
-    assert transaction.symbol == expected_symbol
-    # Pre-split values reported by Morgan Stanley get multiplied by the
-    # split factor (20) for quantity and divided by it for price.
-    assert transaction.quantity == Decimal("40.00")
-    assert transaction.price == Decimal("112.00")
-
-
-def test_read_mssb_withdrawal_goog_sale_on_split_date_is_adjusted(
-    tmp_path: Path,
-) -> None:
-    """Adjust a GOOG sale on July 15 because the report uses pre-split values."""
-
-    withdrawal_file = tmp_path / WITHDRAWALS_REPORT_FILENAME
-    rows = [
-        COLUMNS_WITHDRAWAL,
-        [
-            "15-Jul-2022",
-            "ORDER-5",
-            "GSU Class C",
-            "Sale",
-            "Complete",
-            "$2,240.00",
-            "-2.00",
-            "$4,479.90",
-            "0",
-            "N/A",
-        ],
-    ]
-    _write_csv(withdrawal_file, rows)
-
-    transactions = MSSBParser().load_from_dir(tmp_path)
-
-    assert len(transactions) == 1
-    transaction = transactions[0]
-    # The report notice says activity "on or prior to" July 15 is pre-split.
-    assert transaction.quantity == Decimal("40.00")
-    assert transaction.price == Decimal("112.00")
-
-
-def test_read_mssb_withdrawal_goog_sale_after_split_not_adjusted(
-    tmp_path: Path,
-) -> None:
-    """Leave a GOOG sale after July 15 in its exported post-split values."""
-
-    withdrawal_file = tmp_path / WITHDRAWALS_REPORT_FILENAME
-    rows = [
-        COLUMNS_WITHDRAWAL,
-        [
-            "18-Jul-2022",
-            "ORDER-6",
-            "GSU Class C",
-            "Sale",
-            "Complete",
-            "$112.00",
-            "-40.00",
-            "$4,479.90",
-            "0",
-            "N/A",
-        ],
-    ]
-    _write_csv(withdrawal_file, rows)
-
-    transactions = MSSBParser().load_from_dir(tmp_path)
-
-    assert len(transactions) == 1
-    transaction = transactions[0]
+    assert transaction.symbol == TICKER_RENAMES.get("GOOG", "GOOG")
     assert transaction.quantity == Decimal("40.00")
     assert transaction.price == Decimal("112.00")
 

--- a/tests/morgan_stanley/test_mssb.py
+++ b/tests/morgan_stanley/test_mssb.py
@@ -176,10 +176,10 @@ def test_read_mssb_withdrawal_goog_sale_before_split_window(tmp_path: Path) -> N
     assert transaction.price == Decimal("112.00")
 
 
-def test_read_mssb_withdrawal_goog_sale_after_split_not_adjusted(
+def test_read_mssb_withdrawal_goog_sale_on_split_date_is_adjusted(
     tmp_path: Path,
 ) -> None:
-    """Ensure a GOOG sale on the split date itself is treated as post-split."""
+    """Adjust a GOOG sale on July 15 because the report uses pre-split values."""
 
     withdrawal_file = tmp_path / WITHDRAWALS_REPORT_FILENAME
     rows = [
@@ -187,6 +187,38 @@ def test_read_mssb_withdrawal_goog_sale_after_split_not_adjusted(
         [
             "15-Jul-2022",
             "ORDER-5",
+            "GSU Class C",
+            "Sale",
+            "Complete",
+            "$2,240.00",
+            "-2.00",
+            "$4,479.90",
+            "0",
+            "N/A",
+        ],
+    ]
+    _write_csv(withdrawal_file, rows)
+
+    transactions = MSSBParser().load_from_dir(tmp_path)
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    # The report notice says activity "on or prior to" July 15 is pre-split.
+    assert transaction.quantity == Decimal("40.00")
+    assert transaction.price == Decimal("112.00")
+
+
+def test_read_mssb_withdrawal_goog_sale_after_split_not_adjusted(
+    tmp_path: Path,
+) -> None:
+    """Leave a GOOG sale after July 15 in its exported post-split values."""
+
+    withdrawal_file = tmp_path / WITHDRAWALS_REPORT_FILENAME
+    rows = [
+        COLUMNS_WITHDRAWAL,
+        [
+            "18-Jul-2022",
+            "ORDER-6",
             "GSU Class C",
             "Sale",
             "Complete",
@@ -203,7 +235,6 @@ def test_read_mssb_withdrawal_goog_sale_after_split_not_adjusted(
 
     assert len(transactions) == 1
     transaction = transactions[0]
-    # No adjustment should be applied on/after the split date.
     assert transaction.quantity == Decimal("40.00")
     assert transaction.price == Decimal("112.00")
 


### PR DESCRIPTION
The Morgan Stanley withdrawals report states that Alphabet sales "on or prior to the July 15, 2022 stock split are reflected in pre-split" values, and Alphabet executed the 20-for-1 split on 15 July 2022 with split-adjusted trading from the following Monday. The parser only adjusted sales dated strictly before 15 July, so a `GSU Class C` sale executed on the split date itself kept its pre-split quantity and price: twenty times too few shares sold at twenty times the price. #848 fixed the month of the split date but pinned this boundary the wrong way with a test.

The comparison is now `<=`, the boundary test asserts the adjustment using pre-split values for a 15 July sale, and a separate test keeps a sale on 18 July unadjusted.

Along the way, the three boundary tests become one parametrised test that also pins the action and symbol, `StockSplit.date` documents which side of the split it sits on, and sales now go through `TICKER_RENAMES` as vests already did.
