### PR TITLE
Mark the project stable and expand the trove classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,13 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Console",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Topic :: Office/Business :: Financial",
+  "Topic :: Office/Business :: Financial :: Investment",
   "Typing :: Typed",
 ]
 keywords = [


### PR DESCRIPTION
Promote `Development Status` to `5 - Production/Stable` and add `Environment :: Console` and `Topic :: Office/Business :: Financial :: Investment`. All classifiers validated against the trove registry; `OS Independent` is deliberately left out while `currency_converter.py` uses the POSIX-only `fcntl`.