### PR TITLE
Support Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,12 @@ jobs:
           uvx prek run --hook-stage manual python-typing-update --all-files --show-diff-on-failure --color=always
 
   tests:
-    name: Tests (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: Tests (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12", "3.13", "3.14"]
     env:
       UV_PYTHON: ${{ matrix.python-version }}
@@ -71,7 +72,7 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           files: coverage.xml
-          flags: python-${{ matrix.python-version }}
+          flags: python-${{ matrix.python-version }}-${{ matrix.os }}
           token: ${{ secrets.CODECOV_TOKEN }}
           # Don't fail CI on upload issues: merge protection comes
           # from the codecov/project status check, not this step.
@@ -84,7 +85,7 @@ jobs:
         with:
           report_type: test_results
           files: junit.xml
-          flags: python-${{ matrix.python-version }}
+          flags: python-${{ matrix.python-version }}-${{ matrix.os }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ["3.12", "3.13", "3.14"]
+        include:
+          # One job per extra OS is enough: platform breakage is about
+          # OS APIs and encodings, not the Python minor version.
+          - os: macos-latest
+            python-version: "3.12"
+          - os: windows-latest
+            python-version: "3.12"
     env:
       UV_PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -36,6 +36,7 @@ CG52742
 CG59562
 cgt
 CMF5
+CRLF
 codepage
 codespell
 colorama
@@ -79,6 +80,7 @@ ISIN
 IsinConverter
 ISINs
 Lansdown
+LF
 len
 LSE
 Luhn

--- a/.harper-ignore.txt
+++ b/.harper-ignore.txt
@@ -18,3 +18,5 @@
 ^version\.py:.*PhrasalVerbAsCompoundNoun
 # "A fee on the row is real money" is complete; MissingPreposition misfires.
 ^main\.py:.*MissingPreposition
+# "CR CR LF" spells out the doubled carriage return; the repeat is the point.
+^util\.py:.*RepeatedWords

--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 import csv
 import datetime
 from decimal import Decimal, InvalidOperation
-import fcntl
 import logging
 from typing import TYPE_CHECKING, Final, TextIO, override
 
@@ -21,7 +20,7 @@ from .const import CGT_MODE, RuntimeMode
 from .dates import is_date
 from .exceptions import ExchangeRateMissingError, ExternalApiError, ParsingError
 from .model import CurrencyCode
-from .util import open_with_parents
+from .util import exclusive_lock, open_with_parents
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -355,8 +354,10 @@ class TestCurrencyConverter(CurrencyConverter):
         currency: CurrencyCode,
         value: Decimal,
     ) -> None:
-        with open_with_parents(exchange_rates_file, clear_content=False) as fout:
-            fcntl.flock(fout.fileno(), fcntl.LOCK_EX)
+        with (
+            open_with_parents(exchange_rates_file, clear_content=False) as fout,
+            exclusive_lock(fout),
+        ):
             fout.seek(0)
             data = TestCurrencyConverter._read_exchange_rates_data(
                 exchange_rates_file, fout
@@ -364,7 +365,6 @@ class TestCurrencyConverter(CurrencyConverter):
             if date not in data or currency not in data[date]:
                 writer = csv.writer(fout)
                 writer.writerow([date, currency, str(value)])
-            fcntl.flock(fout.fileno(), fcntl.LOCK_UN)
 
     @staticmethod
     @override

--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from .util import strip_zeros

--- a/cgt_calc/logging.py
+++ b/cgt_calc/logging.py
@@ -169,6 +169,9 @@ def parsing_msg(file: str | Path | Traversable) -> None:
     # Strip package root
     package_root = f"{Path(__file__).resolve().parent.parent}{os.path.sep}"
     file = str(file).removeprefix(package_root)
+    # Forward slashes on every platform: the progress narrative is a
+    # contract, and Windows would otherwise print backslashes here.
+    file = file.replace(os.path.sep, "/")
     LOGGER.info(
         style_text(f"Parsing {file}...", colour=colorama.Fore.CYAN, stream=sys.stderr)
     )

--- a/cgt_calc/logging.py
+++ b/cgt_calc/logging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+import io
 import logging
 import os
 from pathlib import Path
@@ -178,8 +179,21 @@ def bullet(stream: TextIO) -> str:
     return "    • " if get_ui().supports_emoji(stream) else "  "
 
 
+def force_utf8_stdio() -> None:
+    """Emit UTF-8 regardless of the platform's locale.
+
+    Windows encodes piped output with the legacy code page by default,
+    which cannot hold every character the reports use.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if isinstance(stream, io.TextIOWrapper):
+            stream.reconfigure(encoding="utf-8")
+
+
 def setup_logging() -> None:
     """Configure the root logger with coloured output."""
+
+    force_utf8_stdio()
 
     # Enable ANSI pass-through on Windows (harmless on other platforms)
     colorama.just_fix_windows_console()

--- a/cgt_calc/util.py
+++ b/cgt_calc/util.py
@@ -1,8 +1,11 @@
 """Utility functions."""
 
+from collections.abc import Generator
+from contextlib import contextmanager
 import decimal
 from decimal import Decimal
 from pathlib import Path
+import sys
 from typing import TextIO
 
 
@@ -82,6 +85,38 @@ def approx_equal(
 
 
 def open_with_parents(path: Path, *, clear_content: bool = True) -> TextIO:
-    """Open a file for writing, creating parent directories if they do not exist."""
+    """Open a file for writing, creating parent directories if they do not exist.
+
+    Newline translation is disabled because every caller writes CSV:
+    csv.writer emits its own CRLF terminators, which translation would
+    double into CR CR LF on Windows.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    return path.open("w" if clear_content else "r+", encoding="utf8")
+    return path.open("w" if clear_content else "r+", encoding="utf8", newline="")
+
+
+if sys.platform == "win32":
+    import msvcrt
+
+    @contextmanager
+    def exclusive_lock(file: TextIO) -> Generator[None]:
+        """Hold an exclusive advisory lock on the whole open file."""
+        file.seek(0)
+        msvcrt.locking(file.fileno(), msvcrt.LK_LOCK, 1)
+        try:
+            yield
+        finally:
+            file.seek(0)
+            msvcrt.locking(file.fileno(), msvcrt.LK_UNLCK, 1)
+
+else:
+    import fcntl
+
+    @contextmanager
+    def exclusive_lock(file: TextIO) -> Generator[None]:
+        """Hold an exclusive advisory lock on the whole open file."""
+        fcntl.flock(file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(file.fileno(), fcntl.LOCK_UN)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,10 @@ required-version = ">=0.13.0"
 target-version = "py312"
 
 [tool.ruff.lint]
+# Preview is on only to reach PLW1514; explicit-preview-rules keeps every
+# other preview rule and behaviour change off.
+preview = true
+explicit-preview-rules = true
 select = [
   "A", # flake8-builtins
   "ARG", # flake8-unused-arguments
@@ -120,6 +124,7 @@ select = [
   "PGH", # pygrep-hooks
   "PIE", # flake8-pie
   "PL", # pylint
+  "PLW1514", # unspecified-encoding: locale-dependent IO broke Windows once
   "PT", # flake8-pytest-style
   "PTH", # flake8-pathlib
   "PYI", # flake8-pyi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license-files = ["LICENSE"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
+  "Operating System :: OS Independent",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",

--- a/tests/freetrade/test_freetrade.py
+++ b/tests/freetrade/test_freetrade.py
@@ -153,7 +153,7 @@ def test_run_with_freetrade_file(request: pytest.FixtureRequest) -> None:
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -162,7 +162,7 @@ def test_run_with_freetrade_file(request: pytest.FixtureRequest) -> None:
         )
     assert stderr_alerts(result.stderr) == [], "Run with example files generated errors"
     expected_file = Path("tests") / "freetrade" / "data" / "expected_output.txt"
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -102,7 +102,7 @@ def test_main_prints_help_when_no_arguments() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "cgt_calc.main"],
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         check=False,
     )
 
@@ -1127,7 +1127,7 @@ def test_run_with_example_files(request: pytest.FixtureRequest) -> None:
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -1156,7 +1156,7 @@ def test_run_with_example_files(request: pytest.FixtureRequest) -> None:
     expected_file = (
         Path("tests") / "general" / "data" / "test_run_with_example_files_output.txt"
     )
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "

--- a/tests/general/test_currency_converter.py
+++ b/tests/general/test_currency_converter.py
@@ -356,7 +356,7 @@ def test_write_exchange_rates_file(tmp_path: Path) -> None:
         },
     )
 
-    assert rates_file.read_text() == (
+    assert rates_file.read_text(encoding="utf-8") == (
         "month,currency,rate\n2024-01-01,EUR,1.10\n2024-01-01,USD,1.25\n"
     )
 
@@ -428,13 +428,13 @@ def test_test_converter_records_new_rates(tmp_path: Path) -> None:
     converter._query_hmrc_api = fake_query  # type: ignore[method-assign]  # noqa: SLF001
 
     assert converter.currency_to_gbp_rate(CurrencyCode("USD"), DATE) == Decimal("1.25")
-    assert "2024-01-01,USD,1.25" in rates_file.read_text()
+    assert "2024-01-01,USD,1.25" in rates_file.read_text(encoding="utf-8")
 
     # Appending the same rate again is a no-op.
     RecordingCurrencyConverter._append_exchange_rates_file(  # noqa: SLF001
         rates_file, DATE, CurrencyCode("USD"), Decimal("1.25")
     )
-    assert rates_file.read_text().count("USD") == 1
+    assert rates_file.read_text(encoding="utf-8").count("USD") == 1
 
 
 def test_strict_converter_refuses_to_fetch() -> None:

--- a/tests/general/test_isin_converter.py
+++ b/tests/general/test_isin_converter.py
@@ -243,7 +243,9 @@ def test_translation_file_roundtrip(
     converter = IsinConverter(isin_translation_file=translation_file)
     converter.add_from_transaction(_transaction(ISIN_A, "FOO"))
 
-    assert translation_file.read_text() == f"ISIN,symbol\n{ISIN_A},FOO\n"
+    assert (
+        translation_file.read_text(encoding="utf-8") == f"ISIN,symbol\n{ISIN_A},FOO\n"
+    )
 
     restored = IsinConverter(isin_translation_file=translation_file)
     assert restored.get_symbols(ISIN_A) == {"FOO"}

--- a/tests/hl/test_hl.py
+++ b/tests/hl/test_hl.py
@@ -113,7 +113,7 @@ def test_hl_parser(request: pytest.FixtureRequest) -> None:
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -127,7 +127,7 @@ def test_hl_parser(request: pytest.FixtureRequest) -> None:
         / "data"
         / "test_run_with_hl_files_no_balance_check_output.txt"
     )
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "
@@ -147,7 +147,7 @@ def test_hl_parser_missing_pdf(request: pytest.FixtureRequest) -> None:
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     assert result.returncode, "Test succeeded but expected failure"
     assert "Cannot find contract note pdf" in result.stderr, (
         "Test failed with unexpected error"

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -158,7 +158,7 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
             "--output",
             report_path(request),
         )
-        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
         if result.returncode:
             pytest.fail(
                 "Integration test failed\n"
@@ -169,7 +169,7 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
         expected_file = (
             Path("tests") / "interactive_brokers" / "data" / "expected_output.txt"
         )
-        expected = expected_file.read_text()
+        expected = expected_file.read_text(encoding="utf-8")
         cmd_str = " ".join([param or "''" for param in cmd])
         assert result.stdout == expected, (
             "Run with example files generated unexpected outputs, "
@@ -257,7 +257,7 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
             "--output",
             str(tmp_path / "out"),
         )
-        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
         if result.returncode:
             pytest.fail(
                 "Integration test failed\n"
@@ -294,7 +294,7 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
             "--output",
             str(tmp_path / "out"),
         )
-        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
         if result.returncode:
             pytest.fail(
                 "Integration test failed\n"

--- a/tests/raw/test_raw.py
+++ b/tests/raw/test_raw.py
@@ -35,7 +35,7 @@ def test_run_with_raw_files_no_balance_check(request: pytest.FixtureRequest) -> 
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -44,7 +44,7 @@ def test_run_with_raw_files_no_balance_check(request: pytest.FixtureRequest) -> 
         )
     assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
     expected_file = Path("tests") / "raw" / "data" / "expected_output.txt"
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "
@@ -63,7 +63,7 @@ def test_run_with_raw_files(request: pytest.FixtureRequest) -> None:
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -72,7 +72,7 @@ def test_run_with_raw_files(request: pytest.FixtureRequest) -> None:
         )
     assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
     expected_file = Path("tests") / "raw" / "data" / "expected_output_2.txt"
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "
@@ -96,7 +96,7 @@ def test_run_with_raw_files_stdin(request: pytest.FixtureRequest) -> None:
         report_path(request),
     )
     result = subprocess.run(
-        cmd, input=csv_content, capture_output=True, text=True, check=False
+        cmd, input=csv_content, capture_output=True, encoding="utf-8", check=False
     )
     if result.returncode:
         pytest.fail(
@@ -106,7 +106,7 @@ def test_run_with_raw_files_stdin(request: pytest.FixtureRequest) -> None:
         )
     assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
     expected_file = Path("tests") / "raw" / "data" / "expected_output_stdin.txt"
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
 
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
@@ -125,7 +125,7 @@ def test_run_with_nonexistent_file() -> None:
         "--raw-file",
         missing_file,
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     assert result.returncode != 0
     assert "path does not exist" in result.stderr
     assert missing_file in result.stderr

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -91,7 +91,7 @@ def test_run_with_schwab_example_2023_files(request: pytest.FixtureRequest) -> N
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -100,7 +100,7 @@ def test_run_with_schwab_example_2023_files(request: pytest.FixtureRequest) -> N
         )
     assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
     expected_file = Path("tests") / "schwab" / "data" / "2023" / "expected_output.txt"
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "
@@ -119,7 +119,7 @@ def test_run_with_schwab_cash_merger_files(request: pytest.FixtureRequest) -> No
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -133,7 +133,7 @@ def test_run_with_schwab_cash_merger_files(request: pytest.FixtureRequest) -> No
     expected_file = (
         Path("tests") / "schwab" / "data" / "cash_merger" / "expected_output.txt"
     )
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "
@@ -154,7 +154,7 @@ def test_run_with_schwab_rsu_settlement_files(request: pytest.FixtureRequest) ->
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -165,7 +165,7 @@ def test_run_with_schwab_rsu_settlement_files(request: pytest.FixtureRequest) ->
     expected_file = (
         Path("tests") / "schwab" / "data" / "rsu_settlement" / "expected_output.txt"
     )
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "
@@ -184,7 +184,7 @@ def test_run_with_schwab_bond_interest_files(request: pytest.FixtureRequest) -> 
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -195,7 +195,7 @@ def test_run_with_schwab_bond_interest_files(request: pytest.FixtureRequest) -> 
     expected_file = (
         Path("tests") / "schwab" / "data" / "bond_interest" / "expected_output.txt"
     )
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "
@@ -214,7 +214,7 @@ def test_run_with_schwab_interest_tax_files(request: pytest.FixtureRequest) -> N
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -225,7 +225,7 @@ def test_run_with_schwab_interest_tax_files(request: pytest.FixtureRequest) -> N
     expected_file = (
         Path("tests") / "schwab" / "data" / "interest_tax" / "expected_output.txt"
     )
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "

