### PR TITLE
Expand the disclaimer beyond a one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,12 @@ brokers, please open an **issue** or **pull request**. See the
 
 ## ⚠️ Disclaimer
 
-Please note: I'm **not a tax adviser**. Use this tool and its outputs **at your own risk**.
+This tool is a calculation aid, **not tax advice**. It calculates capital gains figures from the
+transaction history you provide and is designed to apply the UK tax rules it supports, following the
+legislation and published HMRC guidance. Its authors and contributors are not acting as your tax
+advisers, the results may contain errors, and tax rules change.
+
+You are responsible for providing complete data and checking the figures against your records and
+current HMRC guidance before using them in a tax return. For unusual or uncertain circumstances,
+consider consulting a suitably qualified tax adviser. The software is provided "as is", without
+warranty of any kind; see the [MIT License](LICENSE).

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -14,4 +14,13 @@ The only external API calls made are:
 
 ## Disclaimer
 
-Please note: I'm **not a tax adviser**. Use this tool and its outputs **at your own risk**.
+This tool is a calculation aid, **not tax advice**. It calculates capital gains figures from the
+transaction history you provide and is designed to apply the UK tax rules it supports, following the
+legislation and published HMRC guidance. Its authors and contributors are not acting as your tax
+advisers, the results may contain errors, and tax rules change.
+
+You are responsible for providing complete data and checking the figures against your records and
+current HMRC guidance before using them in a tax return. For unusual or uncertain circumstances,
+consider consulting a suitably qualified tax adviser. The software is provided "as is", without
+warranty of any kind; see the
+[MIT License](https://github.com/KapJI/capital-gains-calculator/blob/main/LICENSE).


### PR DESCRIPTION
Replace the one-line disclaimer in the README and the docs site with wording that says the output is not tax advice, that no adviser–client relationship exists, and that figures need checking against records and current HMRC guidance before filing. The two copies are identical apart from the LICENSE link target.