### PR TITLE
Handle Forex Trade Component as a balance adjustment

### DIFF
--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -84,14 +84,10 @@ def _action_from_str(action_type: str, file_path: Path) -> ActionType:
         return ActionType.DIVIDEND_TAX
     if action_type == "Other Fee":
         return ActionType.FEE
-    # "FX Translations P&L" arrives as an Adjustment: the revaluation of a
-    # foreign currency balance, not a trade. It moves the cash balance and
-    # creates no taxable event, which is what ADJUSTMENT means here and how the
-    # Schwab parser treats its own. A "Forex Trade Component" is the
-    # base-currency leg of an FX trade and belongs with it: read as a fee, its
-    # Net Amount was rejected outright whenever the trade brought base currency
-    # in, and built a pooled cost for the currency pair whenever it took some
-    # out.
+    # "FX Translations P&L" arrives as an Adjustment, and a "Forex Trade
+    # Component" is the base-currency leg of an FX trade. Both move the cash
+    # balance and create no taxable event, which is what ADJUSTMENT means here
+    # and how the Schwab parser treats its own.
     if action_type in ["Adjustment", "Forex Trade Component"]:
         return ActionType.ADJUSTMENT
 
@@ -164,10 +160,10 @@ class InteractiveBrokersTransaction(BrokerTransaction):
             price = price * exchange_rate
             price_currency = CurrencyCode("GBP")
 
-        # An adjustment only moves the cash balance, so the columns describing
-        # a security are meaningless on one. IBKR files a Forex Trade Component
-        # under the currency pair with a quantity and a price; a currency pair
-        # is not a holding, and keeping them would open a pool for it.
+        # An adjustment is balance-only: the calculator reads its amount and
+        # nothing else. IBKR files a Forex Trade Component under the currency
+        # pair, with a quantity and a price, so clear the columns describing a
+        # security here rather than carry values no reader may rely on.
         if action is ActionType.ADJUSTMENT:
             symbol = None
             quantity = None

--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -82,12 +82,17 @@ def _action_from_str(action_type: str, file_path: Path) -> ActionType:
         return ActionType.SELL
     if action_type == "Foreign Tax Withholding":
         return ActionType.DIVIDEND_TAX
-    if action_type in ["Forex Trade Component", "Other Fee"]:
+    if action_type == "Other Fee":
         return ActionType.FEE
-    # "FX Translations P&L": the revaluation of a foreign currency balance, not
-    # a trade. It moves the cash balance and creates no taxable event, which is
-    # what ADJUSTMENT means here and how the Schwab parser treats its own.
-    if action_type == "Adjustment":
+    # "FX Translations P&L" arrives as an Adjustment: the revaluation of a
+    # foreign currency balance, not a trade. It moves the cash balance and
+    # creates no taxable event, which is what ADJUSTMENT means here and how the
+    # Schwab parser treats its own. A "Forex Trade Component" is the
+    # base-currency leg of an FX trade and belongs with it: read as a fee, its
+    # Net Amount was rejected outright whenever the trade brought base currency
+    # in, and built a pooled cost for the currency pair whenever it took some
+    # out.
+    if action_type in ["Adjustment", "Forex Trade Component"]:
         return ActionType.ADJUSTMENT
 
     raise ParsingError(file_path, f"Unknown type: '{action_type}'")
@@ -158,6 +163,16 @@ class InteractiveBrokersTransaction(BrokerTransaction):
         if price is not None and price_currency != "GBP" and exchange_rate is not None:
             price = price * exchange_rate
             price_currency = CurrencyCode("GBP")
