### PR TITLE
Print withheld dividend tax that has no matching dividend

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -1179,16 +1179,19 @@ class CapitalGainsCalculator:
         print(style_text("Final balance", colour=Style.BRIGHT, emoji="💰"))
         for (broker, currency), amount in balance.items():
             print(f"{bul}{broker}: {round_decimal(amount, 2)} ({currency})")
-        if dividends:
+        if dividends or dividends_tax:
             print()
             print(style_text("Dividends", colour=Style.BRIGHT, emoji="💵"))
-            for (symbol, currency), amount in dividends.items():
-                tax = dividends_tax[symbol, currency]
-                tax_str = (
-                    f", excluding {round_decimal(-tax, 2)} taxed at source"
-                    if tax < 0
-                    else ""
+            # Withholding can arrive without income in the same run, so taxed
+            # symbols are listed even when no dividend was paid.
+            keys = list(dividends)
+            keys += [key for key in dividends_tax if key not in dividends]
+            for symbol, currency in keys:
+                amount = dividends.get((symbol, currency), Decimal(0))
+                tax = round_decimal(
+                    -dividends_tax.get((symbol, currency), Decimal(0)), 2
                 )
+                tax_str = f", excluding {tax} taxed at source" if tax > 0 else ""
                 print(
                     f"{bul}{symbol}: {round_decimal(amount, 2)}{tax_str} ({currency})"
                 )

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -1179,22 +1179,27 @@ class CapitalGainsCalculator:
         print(style_text("Final balance", colour=Style.BRIGHT, emoji="💰"))
         for (broker, currency), amount in balance.items():
             print(f"{bul}{broker}: {round_decimal(amount, 2)} ({currency})")
-        if dividends or dividends_tax:
+        # Withholding can arrive without income in the same run, so taxed
+        # symbols are listed even when no dividend was paid. A tax-only
+        # entry whose withholding rounds to 0.00, or is a net refund, has
+        # nothing to display, so it is left out entirely.
+        keys = list(dividends)
+        keys += [key for key in dividends_tax if key not in dividends]
+        dividend_lines = []
+        for symbol, currency in keys:
+            amount = dividends.get((symbol, currency), Decimal(0))
+            tax = round_decimal(-dividends_tax.get((symbol, currency), Decimal(0)), 2)
+            if (symbol, currency) not in dividends and tax <= 0:
+                continue
+            tax_str = f", excluding {tax} taxed at source" if tax > 0 else ""
+            dividend_lines.append(
+                f"{bul}{symbol}: {round_decimal(amount, 2)}{tax_str} ({currency})"
+            )
+        if dividend_lines:
             print()
             print(style_text("Dividends", colour=Style.BRIGHT, emoji="💵"))
-            # Withholding can arrive without income in the same run, so taxed
-            # symbols are listed even when no dividend was paid.
-            keys = list(dividends)
-            keys += [key for key in dividends_tax if key not in dividends]
-            for symbol, currency in keys:
-                amount = dividends.get((symbol, currency), Decimal(0))
-                tax = round_decimal(
-                    -dividends_tax.get((symbol, currency), Decimal(0)), 2
-                )
-                tax_str = f", excluding {tax} taxed at source" if tax > 0 else ""
-                print(
-                    f"{bul}{symbol}: {round_decimal(amount, 2)}{tax_str} ({currency})"
-                )
+            for line in dividend_lines:
+                print(line)
         if interests:
             print()
             print(style_text("Interest", colour=Style.BRIGHT, emoji="🏦"))

--- a/tests/general/test_first_pass_report.py
+++ b/tests/general/test_first_pass_report.py
@@ -1,0 +1,70 @@
+"""Tests for the dividend section of the first pass report."""
+
+from decimal import Decimal
+
+import pytest
+
+from cgt_calc.currency_converter import CurrencyConverter
+from cgt_calc.current_price_fetcher import CurrentPriceFetcher
+from cgt_calc.initial_prices import InitialPrices
+from cgt_calc.isin_converter import IsinConverter
+from cgt_calc.main import CapitalGainsCalculator
+from cgt_calc.model import CurrencyCode
+from cgt_calc.spin_off_handler import SpinOffHandler
+
+GBP = CurrencyCode("GBP")
+
+
+def _calculator() -> CapitalGainsCalculator:
+    """Create a calculator with no transactions behind it."""
+    currency_converter = CurrencyConverter(None, {})
+    return CapitalGainsCalculator(
+        2024,
+        currency_converter,
+        IsinConverter(),
+        CurrentPriceFetcher(currency_converter, {}, {}),
+        SpinOffHandler(),
+        InitialPrices(),
+        interest_fund_tickers=[],
+        balance_check=False,
+    )
+
+
+def _dividend_lines(
+    capsys: pytest.CaptureFixture[str],
+    dividends: dict[tuple[str, CurrencyCode], Decimal],
+    dividends_tax: dict[tuple[str, CurrencyCode], Decimal],
+) -> list[str]:
+    """Run the report and return the printed dividend lines."""
+    _calculator().first_pass_report({}, dividends, dividends_tax, {}, {})
+    lines = capsys.readouterr().out.splitlines()
+    header = next(i for i, line in enumerate(lines) if "Dividends" in line)
+    section = lines[header + 1 :]
+    return section[: section.index("")] if "" in section else section
+
+
+def test_withholding_without_dividend_is_reported(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Tax withheld on a symbol that paid no dividend still shows up."""
+    dividends = {("NDAQ", GBP): Decimal("1.10")}
+    dividends_tax = {("NDAQ", GBP): Decimal("-0.17"), ("AAPL", GBP): Decimal("-0.30")}
+
+    lines = _dividend_lines(capsys, dividends, dividends_tax)
+
+    assert lines == [
+        "  NDAQ: 1.10, excluding 0.17 taxed at source (GBP)",
+        "  AAPL: 0.00, excluding 0.30 taxed at source (GBP)",
+    ]
+
+
+def test_sub_half_penny_withholding_is_not_reported(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A withholding that rounds to 0.00 does not produce an empty note."""
+    dividends = {("NDAQ", GBP): Decimal("1.10")}
+    dividends_tax = {("NDAQ", GBP): Decimal("-0.004")}
+
+    lines = _dividend_lines(capsys, dividends, dividends_tax)
+
+    assert lines == ["  NDAQ: 1.10 (GBP)"]

--- a/tests/general/test_first_pass_report.py
+++ b/tests/general/test_first_pass_report.py
@@ -38,7 +38,9 @@ def _dividend_lines(
     """Run the report and return the printed dividend lines."""
     _calculator().first_pass_report({}, dividends, dividends_tax, {}, {})
     lines = capsys.readouterr().out.splitlines()
-    header = next(i for i, line in enumerate(lines) if "Dividends" in line)
+    header = next((i for i, line in enumerate(lines) if "Dividends" in line), None)
+    if header is None:
+        return []
     section = lines[header + 1 :]
     return section[: section.index("")] if "" in section else section
 
@@ -68,3 +70,20 @@ def test_sub_half_penny_withholding_is_not_reported(
     lines = _dividend_lines(capsys, dividends, dividends_tax)
 
     assert lines == ["  NDAQ: 1.10 (GBP)"]
+
+
+@pytest.mark.parametrize(
+    "tax",
+    [
+        pytest.param(Decimal("-0.004"), id="rounds-to-zero"),
+        pytest.param(Decimal("0.30"), id="net-refund"),
+        pytest.param(Decimal(0), id="zero"),
+    ],
+)
+def test_undisplayable_tax_without_dividend_prints_no_section(
+    capsys: pytest.CaptureFixture[str], tax: Decimal
+) -> None:
+    """A tax-only entry with nothing to show prints no dividend section."""
+    lines = _dividend_lines(capsys, {}, {("AAPL", GBP): tax})
+
+    assert lines == []


### PR DESCRIPTION
- Withheld dividend tax whose symbol paid no dividend in the run is now listed instead of silently dropped.
- A withholding that rounds to 0.00 no longer prints "excluding 0.00 taxed at source".