### PR TITLE
Revalidate the docs site's stylesheets and assets

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -1,0 +1,12 @@
+# Cloudflare Pages caches everything but HTML for four hours by default. Zensical
+# content-hashes its own bundles, but extra.css, the images and the example
+# report keep stable names, so a deploy would stay invisible until the browser's
+# copy expired. Revalidate those instead: with an ETag that is a 304 unless the
+# file really changed. Matching rules are merged and same-name headers joined
+# with a comma, so these patterns must not overlap.
+
+/stylesheets/*
+  Cache-Control: public, max-age=0, must-revalidate
+
+/assets/*
+  Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
Cloudflare Pages caches everything but HTML for four hours by default, so an updated `extra.css` stayed invisible until the browser's copy expired — a force-refresh was the only way to see it. Zensical content-hashes its own bundles, but our stylesheet, images and example report keep stable names.

A `_headers` file in the deploy root asks browsers to revalidate those paths instead. With an ETag that is a 304 unless the file changed. Zensical copies `docs/_headers` into the build output verbatim, so the deploy workflow is unchanged.