### PR TITLE
Use PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,10 @@ version = "0.0.0"
 description = "Calculate UK capital gains from broker exports — supports Charles Schwab, Freetrade, Hargreaves Lansdown, Interactive Brokers, Morgan Stanley, Sharesight, Trading 212, Vanguard and a custom RAW format."
 authors = [{ name = "Ruslan Sayfutdinov", email = "ruslan@sayfutdinov.com" }]
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
   "Development Status :: 4 - Beta",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",


### PR DESCRIPTION
Replace the legacy `license = { text = "MIT" }` table with an SPDX expression and `license-files`, and drop the now-deprecated license classifier. `uv build` no longer warns, the wheel carries `License-Expression: MIT` (Metadata-Version 2.4), and the LICENSE file is embedded in every built artifact.