### PR TITLE
Guard loop mutation, eq-without-hash and tuple subscripts

### DIFF
--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -229,7 +229,7 @@ class IsinConverter:
         result = {
             data["ticker"]
             for data in json_data
-            if data["exchCode"] in ("LC", "LT", "LI", "LO")
+            if data["exchCode"] in {"LC", "LT", "LI", "LO"}
         }
 
         if result:

--- a/cgt_calc/logging.py
+++ b/cgt_calc/logging.py
@@ -131,7 +131,7 @@ class ColourMessageFormatter(logging.Formatter):
                 lines[1:] = [f"    {line}" for line in lines[1:]]
                 message = "\n".join(lines)
 
-        is_alert = record.levelno in (logging.WARNING, logging.ERROR)
+        is_alert = record.levelno in {logging.WARNING, logging.ERROR}
         if is_alert:
             # Blank lines both sides so alerts stand apart from the progress flow,
             # collapsed to a single blank line within a run of consecutive alerts.

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -342,7 +342,7 @@ class CapitalGainsCalculator:
 
         gbp_amount = self.currency_converter.to_gbp_for(amount, transaction)
         if transaction.action is ActionType.SPIN_OFF:
-            self.spin_off_estimates[(transaction.date, symbol)] += gbp_amount
+            self.spin_off_estimates[transaction.date, symbol] += gbp_amount
         add_to_list(
             self.acquisition_list,
             transaction.date,
@@ -776,13 +776,13 @@ class CapitalGainsCalculator:
             readings = [quantity]
             if transaction.ambiguous_quantity is not None:
                 readings.append(transaction.ambiguous_quantity)
-            groups[(transaction.date, transaction.symbol)].append((index, readings))
+            groups[transaction.date, transaction.symbol].append((index, readings))
 
         settled: set[int] = set()
         for (day, symbol), gifts in groups.items():
             available = Counter(
                 {
-                    reading: classified[(day, symbol, reading)]
+                    reading: classified[day, symbol, reading]
                     for _, readings in gifts
                     for reading in readings
                 }
@@ -1021,7 +1021,7 @@ class CapitalGainsCalculator:
                     Decimal(0)
                 )  # dummy value, this will get filtered out
                 continue
-            new_balance = balance[(transaction.broker, transaction.currency)]
+            new_balance = balance[transaction.broker, transaction.currency]
             if transaction.action is ActionType.TRANSFER:
                 new_balance += get_amount_or_fail(transaction)
             elif transaction.action in [
@@ -1053,29 +1053,29 @@ class CapitalGainsCalculator:
                 symbol = get_symbol_or_fail(transaction)
                 holding_quantity = self.portfolio[symbol].quantity
                 multiplier = (acquired_quantity + holding_quantity) / holding_quantity
-                self.split_list[(symbol, transaction.date)] = multiplier
-                self.split_shares[(symbol, transaction.date)] += acquired_quantity
+                self.split_list[symbol, transaction.date] = multiplier
+                self.split_shares[symbol, transaction.date] += acquired_quantity
                 self.add_acquisition(transaction)
             elif transaction.action in [ActionType.DIVIDEND, ActionType.CAPITAL_GAIN]:
                 amount = get_amount_or_fail(transaction)
                 symbol = get_symbol_or_fail(transaction)
                 currency = transaction.currency
                 new_balance += amount
-                self.dividend_list[(symbol, transaction.date)] += ForeignCurrencyAmount(
+                self.dividend_list[symbol, transaction.date] += ForeignCurrencyAmount(
                     amount, currency
                 )
                 if self.date_in_tax_year(transaction.date):
-                    dividends[(symbol, currency)] += amount
+                    dividends[symbol, currency] += amount
             elif transaction.action is ActionType.DIVIDEND_TAX:
                 amount = get_amount_or_fail(transaction)
                 symbol = get_symbol_or_fail(transaction)
                 currency = transaction.currency
                 new_balance += amount
-                self.dividend_tax_list[(symbol, transaction.date)] += (
+                self.dividend_tax_list[symbol, transaction.date] += (
                     ForeignCurrencyAmount(amount, currency)
                 )
                 if self.date_in_tax_year(transaction.date):
-                    dividends_tax[(symbol, currency)] += amount
+                    dividends_tax[symbol, currency] += amount
             elif transaction.action is ActionType.ADJUSTMENT:
                 amount = get_amount_or_fail(transaction)
                 new_balance += amount
@@ -1083,18 +1083,18 @@ class CapitalGainsCalculator:
                 amount = get_amount_or_fail(transaction)
                 new_balance += amount
                 self.interest_list[
-                    (transaction.broker, transaction.currency, transaction.date)
+                    transaction.broker, transaction.currency, transaction.date
                 ] += ForeignCurrencyAmount(amount, transaction.currency)
                 if self.date_in_tax_year(transaction.date):
-                    interests[(transaction.broker, transaction.currency)] += amount
+                    interests[transaction.broker, transaction.currency] += amount
             elif transaction.action is ActionType.INTEREST_TAX:
                 amount = get_amount_or_fail(transaction)
                 new_balance += amount
                 self.interest_tax_list[
-                    (transaction.broker, transaction.currency, transaction.date)
+                    transaction.broker, transaction.currency, transaction.date
                 ] += ForeignCurrencyAmount(amount, transaction.currency)
                 if self.date_in_tax_year(transaction.date):
-                    interest_taxes[(transaction.broker, transaction.currency)] += amount
+                    interest_taxes[transaction.broker, transaction.currency] += amount
             elif transaction.action is ActionType.WIRE_FUNDS_RECEIVED:
                 amount = get_amount_or_fail(transaction)
                 new_balance += amount
@@ -1144,7 +1144,7 @@ class CapitalGainsCalculator:
                 msg += "\n".join(entries) + "\n"
                 msg += "Tip: If your input file is missing deposits/withdrawals use --no-balance-check."
                 raise CalculationError(msg)
-            balance[(transaction.broker, transaction.currency)] = new_balance
+            balance[transaction.broker, transaction.currency] = new_balance
 
         self.first_pass_report(
             balance,
@@ -1183,7 +1183,7 @@ class CapitalGainsCalculator:
             print()
             print(style_text("Dividends", colour=Style.BRIGHT, emoji="💵"))
             for (symbol, currency), amount in dividends.items():
-                tax = dividends_tax[(symbol, currency)]
+                tax = dividends_tax[symbol, currency]
                 tax_str = (
                     f", excluding {round_decimal(-tax, 2)} taxed at source"
                     if tax < 0
@@ -2087,10 +2087,10 @@ class CapitalGainsCalculator:
                 and currency == last_currency
                 and (date.year, date.month) == (last_date.year, last_date.month)
             ):
-                monthly[(broker, currency, date)] = monthly.pop(
+                monthly[broker, currency, date] = monthly.pop(
                     (broker, currency, last_date)
                 )
-            monthly[(broker, currency, date)] += foreign_amount
+            monthly[broker, currency, date] += foreign_amount
             last_date = date
             last_broker = broker
             last_currency = currency
@@ -2174,7 +2174,7 @@ class CapitalGainsCalculator:
             if not self.date_in_tax_year(date):
                 continue
 
-            tax = self.dividend_tax_list[(symbol, date)]
+            tax = self.dividend_tax_list[symbol, date]
             currency = foreign_amount.currency
             assert currency is not None, f"Dividend for {symbol} has no currency"
 

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -754,11 +754,11 @@ class CapitalGainsCalculator:
             (transaction.date, transaction.symbol, transaction.quantity)
             for transaction in transactions
             if transaction.action
-            in (
+            in {
                 ActionType.TRANSFER_TO_SPOUSE,
                 ActionType.GIFT,
                 ActionType.GIFT_UNCONNECTED,
-            )
+            }
         )
         # Gifts of one symbol on one day all draw on the same rows, and a gift
         # printed before a split can state either of two counts, so which row
@@ -985,7 +985,7 @@ class CapitalGainsCalculator:
         # The parser derived the price without the foreign fees; re-derive it
         # so that amount, price and fees stay mutually consistent.
         if (
-            transaction.action in [ActionType.BUY, ActionType.SELL]
+            transaction.action in {ActionType.BUY, ActionType.SELL}
             and transaction.quantity
             and transaction.amount is not None
         ):
@@ -1024,28 +1024,28 @@ class CapitalGainsCalculator:
             new_balance = balance[transaction.broker, transaction.currency]
             if transaction.action is ActionType.TRANSFER:
                 new_balance += get_amount_or_fail(transaction)
-            elif transaction.action in [
+            elif transaction.action in {
                 ActionType.BUY,
                 ActionType.REINVEST_SHARES,
-            ]:
+            }:
                 new_balance += get_amount_or_fail(transaction)
                 self.add_acquisition(transaction)
-            elif transaction.action in [
+            elif transaction.action in {
                 ActionType.SELL,
                 ActionType.CASH_MERGER,
                 ActionType.FULL_REDEMPTION,
-            ]:
+            }:
                 amount = get_amount_or_fail(transaction)
                 new_balance += amount
                 self.add_disposal(transaction)
             elif transaction.action is ActionType.FEE:
                 new_balance += self.add_management_fee(transaction)
-            elif transaction.action in [
+            elif transaction.action in {
                 ActionType.STOCK_ACTIVITY,
                 ActionType.SPIN_OFF,
                 # Shares arriving from a spouse: a cost, but no cash paid.
                 ActionType.TRANSFER_FROM_SPOUSE,
-            ]:
+            }:
                 self.add_acquisition(transaction)
             elif transaction.action == ActionType.STOCK_SPLIT:
                 # Calculate the multiplier based on portfolio and received shares
@@ -1056,7 +1056,7 @@ class CapitalGainsCalculator:
                 self.split_list[symbol, transaction.date] = multiplier
                 self.split_shares[symbol, transaction.date] += acquired_quantity
                 self.add_acquisition(transaction)
-            elif transaction.action in [ActionType.DIVIDEND, ActionType.CAPITAL_GAIN]:
+            elif transaction.action in {ActionType.DIVIDEND, ActionType.CAPITAL_GAIN}:
                 amount = get_amount_or_fail(transaction)
                 symbol = get_symbol_or_fail(transaction)
                 currency = transaction.currency
@@ -1100,11 +1100,11 @@ class CapitalGainsCalculator:
                 new_balance += amount
             elif transaction.action is ActionType.RENAME:
                 self.add_rename(transaction)
-            elif transaction.action in [
+            elif transaction.action in {
                 ActionType.TRANSFER_TO_SPOUSE,
                 ActionType.GIFT,
                 ActionType.GIFT_UNCONNECTED,
-            ]:
+            }:
                 # Shares leave for no money, so the balance is left alone. A fee
                 # on the row is real money, but these rows are written by hand
                 # in a RAW file, which is its own unfunded "Unknown" ledger, so

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -376,14 +376,14 @@ class CalculationEntry:
                 f"Mismatch: {self.allowable_cost} != "
                 f"{self.amount} + {self.new_pool_cost} (for {self})"
             )
-        elif self.amount >= 0 and self.rule_type not in (
+        elif self.amount >= 0 and self.rule_type not in {
             RuleType.SPIN_OFF,
             RuleType.DIVIDEND,
             RuleType.INTEREST,
             RuleType.INTEREST_TAX,
             RuleType.EXCESS_REPORTED_INCOME_DISTRIBUTION,
             RuleType.RENAME,
-        ):
+        }:
             assert self.gain == self.amount + self.fees - self.allowable_cost, (
                 f"Mismatch: {self.gain} != "
                 f"{self.amount} + {self.fees} - {self.allowable_cost} (for {self})"
@@ -714,7 +714,7 @@ class CapitalGainsReport:
             out += f"\n{style_text(title, colour=Style.BRIGHT)}\n"
             for label, value in rows:
                 line = f"  {label + ':':<{label_width}} {value:>{value_width}}"
-                if label in ("Total gain", "Taxable gain"):
+                if label in {"Total gain", "Taxable gain"}:
                     # The headline figures of the whole report.
                     line = style_text(line, colour=Style.BRIGHT)
                 out += f"{line}\n"

--- a/cgt_calc/parsers/broker_registry.py
+++ b/cgt_calc/parsers/broker_registry.py
@@ -59,16 +59,16 @@ def _transaction_sort_key(
     Everything else keeps its relative order, so the "buys last" ordering that
     some parsers rely on to avoid negative balances is preserved.
     """
-    if transaction.action in (
+    if transaction.action in {
         ActionType.STOCK_ACTIVITY,
         ActionType.TRANSFER_FROM_SPOUSE,
-    ):
+    }:
         order = 0
-    elif transaction.action in (
+    elif transaction.action in {
         ActionType.TRANSFER_TO_SPOUSE,
         ActionType.GIFT,
         ActionType.GIFT_UNCONNECTED,
-    ):
+    }:
         order = 2
     else:
         order = 1

--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -116,9 +116,9 @@ def _action_from_str(action_type: str, buy_sell: str, file: Path) -> ActionType:
         return ActionType.INTEREST
     if action_type == "DIVIDEND":
         return ActionType.DIVIDEND
-    if action_type in ["TOP_UP", "WITHDRAWAL"]:
+    if action_type in {"TOP_UP", "WITHDRAWAL"}:
         return ActionType.TRANSFER
-    if action_type in ["ORDER", "FREESHARE_ORDER"]:
+    if action_type in {"ORDER", "FREESHARE_ORDER"}:
         if buy_sell == "BUY":
             return ActionType.BUY
         if buy_sell == "SELL":
@@ -141,7 +141,7 @@ class FreetradeTransaction(BrokerTransaction):
         symbol = (
             row[FreetradeColumn.TICKER] if row[FreetradeColumn.TICKER] != "" else None
         )
-        if symbol is None and action not in [ActionType.TRANSFER, ActionType.INTEREST]:
+        if symbol is None and action not in {ActionType.TRANSFER, ActionType.INTEREST}:
             raise ParsingError(file, f"No symbol for action: {action}")
 
         # The importer and calculation path below use the exported GBP account
@@ -153,7 +153,7 @@ class FreetradeTransaction(BrokerTransaction):
             )
 
         fees = Decimal(0)
-        if action in [ActionType.SELL, ActionType.BUY]:
+        if action in {ActionType.SELL, ActionType.BUY}:
             quantity = _parse_decimal(row, FreetradeColumn.QUANTITY)
             # These two fields are already in account currency. Total Amount
             # is the cash movement after fees, while the account-currency unit
@@ -169,7 +169,7 @@ class FreetradeTransaction(BrokerTransaction):
             amount = _dividend_amount_in_gbp(row, FreetradeColumn.DIVIDEND_GROSS_AMOUNT)
             quantity, price = None, None
             currency = CurrencyCode("GBP")
-        elif action in [ActionType.TRANSFER, ActionType.INTEREST]:
+        elif action in {ActionType.TRANSFER, ActionType.INTEREST}:
             amount = _parse_decimal(row, FreetradeColumn.TOTAL_AMOUNT)
             quantity, price = None, None
             currency = CurrencyCode("GBP")

--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -75,7 +75,7 @@ class HargreavesLansdownParser(StandardCSVParser, BaseDirParser):
             return ActionType.SELL
         if ref == "INTEREST":
             return ActionType.INTEREST
-        if ref in ("FPC", "MANAGE FEE"):
+        if ref in {"FPC", "MANAGE FEE"}:
             return ActionType.TRANSFER
 
         return None
@@ -183,7 +183,7 @@ class HargreavesLansdownParser(StandardCSVParser, BaseDirParser):
         )
 
         # Live PDF lookup only when needed for buy/sell actions
-        if action_type in [ActionType.BUY, ActionType.SELL]:
+        if action_type in {ActionType.BUY, ActionType.SELL}:
             matching_pdfs = list(
                 file_path.parent.glob(
                     f"{reference}_*.pdf",

--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -72,9 +72,9 @@ def _action_from_str(action_type: str, file_path: Path) -> ActionType:
     # A payment in lieu arrives instead of a dividend when the holding is out on
     # loan. It is the rarer of the two, so a parser that knows it and not the
     # ordinary dividend fails for most holders on their first real statement.
-    if action_type in ["Dividend", "Payment in Lieu"]:
+    if action_type in {"Dividend", "Payment in Lieu"}:
         return ActionType.DIVIDEND
-    if action_type in ["Deposit", "Withdrawal"]:
+    if action_type in {"Deposit", "Withdrawal"}:
         return ActionType.TRANSFER
     if action_type == "Buy":
         return ActionType.BUY
@@ -82,7 +82,7 @@ def _action_from_str(action_type: str, file_path: Path) -> ActionType:
         return ActionType.SELL
     if action_type == "Foreign Tax Withholding":
         return ActionType.DIVIDEND_TAX
-    if action_type in ["Forex Trade Component", "Other Fee"]:
+    if action_type in {"Forex Trade Component", "Other Fee"}:
         return ActionType.FEE
     # "FX Translations P&L": the revaluation of a foreign currency balance, not
     # a trade. It moves the cash balance and creates no taxable event, which is
@@ -229,7 +229,7 @@ class InteractiveBrokersParser(StandardCSVParser):
         # before the dividend it was taken from.
         return (
             transaction.date,
-            transaction.action in (ActionType.BUY, ActionType.DIVIDEND_TAX),
+            transaction.action in {ActionType.BUY, ActionType.DIVIDEND_TAX},
         )
 
     @classmethod

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -91,13 +91,13 @@ class AwardPrices:
 
 def action_from_str(label: str, file: Path) -> ActionType:
     """Convert string label to ActionType."""
-    if label in ["Buy", "Cancel Buy"]:
+    if label in {"Buy", "Cancel Buy"}:
         return ActionType.BUY
 
     if label == "Sell":
         return ActionType.SELL
 
-    if label in [
+    if label in {
         "MoneyLink Transfer",
         "Misc Cash Entry",
         "Service Fee",
@@ -110,38 +110,38 @@ def action_from_str(label: str, file: Path) -> ActionType:
         "MoneyLink Deposit",
         "MoneyLink Adj",  # likely a returned transfer
         "Security Transfer",
-    ]:
+    }:
         return ActionType.TRANSFER
 
     if label == "Stock Plan Activity":
         return ActionType.STOCK_ACTIVITY
 
-    if label in [
+    if label in {
         "Qualified Dividend",
         "Cash Dividend",
         "Qual Div Reinvest",
         "Div Adjustment",
         "Special Qual Div",
         "Non-Qualified Div",
-    ]:
+    }:
         return ActionType.DIVIDEND
 
-    if label in ["NRA Tax Adj", "NRA Withholding", "Foreign Tax Paid"]:
+    if label in {"NRA Tax Adj", "NRA Withholding", "Foreign Tax Paid"}:
         return ActionType.DIVIDEND_TAX
 
     if label == "ADR Mgmt Fee":
         return ActionType.FEE
 
-    if label in ["Adjustment", "IRS Withhold Adj", "Wire Funds Adj"]:
+    if label in {"Adjustment", "IRS Withhold Adj", "Wire Funds Adj"}:
         return ActionType.ADJUSTMENT
 
-    if label in ["Short Term Cap Gain", "Long Term Cap Gain"]:
+    if label in {"Short Term Cap Gain", "Long Term Cap Gain"}:
         return ActionType.CAPITAL_GAIN
 
     if label == "Spin-off":
         return ActionType.SPIN_OFF
 
-    if label in ["Credit Interest", "Bond Interest"]:
+    if label in {"Credit Interest", "Bond Interest"}:
         return ActionType.INTEREST
 
     if label == "Reinvest Shares":
@@ -156,10 +156,10 @@ def action_from_str(label: str, file: Path) -> ActionType:
     if label == "Stock Split":
         return ActionType.STOCK_SPLIT
 
-    if label in ["Cash Merger", "Cash Merger Adj"]:
+    if label in {"Cash Merger", "Cash Merger Adj"}:
         return ActionType.CASH_MERGER
 
-    if label in ["Full Redemption", "Full Redemption Adj"]:
+    if label in {"Full Redemption", "Full Redemption Adj"}:
         return ActionType.FULL_REDEMPTION
 
     raise ParsingError(file, f"Unknown action: '{label}'")

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -243,25 +243,25 @@ def action_from_str(label: str, file: Path) -> ActionType:
     if label in {"Stock Plan Activity", "Deposit"}:
         return ActionType.STOCK_ACTIVITY
 
-    if label in ["Qualified Dividend", "Cash Dividend", "Dividend"]:
+    if label in {"Qualified Dividend", "Cash Dividend", "Dividend"}:
         return ActionType.DIVIDEND
 
-    if label in [
+    if label in {
         "NRA Tax Adj",
         "NRA Withholding",
         "Foreign Tax Paid",
         "Tax Reversal",
         "Tax Withholding",
-    ]:
+    }:
         return ActionType.DIVIDEND_TAX
 
     if label == "ADR Mgmt Fee":
         return ActionType.FEE
 
-    if label in ["Adjustment", "IRS Withhold Adj"]:
+    if label in {"Adjustment", "IRS Withhold Adj"}:
         return ActionType.ADJUSTMENT
 
-    if label in ["Short Term Cap Gain", "Long Term Cap Gain"]:
+    if label in {"Short Term Cap Gain", "Long Term Cap Gain"}:
         return ActionType.CAPITAL_GAIN
 
     if label == "Spin-off":
@@ -686,7 +686,7 @@ class SchwabTransaction(BrokerTransaction):
                     f"{details[names.award_date]} "
                     f"(ID {details[names.award_id]})"
                 )
-        elif row[names.action] in ("Sale", "Forced Quick Sell"):
+        elif row[names.action] in {"Sale", "Forced Quick Sell"}:
             date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
 
             if _restates_acquisitions_only(symbol):
@@ -784,13 +784,13 @@ class SchwabTransaction(BrokerTransaction):
                     file, "Unexpected amount or fees on a gift of shares."
                 )
             description = self.raw_action
-        elif action in [
+        elif action in {
             ActionType.DIVIDEND,
             ActionType.DIVIDEND_TAX,
             # Pure cash movements, e.g. Forced Disbursement wiring out the
             # proceeds of the autosale programme.
             ActionType.TRANSFER,
-        ]:
+        }:
             date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
             price = None
             amount = _decimal_from_str(row[names.amount])
@@ -835,7 +835,7 @@ class SchwabTransaction(BrokerTransaction):
         Missing this costs 54 shares on the two 2023 disposals, and the pool
         stays wrong by that much for every year afterwards.
         """
-        if self.action not in (ActionType.SELL, ActionType.UNCLASSIFIED_GIFT):
+        if self.action not in {ActionType.SELL, ActionType.UNCLASSIFIED_GIFT}:
             return
 
         self._rescale(split_multiplier(self.symbol, self.date))

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -152,7 +152,7 @@ def decimal_or_none(
     """
 
     value = row.get(column)
-    if value is None or value in ("", "Not available"):
+    if value is None or value in {"", "Not available"}:
         return None
     try:
         return Decimal(value)
@@ -162,48 +162,48 @@ def decimal_or_none(
 
 def action_from_str(label: str, file: Path) -> ActionType:
     """Convert label to ActionType."""
-    if label in [
+    if label in {
         "Market buy",
         "Limit buy",
         "Stop buy",
         "Stop limit buy",
-    ]:
+    }:
         return ActionType.BUY
 
-    if label in [
+    if label in {
         "Market sell",
         "Limit sell",
         "Stop sell",
         "Stop limit sell",
-    ]:
+    }:
         return ActionType.SELL
 
-    if label in [
+    if label in {
         "Card credit",
         "Card debit",
         "Card refund",
         "Deposit",
         "Withdrawal",
-    ]:
+    }:
         return ActionType.TRANSFER
 
-    if label in [
+    if label in {
         "Dividend (Ordinary)",
         "Dividend (Dividend)",
         "Dividend (Dividends paid by us corporations)",
         "Dividend (Dividend manufactured payment)",
         "Dividend (Property income distribution)",
         "Dividend adjustment",
-    ]:
+    }:
         return ActionType.DIVIDEND
 
-    if label in [
+    if label in {
         "Interest on cash",
         "Lending interest",
         # Interest distributions from bond and money market funds,
         # taxed as savings income rather than dividends.
         "Dividend (Interest)",
-    ]:
+    }:
         return ActionType.INTEREST
 
     if label == "Stock Split":
@@ -212,11 +212,11 @@ def action_from_str(label: str, file: Path) -> ActionType:
     if label == "Spin off":
         return ActionType.SPIN_OFF
 
-    if label in [
+    if label in {
         "Currency conversion",
         "Result adjustment",
         "Spending cashback",
-    ]:
+    }:
         return ActionType.ADJUSTMENT
 
     raise ParsingError(file, f"Unknown action: {label}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ select = [
   "PGH", # pygrep-hooks
   "PIE", # flake8-pie
   "PL", # pylint
+  "PLR6201", # literal-membership: set literals for membership tests
   "PLW1514", # unspecified-encoding: locale-dependent IO broke Windows once
   "PLW1641", # eq-without-hash: __eq__ without __hash__ makes a class unhashable
   "PT", # flake8-pytest-style

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,9 @@ required-version = ">=0.13.0"
 target-version = "py312"
 
 [tool.ruff.lint]
-# Preview is on only to reach PLW1514; explicit-preview-rules keeps every
-# other preview rule and behaviour change off.
+# Preview is on only to reach the individually selected preview rules below;
+# explicit-preview-rules keeps the rest off, though preview may still sharpen
+# what stable rules catch.
 preview = true
 explicit-preview-rules = true
 select = [
@@ -101,6 +102,7 @@ select = [
   "ARG", # flake8-unused-arguments
   "ASYNC", # flake8-async
   "B", # flake8-bugbear
+  "B909", # loop-iterator-mutation: mutating a collection while iterating it
   "BLE",
   "C", # complexity
   "COM", # flake8-commas
@@ -125,12 +127,14 @@ select = [
   "PIE", # flake8-pie
   "PL", # pylint
   "PLW1514", # unspecified-encoding: locale-dependent IO broke Windows once
+  "PLW1641", # eq-without-hash: __eq__ without __hash__ makes a class unhashable
   "PT", # flake8-pytest-style
   "PTH", # flake8-pathlib
   "PYI", # flake8-pyi
   "RET", # flake8-return
   "RSE", # flake8-raise
   "RUF", # Ruff-specific
+  "RUF031", # incorrectly-parenthesized-tuple-in-subscript
   "S102", # Use of exec detected
   "S103", # bad-file-permissions
   "S108", # hardcoded-temp-file


### PR DESCRIPTION
Enable four more preview rules through the explicit-preview-rules mechanism: `B909` (mutating a collection while iterating it) and `PLW1641` (`__eq__` without `__hash__`) as zero-finding preventive guards, both verified to fire with probes; `RUF031` with its 19 autofixes applied (`d[(a, b)]` → `d[a, b]`); and `PLR6201` with its 47 sites migrated to set-literal membership tests, each reviewed for hashable elements. Also reword the preview comment: explicit-preview-rules gates rule selection only, so preview can still sharpen what stable rules catch.