### PR TITLE
Match splits by the report symbol instead of rename order

### DIFF
--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -239,7 +239,7 @@ class MSSBParser(StandardCSVParser, BaseDirParser):
                 row[WithdrawalColumn.EXECUTION_DATE], "%d-%b-%Y"
             ).date(),
             action=action,
-            symbol=symbol,
+            symbol=TICKER_RENAMES.get(symbol, symbol),
             description=plan,
             quantity=quantity,
             price=price,
@@ -249,16 +249,20 @@ class MSSBParser(StandardCSVParser, BaseDirParser):
             broker=BROKER_NAME,
         )
 
-        # Splits are keyed by the symbol the report uses, so rename afterwards.
-        transaction = MSSBParser._handle_stock_split(transaction)
-        transaction.symbol = TICKER_RENAMES.get(symbol, symbol)
-        return transaction
+        return MSSBParser._handle_stock_split(transaction, report_symbol=symbol)
 
     @staticmethod
-    def _handle_stock_split(transaction: BrokerTransaction) -> BrokerTransaction:
+    def _handle_stock_split(
+        transaction: BrokerTransaction, report_symbol: str
+    ) -> BrokerTransaction:
+        """Adjust pre-split sales, keyed by the symbol the report uses.
+
+        Splits are matched on ``report_symbol`` rather than the transaction's,
+        which a ``TICKER_RENAMES`` entry may have renamed.
+        """
         for split in STOCK_SPLIT_INFO:
             if (
-                transaction.symbol == split.symbol
+                report_symbol == split.symbol
                 and transaction.action == ActionType.SELL
                 and transaction.date <= split.date
             ):

--- a/tests/morgan_stanley/test_mssb.py
+++ b/tests/morgan_stanley/test_mssb.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType
 from cgt_calc.parsers.mssb import (
@@ -67,8 +66,7 @@ def test_read_mssb_release_success(tmp_path: Path) -> None:
 
     assert len(transactions) == 1
     transaction = transactions[0]
-    expected_symbol = TICKER_RENAMES.get("GOOG", "GOOG")
-    assert transaction.symbol == expected_symbol
+    assert transaction.symbol == "GOOG"
     assert transaction.action == ActionType.STOCK_ACTIVITY
     assert transaction.quantity == Decimal(3)
     assert transaction.price == Decimal("10.00")
@@ -180,7 +178,7 @@ def test_read_mssb_withdrawal_goog_sale_split_adjustment(
     assert len(transactions) == 1
     transaction = transactions[0]
     assert transaction.action == ActionType.SELL
-    assert transaction.symbol == TICKER_RENAMES.get("GOOG", "GOOG")
+    assert transaction.symbol == "GOOG"
     assert transaction.quantity == Decimal("40.00")
     assert transaction.price == Decimal("112.00")
 

--- a/tests/morgan_stanley/test_mssb.py
+++ b/tests/morgan_stanley/test_mssb.py
@@ -183,6 +183,43 @@ def test_read_mssb_withdrawal_goog_sale_split_adjustment(
     assert transaction.price == Decimal("112.00")
 
 
+def test_read_mssb_withdrawal_split_matches_report_symbol_not_renamed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Adjust a pre-split sale even when its ticker is renamed.
+
+    Splits are keyed by the symbol the report prints, so a TICKER_RENAMES
+    entry for it must not stop the adjustment from applying.
+    """
+    monkeypatch.setattr("cgt_calc.parsers.mssb.TICKER_RENAMES", {"GOOG": "GOOGL"})
+
+    withdrawal_file = tmp_path / WITHDRAWALS_REPORT_FILENAME
+    rows = [
+        COLUMNS_WITHDRAWAL,
+        [
+            "01-Jul-2022",
+            "ORDER-4",
+            "GSU Class C",
+            "Sale",
+            "Complete",
+            "$2,240.00",
+            "-2.00",
+            "$4,479.90",
+            "0",
+            "N/A",
+        ],
+    ]
+    _write_csv(withdrawal_file, rows)
+
+    transactions = MSSBParser().load_from_dir(tmp_path)
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert transaction.symbol == "GOOGL"
+    assert transaction.quantity == Decimal("40.00")
+    assert transaction.price == Decimal("112.00")
+
+
 def test_read_mssb_withdrawal_invalid_decimal(tmp_path: Path) -> None:
     """Raise parsing error when numeric values cannot be parsed."""
 


### PR DESCRIPTION
- The withdrawal report applies `TICKER_RENAMES` where the symbol is computed and passes the report symbol to `_handle_stock_split` explicitly, instead of mutating the transaction after split handling and relying on the call order.
- The tests assert the literal "GOOG" rather than restating the rename mapping.