### PR TITLE
Report bad input as errors instead of assertions

### DIFF
--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -152,6 +152,12 @@ class CurrencyConverter:
                     exchange_rates_file,
                     f"Invalid rate '{rate_value}' at line {row_number}",
                 ) from err
+            if not rate.is_finite() or rate <= 0:
+                raise ParsingError(
+                    exchange_rates_file,
+                    f"Exchange rate must be finite and positive at line "
+                    f"{row_number}: {rate_value!r}",
+                )
 
             # Duplicates suggest conflicting data, so fail fast.
             if currency in cache[date]:
@@ -256,12 +262,19 @@ class CurrencyConverter:
                     f"{currency_code_elem.text!r}",
                 )
             try:
-                rates[currency] = Decimal(rate_new_elem.text)
+                rate = Decimal(rate_new_elem.text)
             except (InvalidOperation, ValueError) as err:
                 raise ExternalApiError(
                     url,
                     f"HMRC API response for {month_str} contains invalid rate: {rate_new_elem.text}",
                 ) from err
+            if not rate.is_finite() or rate <= 0:
+                raise ExternalApiError(
+                    url,
+                    f"HMRC API response for {month_str} contains a non-positive "
+                    f"or non-finite rate: {rate_new_elem.text}",
+                )
+            rates[currency] = rate
         self.cache[date] = rates
         self._write_exchange_rates_file(self.exchange_rates_file, self.cache)
 

--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -185,6 +185,14 @@ class PriceMissingError(InvalidTransactionError):
         super().__init__(transaction, "Price missing")
 
 
+class IsinMissingError(InvalidTransactionError):
+    """ISIN is missing error."""
+
+    def __init__(self, transaction: BrokerTransaction):
+        """Initialise."""
+        super().__init__(transaction, "ISIN missing")
+
+
 class QuantityMissingError(InvalidTransactionError):
     """Quantity is missing error."""
 

--- a/cgt_calc/initial_prices.py
+++ b/cgt_calc/initial_prices.py
@@ -41,6 +41,10 @@ class InitialPricesEntry:
             self.price = Decimal(row[2])
         except InvalidOperation as err:
             raise ParsingError(file, f"Invalid decimal price: {row[2]!r}") from err
+        if not self.price.is_finite() or self.price < 0:
+            raise ParsingError(
+                file, f"Initial price must be finite and non-negative: {row[2]!r}"
+            )
 
     @staticmethod
     def _parse_date(date_str: str, file: Path) -> datetime.date:

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -38,6 +38,7 @@ from .exceptions import (
     CalculationError,
     CgtError,
     InvalidTransactionError,
+    IsinMissingError,
     PriceMissingError,
     QuantityMissingError,
     QuantityNotPositiveError,
@@ -411,8 +412,7 @@ class CapitalGainsCalculator:
         MMM shares will be used as the acquisition date for the SOLV shares.
         """
         symbol = get_symbol_or_fail(transaction)
-        quantity = transaction.quantity
-        assert quantity is not None
+        quantity = get_quantity_or_fail(transaction)
 
         ticker = self.spin_off_handler.get_spin_off_source(
             symbol, transaction.date, self.portfolio
@@ -871,10 +871,15 @@ class CapitalGainsCalculator:
         """
         distribution_date = transaction.date + ERI_TAX_DATE_DELTA
 
-        assert transaction.isin is not None, f"{transaction} doesn't have a valid ISIN"
-        assert transaction.price is not None, (
-            f"{transaction} doesn't have a valid price"
-        )
+        if transaction.isin is None:
+            raise IsinMissingError(transaction)
+        if transaction.price is None:
+            raise PriceMissingError(transaction)
+        if not transaction.price.is_finite() or transaction.price < 0:
+            raise InvalidTransactionError(
+                transaction,
+                "Excess reported income price must be finite and non-negative",
+            )
 
         if transaction.price == Decimal(0):
             return
@@ -912,6 +917,42 @@ class CapitalGainsCalculator:
                 distribution_date=distribution_date,
                 is_interest=symbol in self.interest_fund_tickers,
             )
+
+    def add_rename(self, transaction: BrokerTransaction) -> None:
+        """Apply a ticker rename during the first calculation pass."""
+        new_symbol = get_symbol_or_fail(transaction)
+        if not transaction.description.startswith(RENAME_DESCRIPTION_PREFIX):
+            raise InvalidTransactionError(
+                transaction,
+                "Rename transaction does not identify the old symbol",
+            )
+        old_symbol = transaction.description[len(RENAME_DESCRIPTION_PREFIX) :]
+        self.rename_list[transaction.date][old_symbol] = new_symbol
+        self.portfolio[new_symbol] += self.portfolio.pop(old_symbol, Position())
+
+    def add_management_fee(self, transaction: BrokerTransaction) -> Decimal:
+        """Record a fee that increases the holding's pooled cost."""
+        amount = get_amount_or_fail(transaction)
+        if amount > 0:
+            raise InvalidTransactionError(
+                transaction,
+                "Fee amount must not be positive: a positive fee would reduce "
+                "the pooled cost",
+            )
+        transaction.fees = -amount
+        transaction.quantity = Decimal(0)
+        gbp_fees = self.currency_converter.to_gbp_for(transaction.fees, transaction)
+        symbol = get_symbol_or_fail(transaction)
+        self.fee_days.add((transaction.date, symbol))
+        add_to_list(
+            self.acquisition_list,
+            transaction.date,
+            symbol,
+            transaction.quantity,
+            gbp_fees,
+            gbp_fees,
+        )
+        return amount
 
     def _convert_foreign_fees(self, transaction: BrokerTransaction) -> None:
         """Fold fees paid in other currencies into the transaction's fees.
@@ -990,23 +1031,7 @@ class CapitalGainsCalculator:
                 new_balance += amount
                 self.add_disposal(transaction)
             elif transaction.action is ActionType.FEE:
-                amount = get_amount_or_fail(transaction)
-                new_balance += amount
-                transaction.fees = -amount
-                transaction.quantity = Decimal(0)
-                gbp_fees = self.currency_converter.to_gbp_for(
-                    transaction.fees, transaction
-                )
-                symbol = get_symbol_or_fail(transaction)
-                self.fee_days.add((transaction.date, symbol))
-                add_to_list(
-                    self.acquisition_list,
-                    transaction.date,
-                    symbol,
-                    transaction.quantity,
-                    gbp_fees,
-                    gbp_fees,
-                )
+                new_balance += self.add_management_fee(transaction)
             elif transaction.action in [
                 ActionType.STOCK_ACTIVITY,
                 ActionType.SPIN_OFF,
@@ -1066,11 +1091,7 @@ class CapitalGainsCalculator:
                 amount = get_amount_or_fail(transaction)
                 new_balance += amount
             elif transaction.action is ActionType.RENAME:
-                new_symbol = get_symbol_or_fail(transaction)
-                assert transaction.description.startswith(RENAME_DESCRIPTION_PREFIX)
-                old_symbol = transaction.description[len(RENAME_DESCRIPTION_PREFIX) :]
-                self.rename_list[transaction.date][old_symbol] = new_symbol
-                self.portfolio[new_symbol] += self.portfolio.pop(old_symbol, Position())
+                self.add_rename(transaction)
             elif transaction.action in [
                 ActionType.TRANSFER_TO_SPOUSE,
                 ActionType.GIFT,
@@ -2157,10 +2178,12 @@ class CapitalGainsCalculator:
                         "Cannot apply taxation treaty for bond fund %s", symbol
                     )
                 else:
-                    assert tax.currency == foreign_amount.currency, (
-                        f"Not matching currency for dividend {foreign_amount.currency} "
-                        f"and its tax {tax.currency}"
-                    )
+                    if tax.currency != foreign_amount.currency:
+                        raise CalculationError(
+                            f"Dividend and withholding tax currencies do not match "
+                            f"for {symbol} on {date}: dividend "
+                            f"{foreign_amount.currency}, tax {tax.currency}"
+                        )
                     country = self.dividend_source_country(symbol, currency)
                     if country is None:
                         LOGGER.warning(

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -921,18 +921,26 @@ class CapitalGainsCalculator:
     def add_rename(self, transaction: BrokerTransaction) -> None:
         """Apply a ticker rename during the first calculation pass."""
         new_symbol = get_symbol_or_fail(transaction)
-        if not transaction.description.startswith(RENAME_DESCRIPTION_PREFIX):
+        old_symbol = transaction.description[len(RENAME_DESCRIPTION_PREFIX) :]
+        if (
+            not transaction.description.startswith(RENAME_DESCRIPTION_PREFIX)
+            or not old_symbol
+        ):
             raise InvalidTransactionError(
                 transaction,
                 "Rename transaction does not identify the old symbol",
             )
-        old_symbol = transaction.description[len(RENAME_DESCRIPTION_PREFIX) :]
         self.rename_list[transaction.date][old_symbol] = new_symbol
         self.portfolio[new_symbol] += self.portfolio.pop(old_symbol, Position())
 
     def add_management_fee(self, transaction: BrokerTransaction) -> Decimal:
         """Record a fee that increases the holding's pooled cost."""
         amount = get_amount_or_fail(transaction)
