### PR TITLE
Wait for all six coverage uploads before Codecov reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,12 @@
 codecov:
   notify:
-    # Wait for all test jobs (matrix and Docker) before setting statuses,
-    # so they aren't computed from partial coverage.
-    after_n_builds: 4
+    # Wait for all test jobs (the Ubuntu matrix, macOS, Windows and
+    # Docker) before setting statuses, so they aren't computed from
+    # partial coverage.
+    after_n_builds: 6
 
 comment:
-  after_n_builds: 4
+  after_n_builds: 6
   layout: "reach, diff, flags, components, files"
 
 # Path-based coverage views, shown in the PR comment and the Codecov


### PR DESCRIPTION
The macOS and Windows test jobs added in #963 raised the coverage uploads per commit from four to six, so `after_n_builds: 4` let Codecov compute statuses and the PR comment from partial coverage — possibly before the Windows upload, the only one covering the `msvcrt` locking branch. Config validated against the Codecov schema.