+
+        # An adjustment only moves the cash balance, so the columns describing
+        # a security are meaningless on one. IBKR files a Forex Trade Component
+        # under the currency pair with a quantity and a price; a currency pair
+        # is not a holding, and keeping them would open a pool for it.
+        if action is ActionType.ADJUSTMENT:
+            symbol = None
+            quantity = None
+            price = None
+            fees = Decimal(0)
 
         super().__init__(
             date=date,

--- a/docs/brokers/interactive-brokers.md
+++ b/docs/brokers/interactive-brokers.md
@@ -53,15 +53,15 @@ check the date range and filters as described in [Troubleshooting](#troubleshoot
 
 The importer recognises these literal values from the CSV's `Transaction Type` column:
 
-| Transaction type                     | How cgt-calc handles it                                                 |
-| ------------------------------------ | ----------------------------------------------------------------------- |
-| `Buy`, `Sell`                        | Share or fund acquisitions and disposals, with commission               |
-| `Dividend`, `Payment in Lieu`        | Dividend income                                                         |
-| `Foreign Tax Withholding`            | Tax deducted at source; treated as dividend tax                         |
-| `Credit Interest`                    | Interest income                                                         |
-| `Deposit`, `Withdrawal`              | Cash movements used by the balance check                                |
-| `Other Fee`, `Forex Trade Component` | Charged against the cash balance as fees; no security is bought or sold |
-| `Adjustment`                         | Cash-balance adjustments such as `FX Translations P&L`                  |
+| Transaction type                      | How cgt-calc handles it                                   |
+| ------------------------------------- | --------------------------------------------------------- |
+| `Buy`, `Sell`                         | Share or fund acquisitions and disposals, with commission |
+| `Dividend`, `Payment in Lieu`         | Dividend income                                           |
+| `Foreign Tax Withholding`             | Tax deducted at source; treated as dividend tax           |
+| `Credit Interest`                     | Interest income                                           |
+| `Deposit`, `Withdrawal`               | Cash movements used by the balance check                  |
+| `Other Fee`                           | A charge against a holding, added to its pooled cost      |
+| `Adjustment`, `Forex Trade Component` | Cash-balance adjustments such as `FX Translations P&L`    |
 
 For a GBP-base account, IBKR reports gross amounts, commissions and net amounts in GBP. When the CSV
 also supplies `Price Currency` and `Exchange Rate`, cgt-calc converts a foreign-currency unit price

--- a/tests/interactive_brokers/data/expected_output.txt
+++ b/tests/interactive_brokers/data/expected_output.txt
@@ -2,7 +2,7 @@ Final portfolio
   CNX1: 2.00
 
 Final balance
-  Interactive Brokers: 3027.40 (GBP)
+  Interactive Brokers: 3032.40 (GBP)
 
 Dividends
   IBKR: 1.00, excluding 0.15 taxed at source (GBP)

--- a/tests/interactive_brokers/data/test_basic.csv
+++ b/tests/interactive_brokers/data/test_basic.csv
@@ -14,6 +14,7 @@ Transaction History,Data,2025-11-30,U***00000,FX Translations P&L,Adjustment,-,-
 Transaction History,Data,2025-10-01,U***00000,IBKR(US45841N1072) Payment in Lieu of Dividend (Ordinary Dividend),Payment in Lieu,IBKR,-,-,1.0,-,1.0
 Transaction History,Data,2025-10-01,U***00000,IBKR(US45841N1072) Payment in Lieu of Dividend - US Tax,Foreign Tax Withholding,IBKR,-,-,-0.15,-,-0.15
 Transaction History,Data,2025-10-01,U***00000,Net Amount in Base from Forex Trade: 0.8 GBP.USD,Forex Trade Component,GBP.USD,0.8,1.32,-2.637591265E-4,-,-2.637591265E-4
+Transaction History,Data,2025-10-01,U***00000,Net Amount in Base from Forex Trade: 1.5 GBP.USD,Forex Trade Component,GBP.USD,1.5,1.32,5.0,-,5.0
 Transaction History,Data,2025-08-15,U***00000,ISHARES NASDAQ 100 USD ACC,Sell,CNX1,-2.0,1001.00,2002.0,-3.0,1999.0
 Transaction History,Data,2025-03-15,U***00000,ISHARES NASDAQ 100 USD ACC,Buy,CNX1,4.0,1000.0,-4000.0,-3.0,-4003.0
 Transaction History,Data,2025-02-08,U***00000,CANCEL WITHHOLDING ON Credit Interest for Feb-2025,Foreign Tax Withholding,-,-,-,3.9,-,3.9

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -226,6 +226,93 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
         assert transactions[0].quantity is None
         assert transactions[0].price is None
 
+    @pytest.mark.parametrize("net_amount", ["5.0", "-5.0"])
+    def test_forex_trade_component_adjusts_the_balance_only(
+        self, tmp_path: Path, net_amount: str
+    ) -> None:
+        """The base-currency leg of an FX trade is not a fee.
+
+        IBKR reports it under the currency pair as a "Forex Trade Component",
+        and its Net Amount is positive when the trade brings base currency in
+        and negative when it takes it out. Read as a fee it was rejected
+        outright on the positive side, and on the negative side it built a
+        zero-quantity pooled cost for a symbol that is a currency pair rather
+        than a security. It belongs with the other balance-only adjustments.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header
+            + f"Transaction History,Data,2025-10-01,U***00000,Net Amount in Base from Forex Trade: 0.8 GBP.USD,Forex Trade Component,GBP.USD,0.8,1.32,{net_amount},-,{net_amount}\n"
+        )
+
+        transactions = InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert len(transactions) == 1
+        assert transactions[0].action == ActionType.ADJUSTMENT
+        assert transactions[0].amount == Decimal(net_amount)
+        # The currency pair is not a security, and without a symbol, quantity
+        # or price the row cannot become an acquisition, a disposal or a fee
+        # however it is grouped downstream.
+        assert transactions[0].symbol is None
+        assert transactions[0].quantity is None
+        assert transactions[0].price is None
+        assert transactions[0].fees == Decimal(0)
+        # The description still says which pair it came from.
+        assert transactions[0].description == (
+            "Net Amount in Base from Forex Trade: 0.8 GBP.USD"
+        )
+
+    def test_forex_trade_components_reach_the_final_balance(
+        self, tmp_path: Path
+    ) -> None:
+        """Both signs move the cash balance and nothing else.
+
+        A full run is what proves it: the positive component used to abort the
+        calculation outright, and neither sign may leave a holding or a fee day
+        behind for a currency pair.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header
+            + "Transaction History,Data,2025-01-01,U***00000,Electronic Fund Transfer,Deposit,-,-,-,1000.0,-,1000.0\n"
+            + "Transaction History,Data,2025-10-01,U***00000,Net Amount in Base from Forex Trade: 0.8 GBP.USD,Forex Trade Component,GBP.USD,0.8,1.32,5.0,-,5.0\n"
+            + "Transaction History,Data,2025-10-02,U***00000,Net Amount in Base from Forex Trade: 1.5 GBP.USD,Forex Trade Component,GBP.USD,1.5,1.32,-2.0,-,-2.0\n"
+        )
+
+        cmd = build_cmd(
+            "--year",
+            "2025",
+            "--interactive-brokers-file",
+            str(csv_file),
+            "--output",
+            str(tmp_path / "out"),
+        )
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode:
+            pytest.fail(
+                "Integration test failed\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+        assert stderr_alerts(result.stderr) == []
+        assert "Final balance\n  Interactive Brokers: 1003.00 (GBP)" in result.stdout
+        assert "GBP.USD" not in result.stdout
+
+    def test_other_fee_is_still_a_fee(self, tmp_path: Path) -> None:
+        """A fee charged against a holding keeps increasing its pooled cost."""
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header
+            + "Transaction History,Data,2025-10-01,U***00000,CNX1 ADR Fee,Other Fee,CNX1,-,-,-1.5,-,-1.5\n"
+        )
+
+        transactions = InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert len(transactions) == 1
+        assert transactions[0].action == ActionType.FEE
+        assert transactions[0].symbol == "CNX1"
+        assert transactions[0].amount == Decimal("-1.5")
+
     def test_buy_before_same_day_sell_does_not_go_negative(
         self, tmp_path: Path
     ) -> None:

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -226,56 +226,64 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
         assert transactions[0].quantity is None
         assert transactions[0].price is None
 
-    @pytest.mark.parametrize("net_amount", ["5.0", "-5.0"])
-    def test_forex_trade_component_adjusts_the_balance_only(
-        self, tmp_path: Path, net_amount: str
+    def test_forex_trade_component_is_an_adjustment_not_a_fee(
+        self, tmp_path: Path
     ) -> None:
-        """The base-currency leg of an FX trade is not a fee.
+        """The base-currency leg of an FX trade is not a charge on a holding.
 
-        IBKR reports it under the currency pair as a "Forex Trade Component",
-        and its Net Amount is positive when the trade brings base currency in
-        and negative when it takes it out. Read as a fee it was rejected
-        outright on the positive side, and on the negative side it built a
-        zero-quantity pooled cost for a symbol that is a currency pair rather
-        than a security. It belongs with the other balance-only adjustments.
+        IBKR files it under the currency pair as a "Forex Trade Component",
+        with a Net Amount that is positive when the trade brings base currency
+        in and negative when it takes some out. Read as a fee, the positive
+        direction is rejected outright, and either way a currency pair is not
+        a security to attach a cost to. "Other Fee", which is a charge on a
+        holding, keeps its old meaning.
         """
         csv_file = tmp_path / "transactions.csv"
         csv_file.write_text(
             self.base_header
-            + f"Transaction History,Data,2025-10-01,U***00000,Net Amount in Base from Forex Trade: 0.8 GBP.USD,Forex Trade Component,GBP.USD,0.8,1.32,{net_amount},-,{net_amount}\n"
+            + "Transaction History,Data,2025-10-01,U***00000,Net Amount in Base from Forex Trade: 0.8 GBP.USD,Forex Trade Component,GBP.USD,0.8,1.32,5.0,-0.5,4.5\n"
+            + "Transaction History,Data,2025-10-02,U***00000,Net Amount in Base from Forex Trade: 1.5 GBP.USD,Forex Trade Component,GBP.USD,1.5,1.32,-2.0,-,-2.0\n"
+            + "Transaction History,Data,2025-10-03,U***00000,CNX1 ADR Fee,Other Fee,CNX1,-,-,-1.5,-,-1.5\n"
         )
 
         transactions = InteractiveBrokersParser().load_from_file(csv_file)
 
-        assert len(transactions) == 1
-        assert transactions[0].action == ActionType.ADJUSTMENT
-        assert transactions[0].amount == Decimal(net_amount)
-        # The currency pair is not a security, and without a symbol, quantity
-        # or price the row cannot become an acquisition, a disposal or a fee
-        # however it is grouped downstream.
-        assert transactions[0].symbol is None
-        assert transactions[0].quantity is None
-        assert transactions[0].price is None
-        assert transactions[0].fees == Decimal(0)
-        # The description still says which pair it came from.
-        assert transactions[0].description == (
-            "Net Amount in Base from Forex Trade: 0.8 GBP.USD"
-        )
+        assert [t.action for t in transactions] == [
+            ActionType.ADJUSTMENT,
+            ActionType.ADJUSTMENT,
+            ActionType.FEE,
+        ]
+        assert [t.amount for t in transactions] == [
+            Decimal("4.5"),
+            Decimal("-2.0"),
+            Decimal("-1.5"),
+        ]
+        # Both signs keep nothing that could be read as a security, and the
+        # description still says which pair the movement came from.
+        for adjustment in transactions[:2]:
+            assert (adjustment.symbol, adjustment.quantity, adjustment.price) == (
+                None,
+                None,
+                None,
+            )
+            assert adjustment.fees == Decimal(0)
+            assert adjustment.description.startswith("Net Amount in Base from Forex")
+        assert transactions[2].symbol == "CNX1"
 
-    def test_forex_trade_components_reach_the_final_balance(
+    def test_forex_trade_component_leaves_no_fee_in_the_report(
         self, tmp_path: Path
     ) -> None:
-        """Both signs move the cash balance and nothing else.
+        """A currency pair must not reach the report as a holding with a cost.
 
-        A full run is what proves it: the positive component used to abort the
-        calculation outright, and neither sign may leave a holding or a fee day
-        behind for a currency pair.
+        The pooled cost a fee opens is invisible in the printed summary when
+        the quantity is zero, so the rendered report is what shows it: on the
+        fee path this run writes a "Management fee for GBP.USD" section for a
+        symbol that is not a security.
         """
         csv_file = tmp_path / "transactions.csv"
         csv_file.write_text(
             self.base_header
             + "Transaction History,Data,2025-01-01,U***00000,Electronic Fund Transfer,Deposit,-,-,-,1000.0,-,1000.0\n"
-            + "Transaction History,Data,2025-10-01,U***00000,Net Amount in Base from Forex Trade: 0.8 GBP.USD,Forex Trade Component,GBP.USD,0.8,1.32,5.0,-,5.0\n"
             + "Transaction History,Data,2025-10-02,U***00000,Net Amount in Base from Forex Trade: 1.5 GBP.USD,Forex Trade Component,GBP.USD,1.5,1.32,-2.0,-,-2.0\n"
         )
 
@@ -295,23 +303,8 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
                 f"stderr:\n{result.stderr}"
             )
         assert stderr_alerts(result.stderr) == []
-        assert "Final balance\n  Interactive Brokers: 1003.00 (GBP)" in result.stdout
-        assert "GBP.USD" not in result.stdout
-
-    def test_other_fee_is_still_a_fee(self, tmp_path: Path) -> None:
-        """A fee charged against a holding keeps increasing its pooled cost."""
-        csv_file = tmp_path / "transactions.csv"
-        csv_file.write_text(
-            self.base_header
-            + "Transaction History,Data,2025-10-01,U***00000,CNX1 ADR Fee,Other Fee,CNX1,-,-,-1.5,-,-1.5\n"
-        )
-
-        transactions = InteractiveBrokersParser().load_from_file(csv_file)
-
-        assert len(transactions) == 1
-        assert transactions[0].action == ActionType.FEE
-        assert transactions[0].symbol == "CNX1"
-        assert transactions[0].amount == Decimal("-1.5")
+        assert "Final balance\n  Interactive Brokers: 998.00 (GBP)" in result.stdout
+        assert "GBP.USD" not in (tmp_path / "out.tex").read_text(encoding="utf-8")
 
     def test_buy_before_same_day_sell_does_not_go_negative(
         self, tmp_path: Path


### PR DESCRIPTION
Fixes #951.

`Forex Trade Component` shared the `ActionType.FEE` branch with `Other Fee`, so the base-currency
cash leg of an FX trade was read as a cost attached to a security. Both signs were wrong:

- A positive Net Amount (the trade brings base currency in) aborts the whole run in
  `add_management_fee` with `Fee amount must not be positive: a positive fee would reduce the pooled
  cost`, so nothing else in the file gets calculated.
- A negative one opens a pooled cost under the currency pair. It is invisible in the printed
  summary because the quantity is zero, but the report grows a `Management fee for GBP.USD` section
  for a symbol that is not a security. `tests/interactive_brokers/data/test_basic.csv` already has
  such a row, so the report generated from it carries one today.

It is now an `ActionType.ADJUSTMENT`, alongside the FX Translations P&L adjustment the parser
already handled that way, so `main` adds Net Amount to the cash balance and does nothing else. The
literal transaction types are still matched exactly and anything unrecognised still raises
`ParsingError`, so FX derivatives and the rest stay out.

One judgement call, happy to flip it: the normalisation of `symbol`, `quantity`, `price` and `fees`
is keyed on the action rather than on the literal type string. An adjustment is balance-only by
definition and `main` reads only its amount, so those columns are meaningless on any of them, and
`Adjustment` rows already arrive with `-` in all of them, which makes it a no-op there. Narrowing it
to `Forex Trade Component` would mean threading the type string into `__init__`. To be clear about
what it does and does not do: the fee pool came from the FEE mapping, not from the symbol, so the
mapping change alone fixes the reported bug. The normalisation is what #951 asks for on top of that,
so a row cannot be read as a security further down.

Tests cover the four cases in the issue. One parser test takes a positive component, a negative one
and an `Other Fee` in a single file and pins the actions, the amounts, the cleared columns and the
retained description. A second runs the calculator and asserts the rendered report has no management
fee for the pair; that assertion is against the `.tex` rather than stdout deliberately, since a
zero-quantity pool never reaches the printed summary. Both fail on the unfixed parser, and dropping
any one of the four normalisation lines turns the suite red.

`tests/interactive_brokers/data/test_basic.csv` gains a positive component too, which puts the
previously fatal path in the end-to-end regression net; `expected_output.txt` moves by the one
balance line. `docs/brokers/interactive-brokers.md` listed the old behaviour in its transaction-type
table, so that row moves as well.

Spotted in passing, not fixed here: `symbol` is read with `row[...] or None` rather than
`_parse_str`, so IBKR's `-` placeholder survives as a literal symbol. An account-level MONTHLY
ACTIVITY FEE (symbol `-`) renders as `Management fee for - of £10.00` on current `main`. Same shape
as this bug, but the obvious fix turns a wrong answer into a hard `get_symbol_or_fail` error for
anyone holding one, so it wants its own decision. Happy to file an issue.

Checks: `CGT_TEST_MODE_STRICT=1 uv run pytest` 837 passed, plus ruff format, ruff check, mypy,
codespell, dprint and harper.

Disclosure: written with AI assistance (Claude). The failure was reproduced against HEAD before
anything was changed, and the new tests were confirmed to fail on the unfixed parser.