--- a/tests/sharesight/test_sharesight.py
+++ b/tests/sharesight/test_sharesight.py
@@ -39,7 +39,7 @@ def test_run_with_sharesight_files_no_balance_check(
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -53,7 +53,7 @@ def test_run_with_sharesight_files_no_balance_check(
         / "data"
         / "test_run_with_sharesight_files_no_balance_check_output.txt"
     )
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "

--- a/tests/spouse/test_transfer_to_spouse_e2e.py
+++ b/tests/spouse/test_transfer_to_spouse_e2e.py
@@ -29,7 +29,7 @@ def _run(name: str, request: pytest.FixtureRequest) -> subprocess.CompletedProce
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             f"{name} run failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
@@ -37,7 +37,7 @@ def _run(name: str, request: pytest.FixtureRequest) -> subprocess.CompletedProce
     assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
     expected_file = DATA / f"expected_output_{name}.txt"
     cmd_str = " ".join([param or "''" for param in cmd])
-    assert result.stdout == expected_file.read_text(), (
+    assert result.stdout == expected_file.read_text(encoding="utf-8"), (
         f"The {name} report changed; if that is intended, update it with:\n"
         f"{cmd_str} > {expected_file}"
     )

--- a/tests/trading212/test_trading212.py
+++ b/tests/trading212/test_trading212.py
@@ -1014,7 +1014,7 @@ def test_run_with_trading212_2026_files(request: pytest.FixtureRequest) -> None:
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -1025,7 +1025,7 @@ def test_run_with_trading212_2026_files(request: pytest.FixtureRequest) -> None:
     expected_file = (
         Path("tests") / "trading212" / "data" / "2026" / "expected_output.txt"
     )
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "
@@ -1044,7 +1044,7 @@ def test_run_with_trading212_2024_files(request: pytest.FixtureRequest) -> None:
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -1055,7 +1055,7 @@ def test_run_with_trading212_2024_files(request: pytest.FixtureRequest) -> None:
     expected_file = (
         Path("tests") / "trading212" / "data" / "2024" / "expected_output.txt"
     )
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -31,7 +31,7 @@ def test_run_with_vanguard_files(request: pytest.FixtureRequest) -> None:
         "--output",
         report_path(request),
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
     if result.returncode:
         pytest.fail(
             "Integration test failed\n"
@@ -40,7 +40,7 @@ def test_run_with_vanguard_files(request: pytest.FixtureRequest) -> None:
         )
     assert stderr_alerts(result.stderr) == [], "Run with example files generated errors"
     expected_file = Path("tests") / "vanguard" / "data" / "expected_output.txt"
-    expected = expected_file.read_text()
+    expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])
     assert result.stdout == expected, (
         "Run with example files generated unexpected outputs, "


### PR DESCRIPTION
Run the test suite on macOS and Windows in CI and fix everything Windows breaks. Ubuntu keeps the full 3.12–3.14 matrix; the extra platforms run one job each.

The first commit only extends the matrix, so its CI run demonstrates the breakage; the fixes land one root cause at a time:

- File locking used the POSIX-only `fcntl`, which does not exist on Windows and killed every CLI run at import. A platform-conditional `exclusive_lock` helper now uses `msvcrt.locking` there.
- CSV writes went through files opened with newline translation, which doubles `csv.writer`'s CRLF terminators into CR CR LF on Windows.
- Console output travelled through the legacy Windows code page, mangling pound signs: the CLI now forces its stdio to UTF-8, and the tests decode subprocess output and golden files as UTF-8 explicitly.
- The parsing progress narrative printed backslash paths on Windows; it now uses forward slashes everywhere.

With all three platforms green, the package declares `Operating System :: OS Independent`.