+        if not amount.is_finite():
+            raise InvalidTransactionError(
+                transaction,
+                "Fee amount must be a finite number",
+            )
         if amount > 0:
             raise InvalidTransactionError(
                 transaction,

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Final, Self, override
 
 from colorama import Style
 
+from .exceptions import CalculationError
 from .logging import bullet, style_text
 from .util import (
     approx_equal,
@@ -182,15 +183,19 @@ class ForeignCurrencyAmount:
 
     def __add__(self, amount: ForeignCurrencyAmount) -> ForeignCurrencyAmount:
         """Add two amounts."""
-        assert self.currency or not self.amount, (
-            f"Invalid foreign currency amount {self}"
-        )
-        assert amount.currency or not amount.amount, (
-            f"Invalid foreign currency amount {amount}"
-        )
-        assert (
-            not self.currency or not amount.currency or self.currency == amount.currency
-        ), f"Incompatible currency operation {self.currency} vs {amount.currency}"
+        if self.currency is None and self.amount:
+            raise CalculationError(f"Currency missing for amount {self.amount}")
+        if amount.currency is None and amount.amount:
+            raise CalculationError(f"Currency missing for amount {amount.amount}")
+        if (
+            self.currency is not None
+            and amount.currency is not None
+            and self.currency != amount.currency
+        ):
+            raise CalculationError(
+                "Cannot combine amounts in different currencies: "
+                f"{self.currency} and {amount.currency}"
+            )
         result = ForeignCurrencyAmount(
             amount=self.amount + amount.amount,
             currency=self.currency or amount.currency,
@@ -537,7 +542,11 @@ class CapitalGainsReport:
 
     def taxable_gain(self) -> Decimal:
         """Taxable gain with current allowance."""
-        assert self.capital_gain_allowance is not None
+        if self.capital_gain_allowance is None:
+            raise CalculationError(
+                f"Taxable gain cannot be calculated because the capital gains "
+                f"allowance for {self.tax_year}/{self.tax_year + 1} is unavailable"
+            )
         return max(Decimal(0), self.total_gain() - self.capital_gain_allowance)
 
     def total_eri_amount(self, *, is_interest: bool) -> Decimal:

--- a/cgt_calc/parsers/eri/importer/invesco.py
+++ b/cgt_calc/parsers/eri/importer/invesco.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, override
 import dateutil.parser as date_parser
 import pdfplumber
 
+from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import CurrencyCode, Isin
 from cgt_calc.util import round_decimal
 
@@ -64,14 +65,18 @@ class InvescoImporter(ERIImporter):
 
     @staticmethod
     def _extract_header(
-        page: pdfplumber.page.Page,
+        page: pdfplumber.page.Page, file: Path, page_num: int
     ) -> tuple[tuple[float, float, float, float], list[float], dict[int, int]]:
         # Useful for debugging:
         # page.to_image(resolution=100).debug_tablefinder().save(f"full_p{page_num}.png")
         header_table = page.find_table()
-        assert header_table
+        if header_table is None:
+            raise ParsingError(file, f"Could not find table headers on page {page_num}")
+        extracted_header = header_table.extract()
+        if not extracted_header or not extracted_header[0]:
+            raise ParsingError(file, f"Table header is empty on page {page_num}")
         cur_header = [
-            (col or "").replace("\n", " ").strip() for col in header_table.extract()[0]
+            (col or "").replace("\n", " ").strip() for col in extracted_header[0]
         ]
         LOGGER.debug("cur_header=%s", cur_header)
         colmap = {}
@@ -85,22 +90,35 @@ class InvescoImporter(ERIImporter):
         }
         for col, regex in colreg.items():
             match_idx = [i for i, h in enumerate(cur_header) if regex.match(h)]
-            assert len(match_idx) <= 1, (
-                f"Multiple columns matching for {regex}: {match_idx}"
-            )
-            assert match_idx, f"No column found for {regex}"
+            if len(match_idx) > 1:
+                raise ParsingError(
+                    file,
+                    f"Multiple columns match {regex.pattern!r} on page {page_num}: "
+                    f"{match_idx}",
+                )
+            if not match_idx:
+                raise ParsingError(
+                    file,
+                    f"No column matching {regex.pattern!r} on page {page_num}",
+                )
             colmap[col] = match_idx[0]
         min_column_count = 11
-        assert len(cur_header) >= min_column_count
+        if len(cur_header) < min_column_count:
+            raise ParsingError(
+                file,
+                f"Expected at least {min_column_count} columns on page {page_num}, "
+                f"found {len(cur_header)}",
+            )
         columns = [col.bbox[0] for col in header_table.columns]
         columns.append(header_table.rows[0].bbox[2])
         return header_table.rows[0].bbox, columns, colmap
 
     @staticmethod
     def _extract_data_rows(
-        page_num: int,  # noqa: ARG004  # kept for the debug line below
+        page_num: int,  # kept for the debug line below
         cropped: pdfplumber.page.CroppedPage,
         columns: list[float],
+        file: Path,
     ) -> list[list[str | None]]:
         table_settings = {
             "vertical_strategy": "explicit",
@@ -110,7 +128,8 @@ class InvescoImporter(ERIImporter):
         # Useful for debugging:
         # cropped.to_image(resolution=100).debug_tablefinder(table_settings).save(f"cropped_p{page_num}.png")
         data_table = cropped.extract_table(table_settings)
-        assert data_table
+        if data_table is None:
+            raise ParsingError(file, f"Could not extract data table on page {page_num}")
         return data_table
 
     @staticmethod
@@ -119,12 +138,20 @@ class InvescoImporter(ERIImporter):
         data_table: list[list[str | None]],
         reporting_period_end: datetime.date,
         colmap: dict[int, int],
+        file: Path,
     ) -> list[ERITransaction]:
         transactions = []
+        required_cells = max(colmap.values()) + 1
         for row_num, raw_row in enumerate(data_table, 1):
-            row = {}
-            for col, pos in colmap.items():
-                row[col] = (raw_row[pos] or "").strip()
+            # A short row cannot be told apart from a subrow by its empty ISIN
+            # cell, and skipping it would silently drop reportable income.
+            if len(raw_row) < required_cells:
+                raise ParsingError(
+                    file,
+                    f"Row {row_num} on page {page_num} has {len(raw_row)} cells, "
+                    f"expected at least {required_cells}",
+                )
+            row = {col: (raw_row[pos] or "").strip() for col, pos in colmap.items()}
             isin_raw = row[ISIN_COLUMN]
             if not isin_raw:
                 # probably a subrow
@@ -133,16 +160,24 @@ class InvescoImporter(ERIImporter):
                 # not part of the table
                 continue
             isin = Isin.parse(isin_raw)
-            assert isin is not None, (
-                f"Bad ISIN in page {page_num}, row {row_num}: {isin_raw}"
-            )
+            if isin is None:
+                raise ParsingError(
+                    file,
+                    f"Invalid ISIN on page {page_num}, row {row_num}: {isin_raw!r}",
+                )
             currency = CurrencyCode.parse(row[CURRENCY_COLUMN].replace("JPN", "JPY"))
-            assert currency is not None, (
-                f"Bad currency in page {page_num}, row {row_num}: {row[CURRENCY_COLUMN]}"
-            )
-            assert re.match(AMOUNT_REGEX, row[ERI_COLUMN]), (
-                f"Bad amount in page {page_num}, row {row_num}: {row[ERI_COLUMN]}"
-            )
+            if currency is None:
+                raise ParsingError(
+                    file,
+                    f"Invalid currency on page {page_num}, row {row_num}: "
+                    f"{row[CURRENCY_COLUMN]!r}",
+                )
+            if not re.match(AMOUNT_REGEX, row[ERI_COLUMN]):
+                raise ParsingError(
+                    file,
+                    f"Invalid amount on page {page_num}, row {row_num}: "
+                    f"{row[ERI_COLUMN]!r}",
+                )
             amount = round_decimal(Decimal(row[ERI_COLUMN]), 5)
             transactions.append(
                 ERITransaction(
@@ -157,7 +192,7 @@ class InvescoImporter(ERIImporter):
 
     @staticmethod
     # v1 has headers only on the first page
-    def _parse_v1(pdf: pdfplumber.pdf.PDF) -> list[ERITransaction] | None:
+    def _parse_v1(pdf: pdfplumber.pdf.PDF, file: Path) -> list[ERITransaction] | None:
         first_page = pdf.pages[0]
         prefix = "STATEMENT OF REPORTABLE INCOME FOR INVESCO MARKETS II PLC FOR THE PERIOD ENDED"
         if not first_page.search(prefix):
@@ -169,7 +204,9 @@ class InvescoImporter(ERIImporter):
         if reporting_period_end is None or reporting_period_end.year < MIN_VALID_YEAR:
             LOGGER.warning("First page has old or missing reporting date")
             return []
-        header_bbox, columns, colmap = InvescoImporter._extract_header(first_page)
+        header_bbox, columns, colmap = InvescoImporter._extract_header(
+            first_page, file, 1
+        )
         (h_left, _h_top, h_right, h_bottom) = header_bbox
         transactions = []
         for page_num, page in enumerate(pdf.pages, 1):
@@ -177,15 +214,17 @@ class InvescoImporter(ERIImporter):
                 cropped = page.crop((h_left, h_bottom, h_right, page.height))
             else:
                 cropped = page.crop((0, 0, page.width, page.height))
-            data_table = InvescoImporter._extract_data_rows(page_num, cropped, columns)
+            data_table = InvescoImporter._extract_data_rows(
+                page_num, cropped, columns, file
+            )
             transactions += InvescoImporter._process_data_table(
-                page_num, data_table, reporting_period_end, colmap
+                page_num, data_table, reporting_period_end, colmap, file
             )
         return transactions
 
     @staticmethod
     # v2 has headers on all pages, and the headers are slightly different
-    def _parse_v2(pdf: pdfplumber.pdf.PDF) -> list[ERITransaction] | None:
+    def _parse_v2(pdf: pdfplumber.pdf.PDF, file: Path) -> list[ERITransaction] | None:
         first_page = pdf.pages[0]
         if not first_page.search("Invesco Markets II plc"):
             return None
@@ -202,12 +241,16 @@ class InvescoImporter(ERIImporter):
             return []
         transactions = []
         for page_num, page in enumerate(pdf.pages, 1):
-            header_bbox, columns, colmap = InvescoImporter._extract_header(page)
+            header_bbox, columns, colmap = InvescoImporter._extract_header(
+                page, file, page_num
+            )
             (h_left, _h_top, h_right, h_bottom) = header_bbox
             cropped = page.crop((h_left, h_bottom, h_right, page.height))
-            data_table = InvescoImporter._extract_data_rows(page_num, cropped, columns)
+            data_table = InvescoImporter._extract_data_rows(
+                page_num, cropped, columns, file
+            )
             transactions += InvescoImporter._process_data_table(
-                page_num, data_table, reporting_period_end, colmap
+                page_num, data_table, reporting_period_end, colmap, file
             )
         return transactions
 
@@ -226,7 +269,7 @@ class InvescoImporter(ERIImporter):
                 return None
             parsers = [InvescoImporter._parse_v1, InvescoImporter._parse_v2]
             for parser in parsers:
-                parsed_data = parser(pdf)
+                parsed_data = parser(pdf, file)
                 if parsed_data is not None:
                     result.transactions = parsed_data
                     break

--- a/cgt_calc/parsers/eri/importer/xtrackers.py
+++ b/cgt_calc/parsers/eri/importer/xtrackers.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, override
 import dateutil.parser as date_parser
 import pdfplumber
 
+from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import CurrencyCode, Isin
 from cgt_calc.parsers.eri.model import ERITransaction
 from cgt_calc.util import round_decimal
@@ -71,7 +72,7 @@ class XtrackersImporter(ERIImporter):
                 XtrackersImporter._parse_investor_report_format,
             ]
             for parser in parsers:
-                parsed_data = parser(pdf)
+                parsed_data = parser(pdf, file)
                 if parsed_data is not None:
                     result.transactions = parsed_data
                     break
@@ -100,12 +101,16 @@ class XtrackersImporter(ERIImporter):
 
     @staticmethod
     def _extract_header(
-        page: pdfplumber.page.Page,
+        page: pdfplumber.page.Page, file: Path, page_num: int
     ) -> tuple[tuple[float, float, float, float], list[float], dict[int, int]]:
         header_table = page.find_table()
-        assert header_table, "Could not find table headers on the page"
+        if header_table is None:
+            raise ParsingError(file, f"Could not find table headers on page {page_num}")
+        extracted_header = header_table.extract()
+        if not extracted_header or not extracted_header[0]:
+            raise ParsingError(file, f"Table header is empty on page {page_num}")
         cur_header = [
-            (col or "").replace("\n", " ").strip() for col in header_table.extract()[0]
+            (col or "").replace("\n", " ").strip() for col in extracted_header[0]
         ]
         LOGGER.debug("cur_header=%s", cur_header)
         colmap = {}
@@ -122,10 +127,17 @@ class XtrackersImporter(ERIImporter):
         }
         for col, regex in colreg.items():
             match_idx = [i for i, h in enumerate(cur_header) if regex.match(h)]
-            assert len(match_idx) <= 1, (
-                f"Multiple columns matching for {regex}: {match_idx}"
-            )
-            assert match_idx, f"No column found for {regex}"
+            if len(match_idx) > 1:
+                raise ParsingError(
+                    file,
+                    f"Multiple columns match {regex.pattern!r} on page {page_num}: "
+                    f"{match_idx}",
+                )
+            if not match_idx:
+                raise ParsingError(
+                    file,
+                    f"No column matching {regex.pattern!r} on page {page_num}",
+                )
             colmap[col] = match_idx[0]
 
         columns = [col.bbox[0] for col in header_table.columns]
@@ -134,7 +146,10 @@ class XtrackersImporter(ERIImporter):
 
     @staticmethod
     def _extract_data_rows(
-        cropped: pdfplumber.page.CroppedPage, columns: list[float]
+        cropped: pdfplumber.page.CroppedPage,
+        columns: list[float],
+        file: Path,
+        page_num: int,
     ) -> list[list[str | None]]:
         table_settings = {
             "vertical_strategy": "explicit",
@@ -142,7 +157,8 @@ class XtrackersImporter(ERIImporter):
             "horizontal_strategy": "text",
         }
         data_table = cropped.extract_table(table_settings)
-        assert data_table
+        if data_table is None:
+            raise ParsingError(file, f"Could not extract data table on page {page_num}")
         return data_table
 
     @staticmethod
@@ -151,6 +167,7 @@ class XtrackersImporter(ERIImporter):
         data_table: list[list[str | None]],
         reporting_period_end: datetime.date,
         colmap: dict[int, int],
+        file: Path,
     ) -> list[ERITransaction]:
         transactions = []
         for row_num, raw_row in enumerate(data_table, 1):
@@ -162,17 +179,24 @@ class XtrackersImporter(ERIImporter):
 
             isin_raw = row[ISIN_COLUMN]
             isin = Isin.parse(isin_raw)
-            assert isin is not None, (
-                f"Bad ISIN in page {page_num}, row {row_num}: {isin_raw!r}"
-            )
+            if isin is None:
+                raise ParsingError(
+                    file,
+                    f"Invalid ISIN on page {page_num}, row {row_num}: {isin_raw!r}",
+                )
             currency = CurrencyCode.parse(row[CURRENCY_COLUMN].replace("JPN", "JPY"))
-            assert currency is not None, (
-                f"Bad currency in page {page_num}, row {row_num}: "
-                f"{row[CURRENCY_COLUMN]!r}"
-            )
-            assert re.match(AMOUNT_REGEX, row[ERI_COLUMN]), (
-                f"Bad amount in page {page_num}, row {row_num}: {row[ERI_COLUMN]!r}"
-            )
+            if currency is None:
+                raise ParsingError(
+                    file,
+                    f"Invalid currency on page {page_num}, row {row_num}: "
+                    f"{row[CURRENCY_COLUMN]!r}",
+                )
+            if not re.match(AMOUNT_REGEX, row[ERI_COLUMN]):
+                raise ParsingError(
+                    file,
+                    f"Invalid amount on page {page_num}, row {row_num}: "
+                    f"{row[ERI_COLUMN]!r}",
+                )
             amount = round_decimal(Decimal(row[ERI_COLUMN]), 5)
 
             transactions.append(
@@ -188,21 +212,29 @@ class XtrackersImporter(ERIImporter):
 
     @staticmethod
     def _parse_pages(
-        pdf: pdfplumber.pdf.PDF, reporting_period_end: datetime.date
+        pdf: pdfplumber.pdf.PDF,
+        reporting_period_end: datetime.date,
+        file: Path,
     ) -> list[ERITransaction]:
         transactions = []
         for page_num, page in enumerate(pdf.pages, 1):
-            header_bbox, columns, colmap = XtrackersImporter._extract_header(page)
+            header_bbox, columns, colmap = XtrackersImporter._extract_header(
+                page, file, page_num
+            )
             (h_left, _h_top, h_right, h_bottom) = header_bbox
             cropped = page.crop((h_left, h_bottom, h_right, page.height))
-            data_table = XtrackersImporter._extract_data_rows(cropped, columns)
+            data_table = XtrackersImporter._extract_data_rows(
+                cropped, columns, file, page_num
+            )
             transactions += XtrackersImporter._process_data_table(
-                page_num, data_table, reporting_period_end, colmap
+                page_num, data_table, reporting_period_end, colmap, file
             )
         return transactions
 
     @staticmethod
-    def _parse_summary_format(pdf: pdfplumber.pdf.PDF) -> list[ERITransaction] | None:
+    def _parse_summary_format(
+        pdf: pdfplumber.pdf.PDF, file: Path
+    ) -> list[ERITransaction] | None:
         """Parse the summary format used by the main Xtrackers umbrella."""
         first_page = pdf.pages[0]
         prefix = "Period ended"
@@ -216,11 +248,11 @@ class XtrackersImporter(ERIImporter):
         if reporting_period_end is None or reporting_period_end.year < MIN_VALID_YEAR:
             return []
 
-        return XtrackersImporter._parse_pages(pdf, reporting_period_end)
+        return XtrackersImporter._parse_pages(pdf, reporting_period_end, file)
 
     @staticmethod
     def _parse_investor_report_format(
-        pdf: pdfplumber.pdf.PDF,
+        pdf: pdfplumber.pdf.PDF, file: Path
     ) -> list[ERITransaction] | None:
         """Parse the investor report format used by Xtrackers II and (IE) Plc."""
         first_page = pdf.pages[0]
@@ -236,4 +268,4 @@ class XtrackersImporter(ERIImporter):
         if reporting_period_end is None or reporting_period_end.year < MIN_VALID_YEAR:
             return []
 
-        return XtrackersImporter._parse_pages(pdf, reporting_period_end)
+        return XtrackersImporter._parse_pages(pdf, reporting_period_end, file)

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -330,6 +330,9 @@ def _combine_cash_merger_pair(
         or not adjustment_quantity.is_finite()
         or adjustment_quantity >= 0
         or cash_merger_adj.amount is not None
+        or cash_merger_adj.price is not None
+        or not cash_merger.fees.is_finite()
+        or not cash_merger_adj.fees.is_finite()
     ):
         raise ParsingError(
             transactions_file,
@@ -387,6 +390,8 @@ def _combine_full_redemption_pair(
         or redemption_quantity >= 0
         or full_redemption.price is not None
         or full_redemption.amount is not None
+        or not full_redemption_adj.fees.is_finite()
+        or not full_redemption.fees.is_finite()
     ):
         raise ParsingError(
             transactions_file,

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -322,17 +322,21 @@ def _combine_cash_merger_pair(
     adjustment_quantity = cash_merger_adj.quantity
     if (
         amount is None
+        or not amount.is_finite()
+        or amount < 0
         or cash_merger.quantity is not None
         or cash_merger.price is not None
         or adjustment_quantity is None
-        or adjustment_quantity == 0
+        or not adjustment_quantity.is_finite()
+        or adjustment_quantity >= 0
         or cash_merger_adj.amount is not None
     ):
         raise ParsingError(
             transactions_file,
             f"Invalid Cash Merger format for {cash_merger.symbol} on "
-            f"{cash_merger.date}: expected proceeds only on the Cash Merger "
-            "row and a non-zero quantity only on the adjustment row",
+            f"{cash_merger.date}: expected non-negative proceeds only on the "
+            "Cash Merger row and a negative share quantity only on the "
+            "adjustment row",
         )
 
     # Create unified transaction
@@ -374,18 +378,22 @@ def _combine_full_redemption_pair(
     redemption_quantity = full_redemption.quantity
     if (
         amount is None
+        or not amount.is_finite()
+        or amount < 0
         or full_redemption_adj.quantity is not None
         or full_redemption_adj.price is not None
         or redemption_quantity is None
-        or redemption_quantity == 0
+        or not redemption_quantity.is_finite()
+        or redemption_quantity >= 0
         or full_redemption.price is not None
         or full_redemption.amount is not None
     ):
         raise ParsingError(
             transactions_file,
             f"Invalid Full Redemption format for {full_redemption.symbol} on "
-            f"{full_redemption.date}: expected proceeds only on the adjustment "
-            "row and a non-zero quantity only on the redemption row",
+            f"{full_redemption.date}: expected non-negative proceeds only on "
+            "the adjustment row and a negative share quantity only on the "
+            "redemption row",
         )
 
     # Create unified transaction (use Full Redemption as base for action type)

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -306,37 +306,40 @@ def _combine_cash_merger_pair(
 
     Returns: Unified transaction with calculated price
     """
-    try:
-        # Validate matching fields
-        assert cash_merger.description == cash_merger_adj.description
-        assert cash_merger.symbol == cash_merger_adj.symbol
-        assert cash_merger.date == cash_merger_adj.date
-
-        # Validate data pattern: Cash Merger has amount, Adj has quantity
-        assert cash_merger.amount is not None, "Cash Merger must have Amount"
-        assert cash_merger.quantity is None, "Cash Merger should not have Quantity"
-        assert cash_merger.price is None, "Cash Merger should not have Price"
-
-        assert cash_merger_adj.quantity is not None, (
-            "Cash Merger Adj must have Quantity"
-        )
-        assert cash_merger_adj.amount is None, "Cash Merger Adj should not have Amount"
-
-    except AssertionError as err:
+    if (
+        cash_merger.description != cash_merger_adj.description
+        or cash_merger.symbol != cash_merger_adj.symbol
+        or cash_merger.date != cash_merger_adj.date
+    ):
         raise ParsingError(
             transactions_file,
-            f"Invalid Cash Merger format: {cash_merger.raw_action}, "
-            "run with --verbose for more details",
-        ) from err
+            f"Invalid Cash Merger format for {cash_merger.symbol} on "
+            f"{cash_merger.date}: the Cash Merger and adjustment rows must "
+            "have the same date, symbol and description",
+        )
+
+    amount = cash_merger.amount
+    adjustment_quantity = cash_merger_adj.quantity
+    if (
+        amount is None
+        or cash_merger.quantity is not None
+        or cash_merger.price is not None
+        or adjustment_quantity is None
+        or adjustment_quantity == 0
+        or cash_merger_adj.amount is not None
+    ):
+        raise ParsingError(
+            transactions_file,
+            f"Invalid Cash Merger format for {cash_merger.symbol} on "
+            f"{cash_merger.date}: expected proceeds only on the Cash Merger "
+            "row and a non-zero quantity only on the adjustment row",
+        )
 
     # Create unified transaction
     unified = cash_merger
     # Quantity is negative (shares leaving), convert to positive for SELL
-    unified.quantity = -1 * cash_merger_adj.quantity
-    # Mypy: at this point unified.amount and unified.quantity are guaranteed non-None
-    assert unified.amount is not None
-    assert unified.quantity is not None
-    unified.price = unified.amount / unified.quantity
+    unified.quantity = -adjustment_quantity
+    unified.price = amount / unified.quantity
     unified.fees += cash_merger_adj.fees
 
     return unified
@@ -355,45 +358,42 @@ def _combine_full_redemption_pair(
 
     Returns: Unified transaction with calculated price
     """
-    try:
-        # Validate matching fields
-        assert full_redemption_adj.description == full_redemption.description
-        assert full_redemption_adj.symbol == full_redemption.symbol
-        assert full_redemption_adj.date == full_redemption.date
-
-        # Validate data pattern: Adj has amount, Full Redemption has quantity
-        assert full_redemption_adj.amount is not None, (
-            "Full Redemption Adj must have Amount"
-        )
-        assert full_redemption_adj.quantity is None, (
-            "Full Redemption Adj should not have Quantity"
-        )
-        assert full_redemption_adj.price is None, (
-            "Full Redemption Adj should not have Price"
-        )
-
-        assert full_redemption.quantity is not None, (
-            "Full Redemption must have Quantity"
-        )
-        assert full_redemption.price is None, "Full Redemption should not have Price"
-        assert full_redemption.amount is None, "Full Redemption should not have Amount"
-
-    except AssertionError as err:
+    if (
+        full_redemption_adj.description != full_redemption.description
+        or full_redemption_adj.symbol != full_redemption.symbol
+        or full_redemption_adj.date != full_redemption.date
+    ):
         raise ParsingError(
             transactions_file,
-            f"Invalid Full Redemption format: {full_redemption.raw_action}, "
-            "run with --verbose for more details",
-        ) from err
+            f"Invalid Full Redemption format for {full_redemption.symbol} on "
+            f"{full_redemption.date}: the adjustment and redemption rows must "
+            "have the same date, symbol and description",
+        )
+
+    amount = full_redemption_adj.amount
+    redemption_quantity = full_redemption.quantity
+    if (
+        amount is None
+        or full_redemption_adj.quantity is not None
+        or full_redemption_adj.price is not None
+        or redemption_quantity is None
+        or redemption_quantity == 0
+        or full_redemption.price is not None
+        or full_redemption.amount is not None
+    ):
+        raise ParsingError(
+            transactions_file,
+            f"Invalid Full Redemption format for {full_redemption.symbol} on "
+            f"{full_redemption.date}: expected proceeds only on the adjustment "
+            "row and a non-zero quantity only on the redemption row",
+        )
 
     # Create unified transaction (use Full Redemption as base for action type)
     unified = full_redemption
     # Quantity is negative (shares leaving), convert to positive
-    unified.quantity = -1 * full_redemption.quantity
-    unified.amount = full_redemption_adj.amount
-    # Mypy: at this point unified.amount and unified.quantity are guaranteed non-None
-    assert unified.amount is not None
-    assert unified.quantity is not None
-    unified.price = unified.amount / unified.quantity
+    unified.quantity = -redemption_quantity
+    unified.amount = amount
+    unified.price = amount / unified.quantity
     unified.fees += full_redemption_adj.fees
 
     return unified
@@ -435,10 +435,11 @@ def _unify_schwab_paired_transactions(
             main_transaction = filtered[-1]
             adj_transaction = transaction
 
-            # Validate it's a Cash Merger pair
-            assert main_transaction.raw_action == "Cash Merger", (
-                "Cash Merger Adj must follow Cash Merger"
-            )
+            if main_transaction.raw_action != "Cash Merger":
+                raise ParsingError(
+                    transactions_file,
+                    "Cash Merger Adj must immediately follow a Cash Merger transaction",
+                )
 
             unified = _combine_cash_merger_pair(
                 main_transaction, adj_transaction, transactions_file
@@ -470,10 +471,12 @@ def _unify_schwab_paired_transactions(
             adj_transaction = transaction
             main_transaction = transactions[i + 1]
 
-            # Validate it's a Full Redemption pair
-            assert main_transaction.raw_action == "Full Redemption", (
-                "Full Redemption Adj must be followed by Full Redemption"
-            )
+            if main_transaction.raw_action != "Full Redemption":
+                raise ParsingError(
+                    transactions_file,
+                    "Full Redemption Adj must be followed by a Full Redemption "
+                    "transaction",
+                )
 
             unified = _combine_full_redemption_pair(
                 adj_transaction, main_transaction, transactions_file
@@ -643,8 +646,16 @@ def _read_schwab_awards(
         # in this format each logical row is split into two rows,
         # so we combine them safely below
         row = []
-        for upper_col, lower_col in zip(upper_row, lower_row, strict=True):
-            assert upper_col == "" or lower_col == ""
+        for column_index, (upper_col, lower_col) in enumerate(
+            zip(upper_row, lower_row, strict=True), start=1
+        ):
+            if upper_col and lower_col:
+                raise ParsingError(
+                    schwab_award_transactions_file,
+                    f"Both halves of the split award row (rows {row_index} and "
+                    f"{row_index + 1}) contain data in column {column_index}",
+                    row_index=row_index,
+                )
             row.append(upper_col + lower_col)
 
         row_dict = OrderedDict(zip(header, row, strict=True))

--- a/cgt_calc/parsers/schwab_cusip_bonds.py
+++ b/cgt_calc/parsers/schwab_cusip_bonds.py
@@ -163,8 +163,6 @@ def adjust_cusip_bond_price(
     if not _is_cusip_symbol(symbol) or price is None:
         return (price, fees)
 
-    # Mypy: at this point price is guaranteed to be non-None due to check above
-    assert price is not None
     adjusted_price = price / BOND_PRICE_DIVISOR
 
     # If we can't validate, apply adjustment anyway (trusted data)

--- a/scripts/import_eri_reports.py
+++ b/scripts/import_eri_reports.py
@@ -7,11 +7,16 @@ import csv
 from decimal import Decimal
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from cgt_calc import resources
 from cgt_calc.const import DEFAULT_ISIN_TRANSLATION_FILE
-from cgt_calc.exceptions import InvalidTransactionError
+from cgt_calc.exceptions import (
+    CgtError,
+    InvalidTransactionError,
+    IsinMissingError,
+    PriceMissingError,
+)
 from cgt_calc.parsers.eri.importer.blackrock import BlackrockImporter
 from cgt_calc.parsers.eri.importer.invesco import InvescoImporter
 from cgt_calc.parsers.eri.importer.vanguard import VanguardImporter
@@ -22,7 +27,8 @@ from cgt_calc.util import approx_equal
 if TYPE_CHECKING:
     import datetime
 
-    from cgt_calc.parsers.eri.model import ERIImporter, ERITransaction
+    from cgt_calc.parsers.eri.importer.model import ERIImporter
+    from cgt_calc.parsers.eri.model import ERITransaction
 
 ERI_IMPORTERS: list[ERIImporter] = [
     BlackrockImporter(),
@@ -41,20 +47,21 @@ def validate_and_remove_duplicates(
 
     Sort the final output by date for writing
     """
-    transaction_index: dict[tuple[str, datetime.date], ERITransaction] = {}
+    transaction_index: dict[
+        tuple[str, datetime.date], tuple[ERITransaction, Decimal]
+    ] = {}
     result = []
     for transaction in transactions:
-        assert transaction.price is not None, (
-            f"Transaction price not set for {transaction}"
-        )
-        assert transaction.isin, f"Transaction ISIN not set for {transaction}"
-        key = (transaction.isin, transaction.date)
+        price = transaction.price
+        if price is None:
+            raise PriceMissingError(transaction)
+        isin = transaction.isin
+        if isin is None:
+            raise IsinMissingError(transaction)
+        key = (isin, transaction.date)
         if key in transaction_index:
-            current_transaction = transaction_index[key]
-            assert current_transaction.price is not None, str(current_transaction)
-            if approx_equal(
-                current_transaction.price, transaction.price, Decimal("0.0001")
-            ):
+            current_transaction, current_price = transaction_index[key]
+            if approx_equal(current_price, price, Decimal("0.0001")):
                 continue
             raise InvalidTransactionError(
                 transaction,
@@ -62,7 +69,7 @@ def validate_and_remove_duplicates(
                 f"{current_transaction}",
             )
         result.append(transaction)
-        transaction_index[key] = transaction
+        transaction_index[key] = (transaction, price)
 
     result.sort(key=lambda t: t.date)
     return result
@@ -71,7 +78,8 @@ def validate_and_remove_duplicates(
 def eri_import_from_file(path: Path) -> None:
     """Import the specified path into the tool resources."""
 
-    assert path.is_file(), f"Specified path {path} not a file!"
+    if not path.is_file():
+        raise CgtError(f"Specified path is not a file: {path}")
 
     print(f"Processing ERI file: {path}")
     for importer in ERI_IMPORTERS:
@@ -79,15 +87,21 @@ def eri_import_from_file(path: Path) -> None:
         if data is None:
             continue
 
-        assert data, f"ERI Importer {importer.name} emitted no transactions for {path}"
+        if not data.transactions:
+            print(
+                f"WARNING: ERI importer {importer.name} found no transactions in {path}"
+            )
+            return
         print(
             f"ERI file {path} successfully parsed with {importer.name}, "
             f"transactions found: {len(data.transactions)}"
         )
         output_path = Path(resources.__file__).parent / "eri" / data.output_file_name
-        transactions = []
+        transactions: list[ERITransaction] = []
         if output_path.exists():
-            transactions += ERIRawParser.load_from_file(output_path)
+            transactions += cast(
+                "list[ERITransaction]", ERIRawParser.load_from_file(output_path)
+            )
         transactions += data.transactions
         transactions = validate_and_remove_duplicates(transactions)
 
@@ -126,7 +140,7 @@ def eri_import_from_path(path_str: str) -> str:
     )
 
 
-def main():
+def main() -> None:
     """Entry point."""
     parser = argparse.ArgumentParser(description="Import ERI Reports in CGT tool")
     parser.add_argument(
@@ -139,7 +153,10 @@ def main():
     )
 
     args = parser.parse_args()
-    eri_import_from_path(args.eri_reports)
+    try:
+        eri_import_from_path(args.eri_reports)
+    except CgtError as err:
+        parser.error(str(err))
     print("Import complete! Run cgt_calc to use the imported data in your reports!")
 
 

--- a/scripts/import_eri_reports.py
+++ b/scripts/import_eri_reports.py
@@ -55,6 +55,10 @@ def validate_and_remove_duplicates(
         price = transaction.price
         if price is None:
             raise PriceMissingError(transaction)
+        if not price.is_finite() or price < 0:
+            raise InvalidTransactionError(
+                transaction, "ERI price must be finite and non-negative"
+            )
         isin = transaction.isin
         if isin is None:
             raise IsinMissingError(transaction)

--- a/tests/eri_importers/test_import_eri_reports.py
+++ b/tests/eri_importers/test_import_eri_reports.py
@@ -1,0 +1,46 @@
+"""Tests for the ERI resource import script."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, override
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+from cgt_calc.parsers.eri.importer.model import ERIImporter, ERIImporterOutput
+from scripts import import_eri_reports
+
+
+class EmptyImporter(ERIImporter):
+    """Importer stub that recognises reports but finds no current transactions."""
+
+    def __init__(self, seen: list[Path]) -> None:
+        """Store parsed paths for assertions."""
+        super().__init__(name="Empty")
+        self.seen = seen
+
+    @override
+    def parse(self, file: Path) -> ERIImporterOutput | None:
+        """Recognise the file and return an intentionally empty result."""
+        self.seen.append(file)
+        return ERIImporterOutput([], "unused.csv")
+
+
+def test_directory_import_continues_after_empty_importer_results(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An old report does not prevent later files in the directory being visited."""
+    reports = [tmp_path / "old.pdf", tmp_path / "next.pdf"]
+    for report in reports:
+        report.touch()
+    seen: list[Path] = []
+    monkeypatch.setattr(import_eri_reports, "ERI_IMPORTERS", [EmptyImporter(seen)])
+
+    import_eri_reports.eri_import_from_path(str(tmp_path))
+
+    assert set(seen) == set(reports)
+    assert capsys.readouterr().out.count("WARNING: ERI importer Empty") == 2

--- a/tests/eri_importers/test_import_eri_reports.py
+++ b/tests/eri_importers/test_import_eri_reports.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import datetime
+from decimal import Decimal
 from typing import TYPE_CHECKING, override
+
+import pytest
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
-
+from cgt_calc.exceptions import InvalidTransactionError
+from cgt_calc.model import CurrencyCode, Isin
 from cgt_calc.parsers.eri.importer.model import ERIImporter, ERIImporterOutput
+from cgt_calc.parsers.eri.model import ERITransaction
 from scripts import import_eri_reports
 
 
@@ -44,3 +49,17 @@ def test_directory_import_continues_after_empty_importer_results(
 
     assert set(seen) == set(reports)
     assert capsys.readouterr().out.count("WARNING: ERI importer Empty") == 2
+
+
+@pytest.mark.parametrize("price", [Decimal(-1), Decimal("NaN"), Decimal("Infinity")])
+def test_unusable_eri_price_is_rejected_before_it_is_written(price: Decimal) -> None:
+    """A price the calculator would refuse must not reach the resource files."""
+    transaction = ERITransaction(
+        date=datetime.date(2024, 6, 30),
+        isin=Isin("IE00B3RBWM25"),
+        price=price,
+        currency=CurrencyCode("USD"),
+    )
+
+    with pytest.raises(InvalidTransactionError, match="finite and non-negative"):
+        import_eri_reports.validate_and_remove_duplicates([transaction])

--- a/tests/eri_importers/test_invesco.py
+++ b/tests/eri_importers/test_invesco.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from reportlab.lib import colors
@@ -30,6 +30,8 @@ from tests.eri_importers.helpers import check_transaction
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import pdfplumber
 
     from cgt_calc.parsers.eri.model import ERITransaction
 
@@ -86,18 +88,26 @@ DATA_ROWS: list[list[str]] = [
 ]
 
 
-def _build_pdf(path: Path, preamble: list[str], with_table: bool = True) -> Path:
+def _build_pdf(
+    path: Path,
+    preamble: list[str],
+    with_table: bool = True,
+    data_rows: list[list[str]] | None = None,
+    header: list[str] | None = None,
+) -> Path:
     """Build a PDF with preamble text lines and optionally a data table."""
     styles = getSampleStyleSheet()
     doc = SimpleDocTemplate(str(path), pagesize=PAGESIZE)
     story: list[Flowable] = [Paragraph(line, styles["Normal"]) for line in preamble]
     if with_table:
+        header = header if header is not None else HEADER
+        data_rows = data_rows if data_rows is not None else DATA_ROWS
         story.append(Spacer(1, 20))
         # The third column is wide enough for its long header to stay
         # within the cell boundaries.
-        col_widths = [180.0] * len(HEADER)
+        col_widths = [180.0] * len(header)
         col_widths[2] = 340.0
-        table = Table([HEADER, *DATA_ROWS], colWidths=col_widths)
+        table = Table([header, *data_rows], colWidths=col_widths)
         table.setStyle(
             TableStyle(
                 [
@@ -236,6 +246,132 @@ def test_v2_unparseable_reporting_date(tmp_path: Path) -> None:
 
     assert result is not None
     assert result.transactions == []
+
+
+V1_PREAMBLE = [
+    (
+        "STATEMENT OF REPORTABLE INCOME FOR INVESCO MARKETS II PLC "
+        "FOR THE PERIOD ENDED 30 June 2022"
+    ),
+]
+
+_ROW_TAIL = ["Fund A", "Acc", "B3RBWM2", "0.1", "a", "b", "0.2", "n1"]
+
+
+@pytest.mark.parametrize(
+    ("row_head", "error_match"),
+    [
+        (["not-an-isin", "USD", "1.23456"], "Invalid ISIN"),
+        (["IE00B3RBWM25", "not-a-currency", "1.23456"], "Invalid currency"),
+        (["IE00B3RBWM25", "USD", "not-a-number"], "Invalid amount"),
+    ],
+)
+def test_bad_data_row_fails_loudly(
+    tmp_path: Path, row_head: list[str], error_match: str
+) -> None:
+    """Raise on rows with unparsable content instead of skipping them."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2022.pdf",
+        V1_PREAMBLE,
+        data_rows=[row_head + _ROW_TAIL],
+    )
+
+    with pytest.raises(ParsingError, match=error_match) as exc_info:
+        InvescoImporter().parse(file)
+
+    assert str(file) in str(exc_info.value)
+    assert "page 1" in str(exc_info.value)
+
+
+def test_report_without_a_table_fails_loudly(tmp_path: Path) -> None:
+    """A recognised report page with no table at all is invalid input."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2022.pdf",
+        V1_PREAMBLE,
+        with_table=False,
+    )
+
+    with pytest.raises(ParsingError, match="Could not find table headers on page 1"):
+        InvescoImporter().parse(file)
+
+
+def test_header_only_table_fails_loudly(tmp_path: Path) -> None:
+    """A table with headers but no data rows is invalid input."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2022.pdf",
+        V1_PREAMBLE,
+        data_rows=[],
+    )
+
+    with pytest.raises(ParsingError, match="Could not extract data table on page 1"):
+        InvescoImporter().parse(file)
+
+
+def test_duplicate_header_columns_fail_loudly(tmp_path: Path) -> None:
+    """Two columns claiming the same field make the table ambiguous."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2022.pdf",
+        V1_PREAMBLE,
+        header=[*HEADER[:-1], "ISIN again"],
+        data_rows=[],
+    )
+
+    with pytest.raises(ParsingError, match=r"Multiple columns match .* on page 1"):
+        InvescoImporter().parse(file)
+
+
+def test_missing_header_column_fails_loudly(tmp_path: Path) -> None:
+    """A table without one of the required columns is invalid input."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2022.pdf",
+        V1_PREAMBLE,
+        header=["Currency" if h == "CURRENCY OF SHARE CLASS" else h for h in HEADER],
+        data_rows=[],
+    )
+
+    with pytest.raises(ParsingError, match=r"No column matching .* on page 1"):
+        InvescoImporter().parse(file)
+
+
+def test_too_few_header_columns_fail_loudly(tmp_path: Path) -> None:
+    """A table narrower than the known report layout is invalid input."""
+    file = _build_pdf(
+        tmp_path / "invesco-excess-reportable-income-2022.pdf",
+        V1_PREAMBLE,
+        header=HEADER[:3],
+        data_rows=[],
+    )
+
+    with pytest.raises(
+        ParsingError, match="Expected at least 11 columns on page 1, found 3"
+    ):
+        InvescoImporter().parse(file)
+
+
+class _HeaderlessTable:
+    """Table stub whose extraction yields no rows."""
+
+    @staticmethod
+    def extract() -> list[list[str]]:
+        return []
+
+
+class _HeaderlessPage:
+    """Page stub with a detectable but empty table."""
+
+    @staticmethod
+    def find_table() -> _HeaderlessTable:
+        return _HeaderlessTable()
+
+
+def test_empty_extracted_header_fails_loudly(tmp_path: Path) -> None:
+    """A detected table that extracts to nothing is reported, not indexed."""
+    page = cast("pdfplumber.page.Page", _HeaderlessPage())
+
+    with pytest.raises(ParsingError, match="Table header is empty on page 1"):
+        InvescoImporter._extract_header(  # noqa: SLF001
+            page, tmp_path / "report.pdf", 1
+        )
 
 
 def test_short_data_row_fails_loudly(tmp_path: Path) -> None:

--- a/tests/eri_importers/test_invesco.py
+++ b/tests/eri_importers/test_invesco.py
@@ -18,7 +18,13 @@ from reportlab.platypus import (
     TableStyle,
 )
 
-from cgt_calc.parsers.eri.importer.invesco import InvescoImporter
+from cgt_calc.exceptions import ParsingError
+from cgt_calc.parsers.eri.importer.invesco import (
+    CURRENCY_COLUMN,
+    ERI_COLUMN,
+    ISIN_COLUMN,
+    InvescoImporter,
+)
 from cgt_calc.parsers.eri.importer.model import ERIImporter
 from tests.eri_importers.helpers import check_transaction
 
@@ -230,6 +236,17 @@ def test_v2_unparseable_reporting_date(tmp_path: Path) -> None:
 
     assert result is not None
     assert result.transactions == []
+
+
+def test_short_data_row_fails_loudly(tmp_path: Path) -> None:
+    """A row with too few cells is an error, not a silently skipped subrow."""
+    colmap = {ISIN_COLUMN: 0, CURRENCY_COLUMN: 1, ERI_COLUMN: 2}
+    data_table: list[list[str | None]] = [["IE00B3RBWM25", "USD"]]
+
+    with pytest.raises(ParsingError, match="has 2 cells, expected at least 3"):
+        InvescoImporter._process_data_table(  # noqa: SLF001
+            1, data_table, datetime.date(2024, 12, 31), colmap, tmp_path / "x.pdf"
+        )
 
 
 def test_unknown_content_is_not_accepted(tmp_path: Path) -> None:

--- a/tests/eri_importers/test_xtrackers.py
+++ b/tests/eri_importers/test_xtrackers.py
@@ -18,6 +18,7 @@ from reportlab.platypus import (
     TableStyle,
 )
 
+from cgt_calc.exceptions import ParsingError
 from cgt_calc.parsers.eri.importer.xtrackers import XtrackersImporter
 from tests.eri_importers.helpers import check_transaction
 
@@ -176,8 +177,11 @@ def test_bad_data_row_fails_loudly(tmp_path: Path) -> None:
         data_rows=[["LU0000000009", "not-a-currency", "1.23456", "Fund A", "Acc"]],
     )
 
-    with pytest.raises(AssertionError, match="Bad currency"):
+    with pytest.raises(ParsingError, match="Invalid currency") as exc_info:
         XtrackersImporter().parse(file)
+
+    assert str(file) in str(exc_info.value)
+    assert "page 1" in str(exc_info.value)
 
 
 def test_unknown_content_is_not_accepted(tmp_path: Path) -> None:

--- a/tests/eri_importers/test_xtrackers.py
+++ b/tests/eri_importers/test_xtrackers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from reportlab.lib import colors
@@ -24,6 +24,8 @@ from tests.eri_importers.helpers import check_transaction
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import pdfplumber
 
     from cgt_calc.parsers.eri.model import ERITransaction
 
@@ -53,18 +55,21 @@ def _build_pdf(
     preamble: list[str],
     with_table: bool = True,
     data_rows: list[list[str]] | None = None,
+    header: list[str] | None = None,
 ) -> Path:
     """Build a PDF with preamble text lines and optionally a data table."""
     styles = getSampleStyleSheet()
     doc = SimpleDocTemplate(str(path), pagesize=PAGESIZE)
     story: list[Flowable] = [Paragraph(line, styles["Normal"]) for line in preamble]
     if with_table:
+        header = header if header is not None else HEADER
+        data_rows = data_rows if data_rows is not None else DATA_ROWS
         story.append(Spacer(1, 20))
         # The third column is wide enough for its long header to stay
         # within the cell boundaries.
-        col_widths = [180.0] * len(HEADER)
+        col_widths = [180.0] * len(header)
         col_widths[2] = 340.0
-        table = Table([HEADER, *(data_rows or DATA_ROWS)], colWidths=col_widths)
+        table = Table([header, *data_rows], colWidths=col_widths)
         table.setStyle(
             TableStyle(
                 [
@@ -166,22 +171,126 @@ def test_missing_reporting_date(tmp_path: Path) -> None:
     assert result.transactions == []
 
 
-def test_bad_data_row_fails_loudly(tmp_path: Path) -> None:
+SUMMARY_PREAMBLE = [
+    "Summary of reportable income calculations",
+    "Period ended 31 December 2024",
+]
+
+
+@pytest.mark.parametrize(
+    ("row", "error_match"),
+    [
+        (["not-an-isin", "USD", "1.23456", "Fund A", "Acc"], "Invalid ISIN"),
+        (
+            ["LU0000000009", "not-a-currency", "1.23456", "Fund A", "Acc"],
+            "Invalid currency",
+        ),
+        (["LU0000000009", "USD", "not-a-number", "Fund A", "Acc"], "Invalid amount"),
+    ],
+)
+def test_bad_data_row_fails_loudly(
+    tmp_path: Path, row: list[str], error_match: str
+) -> None:
     """Raise on rows with unparsable content instead of skipping them."""
     file = _build_pdf(
         tmp_path / "Xtrackers-Report-2024.pdf",
-        [
-            "Summary of reportable income calculations",
-            "Period ended 31 December 2024",
-        ],
-        data_rows=[["LU0000000009", "not-a-currency", "1.23456", "Fund A", "Acc"]],
+        SUMMARY_PREAMBLE,
+        data_rows=[row],
     )
 
-    with pytest.raises(ParsingError, match="Invalid currency") as exc_info:
+    with pytest.raises(ParsingError, match=error_match) as exc_info:
         XtrackersImporter().parse(file)
 
     assert str(file) in str(exc_info.value)
     assert "page 1" in str(exc_info.value)
+
+
+def test_report_without_a_table_fails_loudly(tmp_path: Path) -> None:
+    """A recognised report page with no table at all is invalid input."""
+    file = _build_pdf(
+        tmp_path / "Xtrackers-Report-2024.pdf",
+        SUMMARY_PREAMBLE,
+        with_table=False,
+    )
+
+    with pytest.raises(ParsingError, match="Could not find table headers on page 1"):
+        XtrackersImporter().parse(file)
+
+
+def test_header_only_table_fails_loudly(tmp_path: Path) -> None:
+    """A table with headers but no data rows is invalid input."""
+    file = _build_pdf(
+        tmp_path / "Xtrackers-Report-2024.pdf",
+        SUMMARY_PREAMBLE,
+        data_rows=[],
+    )
+
+    with pytest.raises(ParsingError, match="Could not extract data table on page 1"):
+        XtrackersImporter().parse(file)
+
+
+def test_duplicate_header_columns_fail_loudly(tmp_path: Path) -> None:
+    """Two columns claiming the same field make the table ambiguous."""
+    file = _build_pdf(
+        tmp_path / "Xtrackers-Report-2024.pdf",
+        SUMMARY_PREAMBLE,
+        header=[
+            "ISIN",
+            "Share class currency",
+            "Excess reported income per share",
+            "ISIN again",
+            "Sub fund",
+        ],
+        data_rows=[],
+    )
+
+    with pytest.raises(ParsingError, match=r"Multiple columns match .* on page 1"):
+        XtrackersImporter().parse(file)
+
+
+def test_missing_header_column_fails_loudly(tmp_path: Path) -> None:
+    """A table without one of the required columns is invalid input."""
+    file = _build_pdf(
+        tmp_path / "Xtrackers-Report-2024.pdf",
+        SUMMARY_PREAMBLE,
+        header=[
+            "ISIN",
+            "Currency",
+            "Excess reported income per share",
+            "Fund name",
+            "Sub fund",
+        ],
+        data_rows=[],
+    )
+
+    with pytest.raises(ParsingError, match=r"No column matching .* on page 1"):
+        XtrackersImporter().parse(file)
+
+
+class _HeaderlessTable:
+    """Table stub whose extraction yields no rows."""
+
+    @staticmethod
+    def extract() -> list[list[str]]:
+        return []
+
+
+class _HeaderlessPage:
+    """Page stub with a detectable but empty table."""
+
+    @staticmethod
+    def find_table() -> _HeaderlessTable:
+        return _HeaderlessTable()
+
+
+def test_empty_extracted_header_fails_loudly(tmp_path: Path) -> None:
+    """A detected table that extracts to nothing is reported, not indexed."""
+    page = cast("pdfplumber.page.Page", _HeaderlessPage())
+
+    with pytest.raises(ParsingError, match="Table header is empty on page 1"):
+        XtrackersImporter._extract_header(  # noqa: SLF001
+            page, tmp_path / "report.pdf", 1
+        )
 
 
 def test_unknown_content_is_not_accepted(tmp_path: Path) -> None:

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -329,8 +329,19 @@ def test_dividend_and_tax_currency_mismatch_has_a_calculation_error() -> None:
         calculator.calculate_capital_gain()
 
 
-def test_positive_management_fee_has_a_transaction_error() -> None:
-    """A fee that would reduce pooled cost is rejected before an invariant fires."""
+@pytest.mark.parametrize(
+    ("amount", "error_match"),
+    [
+        (Decimal(1), "must not be positive"),
+        (Decimal("NaN"), "must be a finite number"),
+        (Decimal("Infinity"), "must be a finite number"),
+        (Decimal("-Infinity"), "must be a finite number"),
+    ],
+)
+def test_invalid_management_fee_has_a_transaction_error(
+    amount: Decimal, error_match: str
+) -> None:
+    """A fee that would corrupt pooled cost is rejected before an invariant fires."""
     fee = BrokerTransaction(
         date=datetime.date(2024, 6, 3),
         action=ActionType.FEE,
@@ -339,12 +350,12 @@ def test_positive_management_fee_has_a_transaction_error() -> None:
         quantity=None,
         price=None,
         fees=Decimal(0),
-        amount=Decimal(1),
+        amount=amount,
         currency=CurrencyCode("GBP"),
         broker="Test",
     )
 
-    with pytest.raises(InvalidTransactionError, match="must not be positive"):
+    with pytest.raises(InvalidTransactionError, match=error_match):
         create_calculator(
             tax_year=2024, balance_check=False
         ).convert_to_hmrc_transactions([fee])
@@ -835,10 +846,11 @@ def test_rename_transfers_pool_to_new_ticker() -> None:
     assert entry.new_pool_cost == Decimal(1000)
 
 
-def test_rename_without_old_symbol_has_a_transaction_error() -> None:
+@pytest.mark.parametrize("description", ["", RENAME_DESCRIPTION_PREFIX])
+def test_rename_without_old_symbol_has_a_transaction_error(description: str) -> None:
     """A rename row that cannot name its source is invalid input."""
     transaction = _rename_transaction(datetime.date(2024, 5, 10), "OLD", "NEW")
-    transaction.description = ""
+    transaction.description = description
 
     with pytest.raises(InvalidTransactionError, match="old symbol"):
         create_calculator(

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -15,7 +15,12 @@ import pytest
 from cgt_calc.const import BALANCE_CHECK_CONTEXT_ROWS, RENAME_DESCRIPTION_PREFIX
 from cgt_calc.currency_converter import CurrencyConverter
 from cgt_calc.current_price_fetcher import CurrentPriceFetcher
-from cgt_calc.exceptions import CalculationError, InvalidTransactionError
+from cgt_calc.exceptions import (
+    CalculationError,
+    InvalidTransactionError,
+    IsinMissingError,
+    PriceMissingError,
+)
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.main import CapitalGainsCalculator, main
@@ -259,6 +264,110 @@ def test_eri_conflicting_report_raises_invalid_transaction_error() -> None:
 
     with pytest.raises(InvalidTransactionError, match="conflicting ERI report"):
         calculator.convert_to_hmrc_transactions(transactions)
+
+
+@pytest.mark.parametrize(
+    ("isin", "price", "error"),
+    [
+        (None, Decimal(1), IsinMissingError),
+        (ERI_ISIN, None, PriceMissingError),
+        (ERI_ISIN, Decimal(-1), InvalidTransactionError),
+        (ERI_ISIN, Decimal("NaN"), InvalidTransactionError),
+    ],
+)
+def test_eri_missing_required_data_has_a_transaction_error(
+    isin: Isin | None,
+    price: Decimal | None,
+    error: type[InvalidTransactionError],
+) -> None:
+    """Malformed ERI input identifies the transaction instead of asserting."""
+    transaction = BrokerTransaction(
+        date=datetime.date(2024, 6, 30),
+        action=ActionType.EXCESS_REPORTED_INCOME,
+        symbol=None,
+        description="",
+        quantity=None,
+        price=price,
+        fees=Decimal(0),
+        amount=None,
+        currency=CurrencyCode("GBP"),
+        broker="ERI input",
+        isin=isin,
+    )
+
+    with pytest.raises(error):
+        create_calculator(
+            tax_year=2024, balance_check=False
+        ).convert_to_hmrc_transactions([transaction])
+
+
+def test_dividend_and_tax_currency_mismatch_has_a_calculation_error() -> None:
+    """Inconsistent income rows produce a user-facing data error."""
+    day = datetime.date(2024, 6, 3)
+    transactions = [
+        BrokerTransaction(
+            date=day,
+            action=action,
+            symbol="FOO",
+            description="dividend",
+            quantity=None,
+            price=None,
+            fees=Decimal(0),
+            amount=amount,
+            currency=currency,
+            broker="Test",
+        )
+        for action, amount, currency in [
+            (ActionType.DIVIDEND, Decimal(100), CurrencyCode("USD")),
+            (ActionType.DIVIDEND_TAX, Decimal(-15), CurrencyCode("GBP")),
+        ]
+    ]
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    calculator.convert_to_hmrc_transactions(transactions)
+
+    with pytest.raises(CalculationError, match="currencies do not match"):
+        calculator.calculate_capital_gain()
+
+
+def test_positive_management_fee_has_a_transaction_error() -> None:
+    """A fee that would reduce pooled cost is rejected before an invariant fires."""
+    fee = BrokerTransaction(
+        date=datetime.date(2024, 6, 3),
+        action=ActionType.FEE,
+        symbol="FOO",
+        description="management fee",
+        quantity=None,
+        price=None,
+        fees=Decimal(0),
+        amount=Decimal(1),
+        currency=CurrencyCode("GBP"),
+        broker="Test",
+    )
+
+    with pytest.raises(InvalidTransactionError, match="must not be positive"):
+        create_calculator(
+            tax_year=2024, balance_check=False
+        ).convert_to_hmrc_transactions([fee])
+
+
+def test_zero_management_fee_is_accepted() -> None:
+    """A zero fee leaves pooled cost unchanged and remains valid input."""
+    fee = BrokerTransaction(
+        date=datetime.date(2024, 6, 3),
+        action=ActionType.FEE,
+        symbol="FOO",
+        description="management fee",
+        quantity=None,
+        price=None,
+        fees=Decimal(0),
+        amount=Decimal(0),
+        currency=CurrencyCode("GBP"),
+        broker="Test",
+    )
+
+    create_calculator(tax_year=2024, balance_check=False).convert_to_hmrc_transactions(
+        [fee]
+    )
 
 
 @pytest.mark.parametrize(
@@ -726,6 +835,17 @@ def test_rename_transfers_pool_to_new_ticker() -> None:
     assert entry.new_pool_cost == Decimal(1000)
 
 
+def test_rename_without_old_symbol_has_a_transaction_error() -> None:
+    """A rename row that cannot name its source is invalid input."""
+    transaction = _rename_transaction(datetime.date(2024, 5, 10), "OLD", "NEW")
+    transaction.description = ""
+
+    with pytest.raises(InvalidTransactionError, match="old symbol"):
+        create_calculator(
+            tax_year=2024, balance_check=False
+        ).convert_to_hmrc_transactions([transaction])
+
+
 def test_section_104_disposal_uses_renamed_pool_cost() -> None:
     """After a rename, S104 disposal under NEW uses the pool cost carried from OLD."""
     calculator = create_calculator(tax_year=2024, balance_check=False)
@@ -1181,6 +1301,30 @@ def test_report_labels_full_tax_year() -> None:
 
     assert report.title_period == "2024-25"
     assert "Tax summary for 2024/2025" in str(report)
+
+
+def test_taxable_gain_requires_an_allowance() -> None:
+    """Taxable gain cannot be derived when the tax-year allowance is unknown."""
+    report = CapitalGainsReport(
+        2024,
+        [],
+        0,
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        None,
+        None,
+        {},
+        {},
+        Decimal(0),
+        Decimal(0),
+        Decimal(0),
+        show_unrealized_gains=False,
+    )
+
+    with pytest.raises(CalculationError, match=r"allowance.*unavailable"):
+        report.taxable_gain()
 
 
 def test_foreign_fees_folded_into_gbp_transaction() -> None:

--- a/tests/general/test_currency_converter.py
+++ b/tests/general/test_currency_converter.py
@@ -97,6 +97,20 @@ def test_read_exchange_rates_raises_on_invalid_rate(tmp_path: Path) -> None:
         CurrencyConverter(exchange_rates_file=rates_file)
 
 
+@pytest.mark.parametrize("rate", ["0", "-1.25", "NaN", "Infinity"])
+def test_read_exchange_rates_rejects_non_positive_or_non_finite_rate(
+    tmp_path: Path, rate: str
+) -> None:
+    """Rates that cannot represent a real conversion are invalid input."""
+    rates_file = tmp_path / "invalid_rate.csv"
+    rates_file.write_text(
+        f"month,currency,rate\n2024-01-01,USD,{rate}\n", encoding="utf8"
+    )
+
+    with pytest.raises(ParsingError, match="must be finite and positive"):
+        CurrencyConverter(exchange_rates_file=rates_file)
+
+
 def test_read_exchange_rates_raises_on_malformed_currency(tmp_path: Path) -> None:
     """A malformed code in the rate file is reported there, not as a missing rate."""
     rates_file = tmp_path / "rates.csv"
@@ -225,6 +239,26 @@ def test_hmrc_response_invalid_rate_value_raises_api_error(
     monkeypatch.setattr(converter, "session", CannedSession(CannedResponse(xml)))
 
     with pytest.raises(ExternalApiError, match="contains invalid rate"):
+        converter.currency_to_gbp_rate(CurrencyCode("USD"), datetime.date(2021, 5, 10))
+
+
+@pytest.mark.parametrize("rate", ["0", "-1.25", "NaN", "Infinity"])
+def test_hmrc_response_rejects_non_positive_or_non_finite_rate(
+    monkeypatch: pytest.MonkeyPatch, rate: str
+) -> None:
+    """Invalid numeric rates from the external service are reported as API errors."""
+    xml = (
+        "<exchangeRateMonthList>"
+        "<exchangeRate>"
+        "<currencyCode>USD</currencyCode>"
+        f"<rateNew>{rate}</rateNew>"
+        "</exchangeRate>"
+        "</exchangeRateMonthList>"
+    )
+    converter = CurrencyConverter()
+    monkeypatch.setattr(converter, "session", CannedSession(CannedResponse(xml)))
+
+    with pytest.raises(ExternalApiError, match="non-positive or non-finite"):
         converter.currency_to_gbp_rate(CurrencyCode("USD"), datetime.date(2021, 5, 10))
 
 

--- a/tests/general/test_exceptions.py
+++ b/tests/general/test_exceptions.py
@@ -19,6 +19,7 @@ from cgt_calc.exceptions import (
     InitialPriceMissingError,
     InteractiveInputRequiredError,
     InvalidTransactionError,
+    IsinMissingError,
     IsinTranslationError,
     LatexRenderError,
     MarketDataMissingError,
@@ -104,6 +105,7 @@ CONTEXT_CASES: list[tuple[CgtError, list[str]]] = [
     (AmountMissingError(TRANSACTION), ["FOO", "2023"]),
     (SymbolMissingError(TRANSACTION), ["FOO", "2023"]),
     (PriceMissingError(TRANSACTION), ["FOO", "2023"]),
+    (IsinMissingError(TRANSACTION), ["FOO", "2023"]),
     (QuantityMissingError(TRANSACTION), ["FOO", "2023"]),
     (QuantityNotPositiveError(TRANSACTION), ["FOO", "2023"]),
     # Both the calculated and the supplied amount are needed to see the gap.

--- a/tests/general/test_initial_prices.py
+++ b/tests/general/test_initial_prices.py
@@ -72,6 +72,18 @@ def test_invalid_price(tmp_path: Path) -> None:
     assert "initial_prices.csv" in message
 
 
+@pytest.mark.parametrize("price", ["-1", "NaN", "Infinity"])
+def test_invalid_numeric_price(tmp_path: Path, price: str) -> None:
+    """Negative and non-finite prices are reported as invalid file data."""
+    prices_file = tmp_path / "initial_prices.csv"
+    prices_file.write_text(f'date,symbol,price\n"Mar 08, 2021",FOO,{price}\n')
+
+    with pytest.raises(ParsingError, match="finite and non-negative") as excinfo:
+        InitialPrices(initial_prices_file=prices_file)
+
+    assert excinfo.value.row_index == 2
+
+
 def test_entry_parses_row() -> None:
     """Parse the date, symbol and decimal price from a CSV row."""
     entry = InitialPricesEntry(

--- a/tests/general/test_model.py
+++ b/tests/general/test_model.py
@@ -194,6 +194,10 @@ def test_nonzero_foreign_amount_requires_a_currency() -> None:
     with pytest.raises(CalculationError, match="Currency missing"):
         ForeignCurrencyAmount() + invalid
 
+    # The left operand is validated by the same rule as the right one.
+    with pytest.raises(CalculationError, match="Currency missing"):
+        invalid + ForeignCurrencyAmount()
+
 
 def test_broker_transaction_rejects_a_bare_invalid_currency() -> None:
     """A caller that skips the type still cannot smuggle in a bad currency."""

--- a/tests/general/test_model.py
+++ b/tests/general/test_model.py
@@ -7,7 +7,14 @@ from decimal import Decimal
 
 import pytest
 
-from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode, Isin
+from cgt_calc.exceptions import CalculationError
+from cgt_calc.model import (
+    ActionType,
+    BrokerTransaction,
+    CurrencyCode,
+    ForeignCurrencyAmount,
+    Isin,
+)
 
 # Apple, a real ISIN with a valid check digit.
 VALID_ISIN = "US0378331005"
@@ -169,6 +176,23 @@ def test_currency_code_parse_returns_none_for_invalid_input() -> None:
 def test_currency_code_parse_normalises_valid_input() -> None:
     """The lenient constructor normalises exactly like the strict one."""
     assert CurrencyCode.parse(" GBP ") == CurrencyCode("GBP")
+
+
+def test_foreign_currency_amount_rejects_mixed_currencies() -> None:
+    """Amounts sourced from incompatible input rows produce a domain error."""
+    usd = ForeignCurrencyAmount(Decimal(1), CurrencyCode("USD"))
+    gbp = ForeignCurrencyAmount(Decimal(1), CurrencyCode("GBP"))
+
+    with pytest.raises(CalculationError, match="different currencies"):
+        usd + gbp
+
+
+def test_nonzero_foreign_amount_requires_a_currency() -> None:
+    """A missing input currency produces a domain error rather than an assertion."""
+    invalid = ForeignCurrencyAmount(Decimal(1))
+
+    with pytest.raises(CalculationError, match="Currency missing"):
+        ForeignCurrencyAmount() + invalid
 
 
 def test_broker_transaction_rejects_a_bare_invalid_currency() -> None:

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -10,7 +10,12 @@ import pytest
 
 from cgt_calc.exceptions import ParsingError, SymbolMissingError
 from cgt_calc.model import ActionType, BrokerTransaction
-from cgt_calc.parsers.schwab import AwardPrices, SchwabParser, action_from_str
+from cgt_calc.parsers.schwab import (
+    AwardPrices,
+    SchwabParser,
+    _read_schwab_awards,
+    action_from_str,
+)
 from tests.utils import build_cmd, report_path, stderr_alerts
 
 
@@ -41,6 +46,23 @@ def test_missing_award_file_reports_the_vest_it_cannot_price() -> None:
     # The row that needs the file is named, so it can be found in the statement.
     assert "BAR" in message
     assert "2023-08-18" in message
+
+
+def test_award_rows_overlapping_in_a_column_are_reported(tmp_path: Path) -> None:
+    """A split award row whose halves both fill a column is malformed input."""
+    award_file = tmp_path / "awards.csv"
+    award_file.write_text(
+        "Date,Action,Symbol,Description,Quantity,FeesAndCommissions,"
+        "DisbursementElection,Amount,AwardDate,AwardId,FairMarketValuePrice,"
+        "SalePrice,SharesSoldWithheldForTaxes,NetSharesDeposited,Taxes\n"
+        "08/15/2023,Lapse,BAR,Restricted Stock Lapse,400,,,,,,,,,,\n"
+        ',,,,400,,,,03/21/2022,101883189,$140.35,,200,200,"$13,192.90"\n'
+    )
+
+    with pytest.raises(ParsingError, match="contain data in column 5") as exc_info:
+        _read_schwab_awards(award_file)
+
+    assert exc_info.value.row_index == 2
 
 
 def test_award_file_without_the_award_says_so() -> None:
@@ -331,6 +353,30 @@ def test_cash_merger_adj_without_cash_merger() -> None:
         _read(content)
 
 
+def test_cash_merger_adj_after_another_action() -> None:
+    """Report a malformed pair as input data, not an internal assertion."""
+    content = (
+        SCHWAB_HEADER
+        + "01/15/2023,Credit Interest,,Interest,,,,$1.00\n"
+        + "01/15/2023,Cash Merger Adj,FOO,Merger,,-10,,\n"
+    )
+
+    with pytest.raises(ParsingError, match="must immediately follow"):
+        _read(content)
+
+
+def test_full_redemption_adj_before_another_action() -> None:
+    """Report an unexpected second row as malformed broker data."""
+    content = (
+        SCHWAB_HEADER
+        + "01/15/2023,Full Redemption Adj,FOO,Redemption,,,,$100.00\n"
+        + "01/15/2023,Credit Interest,,Interest,,,,$1.00\n"
+    )
+
+    with pytest.raises(ParsingError, match="must be followed"):
+        _read(content)
+
+
 def test_invalid_cash_merger_pair() -> None:
     """Raise when a Cash Merger pair fails validation."""
     content = (
@@ -338,8 +384,10 @@ def test_invalid_cash_merger_pair() -> None:
         + '01/16/2023,Cash Merger,FOO,Merger,,,,"$100.00"\n'
         + '01/15/2023,Cash Merger Adj,FOO,Merger,,-10,,"$5.00"\n'
     )
-    with pytest.raises(ParsingError, match="Invalid Cash Merger format"):
+    with pytest.raises(ParsingError, match="Invalid Cash Merger format") as exc_info:
         _read(content)
+
+    assert "FOO on 2023-01-16" in str(exc_info.value)
 
 
 def test_invalid_full_redemption_pair() -> None:
@@ -349,5 +397,37 @@ def test_invalid_full_redemption_pair() -> None:
         + '01/16/2023,Full Redemption Adj,FOO,Redemption,,,,"$100.00"\n'
         + '01/15/2023,Full Redemption,FOO,Redemption,"$1.00",-10,,\n'
     )
-    with pytest.raises(ParsingError, match="Invalid Full Redemption format"):
+    with pytest.raises(
+        ParsingError, match="Invalid Full Redemption format"
+    ) as exc_info:
         _read(content)
+
+    assert "FOO on 2023-01-15" in str(exc_info.value)
+
+
+def test_cash_merger_rejects_zero_adjustment_quantity() -> None:
+    """A zero quantity identifies the malformed Cash Merger pair."""
+    content = (
+        SCHWAB_HEADER
+        + "01/15/2023,Cash Merger,FOO,Merger,,,,$100.00\n"
+        + "01/15/2023,Cash Merger Adj,FOO,Merger,,0,,\n"
+    )
+
+    with pytest.raises(ParsingError, match="non-zero quantity") as exc_info:
+        _read(content)
+
+    assert "FOO on 2023-01-15" in str(exc_info.value)
+
+
+def test_full_redemption_rejects_zero_quantity() -> None:
+    """A zero quantity identifies the malformed Full Redemption pair."""
+    content = (
+        SCHWAB_HEADER
+        + "01/15/2023,Full Redemption Adj,FOO,Redemption,,,,$100.00\n"
+        + "01/15/2023,Full Redemption,FOO,Redemption,,0,,\n"
+    )
+
+    with pytest.raises(ParsingError, match="non-zero quantity") as exc_info:
+        _read(content)
+
+    assert "FOO on 2023-01-15" in str(exc_info.value)

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -390,6 +390,51 @@ def test_invalid_cash_merger_pair() -> None:
     assert "FOO on 2023-01-16" in str(exc_info.value)
 
 
+@pytest.mark.parametrize(
+    ("amount", "quantity"),
+    [
+        # Negative proceeds would make a disposal with a negative price.
+        ('"-$100.00"', "-10"),
+        # A positive quantity is not shares leaving the account.
+        ('"$100.00"', "10"),
+        # Non-finite values would silently poison the derived price.
+        ("NaN", "-10"),
+        ('"$100.00"', "NaN"),
+    ],
+)
+def test_cash_merger_pair_with_invalid_values(amount: str, quantity: str) -> None:
+    """Reject values that would corrupt the derived disposal."""
+    content = (
+        SCHWAB_HEADER
+        + f"01/15/2023,Cash Merger,FOO,Merger,,,,{amount}\n"
+        + f"01/15/2023,Cash Merger Adj,FOO,Merger,,{quantity},,\n"
+    )
+
+    with pytest.raises(ParsingError, match="Invalid Cash Merger format"):
+        _read(content)
+
+
+@pytest.mark.parametrize(
+    ("amount", "quantity"),
+    [
+        ('"-$100.00"', "-10"),
+        ('"$100.00"', "10"),
+        ("NaN", "-10"),
+        ('"$100.00"', "NaN"),
+    ],
+)
+def test_full_redemption_pair_with_invalid_values(amount: str, quantity: str) -> None:
+    """Reject values that would corrupt the derived disposal."""
+    content = (
+        SCHWAB_HEADER
+        + f"01/15/2023,Full Redemption Adj,FOO,Redemption,,,,{amount}\n"
+        + f"01/15/2023,Full Redemption,FOO,Redemption,,{quantity},,\n"
+    )
+
+    with pytest.raises(ParsingError, match="Invalid Full Redemption format"):
+        _read(content)
+
+
 def test_invalid_full_redemption_pair() -> None:
     """Raise when a Full Redemption pair fails validation."""
     content = (
@@ -413,7 +458,7 @@ def test_cash_merger_rejects_zero_adjustment_quantity() -> None:
         + "01/15/2023,Cash Merger Adj,FOO,Merger,,0,,\n"
     )
 
-    with pytest.raises(ParsingError, match="non-zero quantity") as exc_info:
+    with pytest.raises(ParsingError, match="negative share quantity") as exc_info:
         _read(content)
 
     assert "FOO on 2023-01-15" in str(exc_info.value)
@@ -427,7 +472,7 @@ def test_full_redemption_rejects_zero_quantity() -> None:
         + "01/15/2023,Full Redemption,FOO,Redemption,,0,,\n"
     )
 
-    with pytest.raises(ParsingError, match="non-zero quantity") as exc_info:
+    with pytest.raises(ParsingError, match="negative share quantity") as exc_info:
         _read(content)
 
     assert "FOO on 2023-01-15" in str(exc_info.value)

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -391,23 +391,29 @@ def test_invalid_cash_merger_pair() -> None:
 
 
 @pytest.mark.parametrize(
-    ("amount", "quantity"),
+    ("amount", "quantity", "adj_price", "adj_fees"),
     [
         # Negative proceeds would make a disposal with a negative price.
-        ('"-$100.00"', "-10"),
+        ('"-$100.00"', "-10", "", ""),
         # A positive quantity is not shares leaving the account.
-        ('"$100.00"', "10"),
+        ('"$100.00"', "10", "", ""),
         # Non-finite values would silently poison the derived price.
-        ("NaN", "-10"),
-        ('"$100.00"', "NaN"),
+        ("NaN", "-10", "", ""),
+        ('"$100.00"', "NaN", "", ""),
+        # Non-finite fees would silently poison the combined fees.
+        ('"$100.00"', "-10", "", "NaN"),
+        # A price on the adjustment row is not part of the format.
+        ('"$100.00"', "-10", "5", ""),
     ],
 )
-def test_cash_merger_pair_with_invalid_values(amount: str, quantity: str) -> None:
+def test_cash_merger_pair_with_invalid_values(
+    amount: str, quantity: str, adj_price: str, adj_fees: str
+) -> None:
     """Reject values that would corrupt the derived disposal."""
     content = (
         SCHWAB_HEADER
         + f"01/15/2023,Cash Merger,FOO,Merger,,,,{amount}\n"
-        + f"01/15/2023,Cash Merger Adj,FOO,Merger,,{quantity},,\n"
+        + f"01/15/2023,Cash Merger Adj,FOO,Merger,{adj_price},{quantity},{adj_fees},\n"
     )
 
     with pytest.raises(ParsingError, match="Invalid Cash Merger format"):
@@ -415,20 +421,23 @@ def test_cash_merger_pair_with_invalid_values(amount: str, quantity: str) -> Non
 
 
 @pytest.mark.parametrize(
-    ("amount", "quantity"),
+    ("amount", "quantity", "redemption_fees"),
     [
-        ('"-$100.00"', "-10"),
-        ('"$100.00"', "10"),
-        ("NaN", "-10"),
-        ('"$100.00"', "NaN"),
+        ('"-$100.00"', "-10", ""),
+        ('"$100.00"', "10", ""),
+        ("NaN", "-10", ""),
+        ('"$100.00"', "NaN", ""),
+        ('"$100.00"', "-10", "NaN"),
     ],
 )
-def test_full_redemption_pair_with_invalid_values(amount: str, quantity: str) -> None:
+def test_full_redemption_pair_with_invalid_values(
+    amount: str, quantity: str, redemption_fees: str
+) -> None:
     """Reject values that would corrupt the derived disposal."""
     content = (
         SCHWAB_HEADER
         + f"01/15/2023,Full Redemption Adj,FOO,Redemption,,,,{amount}\n"
-        + f"01/15/2023,Full Redemption,FOO,Redemption,,{quantity},,\n"
+        + f"01/15/2023,Full Redemption,FOO,Redemption,,{quantity},{redemption_fees},\n"
     )
 
     with pytest.raises(ParsingError, match="Invalid Full Redemption format"):


### PR DESCRIPTION
Checks that can fail on user or broker data were plain asserts, so bad input produced a traceback with no file or row. They now raise the matching `CgtError`: `ParsingError` with the file and location for rate, price, award and ERI report data, `InvalidTransactionError` naming the row for calculator input, and `CalculationError` for inconsistent income data. Asserts that guard internal invariants are left as they are.

Along the way:

- Exchange rates and initial prices must be finite and positive.
- A Cash Merger or Full Redemption pair with a zero quantity is refused rather than dividing by zero, and the errors name the symbol and date.
- A short Invesco report row is an error rather than a silently skipped subrow.
- The ERI import script warns and continues when an importer finds nothing in a file instead of abandoning the rest of the directory.
