### PR TITLE
Skip blank rows in Freetrade exports and exercise stamp duty

### DIFF
--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -261,6 +261,10 @@ class FreetradeParser(BaseSingleFileParser):
         indexed_rows.reverse()
         transactions: list[BrokerTransaction] = []
         for index, row_raw in indexed_rows:
+            # Exports may end with a blank line, which csv reads as an
+            # empty row rather than a transaction.
+            if not any(row_raw):
+                continue
             row = dict(zip(header, row_raw, strict=False))
             action_type = row.get(FreetradeColumn.TYPE)
             if action_type in IGNORED_TYPES:

--- a/tests/freetrade/data/expected_output.txt
+++ b/tests/freetrade/data/expected_output.txt
@@ -1,10 +1,11 @@
 Final portfolio
   GOOGL: 0.14
+  LLOY: 1000.00
   NDAQ: 2.12
   TSLA: 1.45
 
 Final balance
-  Freetrade: 8945.12 (GBP)
+  Freetrade: 8442.62 (GBP)
 
 Dividends
   NDAQ: 1.10, excluding 0.16 taxed at source (GBP)
@@ -14,6 +15,7 @@ Interest
 
 Portfolio at the end of 2023/2024 tax year
   GOOGL: 0.14, £279.59
+  LLOY: 1,000.00, £502.50
   NDAQ: 2.12, £279.59
   TSLA: 1.45, £944.88
 

--- a/tests/freetrade/data/transactions.csv
+++ b/tests/freetrade/data/transactions.csv
@@ -1,6 +1,7 @@
 Title,Type,Timestamp,Account Currency,Total Amount,Buy / Sell,Ticker,ISIN,Price per Share in Account Currency,Stamp Duty,Quantity,Venue,Order ID,Order Type,Instrument Currency,Total Shares Amount,Price per Share,FX Rate,Base FX Rate,FX Fee (BPS),FX Fee Amount,Dividend Ex Date,Dividend Pay Date,Dividend Eligible Quantity,Dividend Amount Per Share,Dividend Gross Distribution Amount,Dividend Net Distribution Amount,Dividend Withheld Tax Percentage,Dividend Withheld Tax Amount
 S&P 500,ORDER,2024-01-16T10:01:02.811Z,GBP,2930.36,SELL,SPXP,IE00B3YCGJ38,732.59000000,0.00,4.00000000,London Stock Exchange,PEJJSM8NABDD,BASIC,GBP,2930.36,732.59000000,,,0,,,,,,,,,
 Nasdaq,DIVIDEND,2023-12-22T17:11:00.000Z,GBP,0.93,,NDAQ,US6311031081,,,6.36545916,,,,USD,,,,0.78491703,0,0.00,2023-12-07,2023-12-22,6.36545916,0.22000000,1.40,1.19,15,0.21
+Lloyds,ORDER,2023-11-06T09:30:00.000Z,GBP,502.50,BUY,LLOY,GB0008706128,0.50000000,2.50,1000.00000000,London Stock Exchange,QWK3M7NP5RTZ,BASIC,GBP,500.00,0.50000000,,,,,,,,,,,,
 Interest,INTEREST_FROM_CASH,2023-10-16T00:00:00.000Z,GBP,9.02,,,,,,,,,,,,,,,,,,,,,,,,
 Nasdaq,DIVIDEND,2022-03-25T02:35:00.000Z,GBP,0.74,,NDAQ,US6311031081,,,2.12181972,,,,USD,,,,0.76110000,0,0.00,2022-03-10,2022-03-25,2.12181972,0.54000000,1.15,0.97,15,0.18
 Tesla,ORDER,2022-02-01T15:14:23.014Z,GBP,5.59,BUY,TSLA,US88160R1014,678.77225238,0.00,0.00819126,Drivewealth,AMN762KCC2G3,MARKET,USD,7.50,915.61000000,1.34403451,1.35011000,45,0.03,,,,,,,,

--- a/tests/freetrade/test_freetrade.py
+++ b/tests/freetrade/test_freetrade.py
@@ -268,6 +268,18 @@ def test_read_freetrade_ignores_document_rows(
     )
 
 
+def test_read_freetrade_skips_blank_rows(tmp_path: Path) -> None:
+    """Blank and comma-only lines in an export are not transactions."""
+    blank_row: list[str] = []
+    empty_fields_row = [""] * len(COLUMNS)
+    path = _write_csv(tmp_path, COLUMNS, [_default_row(), blank_row, empty_fields_row])
+
+    transactions = FreetradeParser().load_from_file(path)
+
+    assert len(transactions) == 1
+    assert transactions[0].action is ActionType.BUY
+
+
 @pytest.mark.parametrize(
     ("buy_sell", "total_amount", "expected_amount"),
     [


### PR DESCRIPTION
- A blank or comma-only line in a Freetrade export now parses as no row instead of crashing with a bare `KeyError`.
- The e2e fixture gains a buy with non-zero stamp duty, so the assumption that Total Amount includes it is exercised against the amount consistency check.