### PR TITLE
Support PowerShell completions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,8 +52,8 @@ apt install texlive-latex-base
 
 ## Shell completions
 
-`cgt-calc` can generate a tab completion script for `bash`, `zsh`, `fish` and `tcsh`. Save it where
-your shell looks for completions, e.g.:
+`cgt-calc` can generate a tab completion script for `bash`, `zsh`, `fish`, `tcsh` and PowerShell.
+Save it where your shell looks for completions, e.g.:
 
 ```shell
 # bash
@@ -64,6 +64,20 @@ cgt-calc --print-completion zsh > ~/.zfunc/_cgt-calc
 
 # fish
 cgt-calc --print-completion fish > ~/.config/fish/completions/cgt-calc.fish
+```
+
+For PowerShell, create the completions directory if needed and generate the script:
+
+```powershell
+$completionDir = "$HOME\.config\powershell\completions"
+New-Item -ItemType Directory -Force $completionDir | Out-Null
+cgt-calc --print-completion powershell > "$completionDir\cgt-calc.ps1"
+```
+
+Then add the following line to your PowerShell profile (`$PROFILE`):
+
+```powershell
+. "$HOME\.config\powershell\completions\cgt-calc.ps1"
 ```
 
 Regenerate the script after upgrading to pick up new options.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "yfinance>=1.6.0",
   "openpyxl>=3.1.5",
   "xlrd>=2.0.2",
-  "shtab>=1.11.0",
+  "shtab>=1.12.0",
 ]
 
 [project.urls]

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -34,7 +34,7 @@ ReturnType = TextIO | IO[bytes]
 DirIterator = Iterator[Path]
 
 
-@pytest.mark.parametrize("shell", ["bash", "zsh", "fish", "tcsh"])
+@pytest.mark.parametrize("shell", ["bash", "zsh", "fish", "tcsh", "powershell"])
 def test_print_completion_outputs_script(
     shell: str, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,7 @@ requires-dist = [
     { name = "pdfplumber", specifier = ">=0.11.9" },
     { name = "pyrate-limiter", specifier = ">=4.0.0" },
     { name = "requests", specifier = ">=2.27.1" },
-    { name = "shtab", specifier = ">=1.11.0" },
+    { name = "shtab", specifier = ">=1.12.0" },
     { name = "xlrd", specifier = ">=2.0.2" },
     { name = "yfinance", specifier = ">=1.6.0" },
 ]
@@ -1503,11 +1503,11 @@ wheels = [
 
 [[package]]
 name = "shtab"
-version = "1.11.0"
+version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/1e/6abd32b6c79e64b8e2e2027b05a65ff5215d913997de4fb973f248f79350/shtab-1.11.0.tar.gz", hash = "sha256:57df8a646484b3f00517a42934b173554f827976a77b605ceb6a1a0e649e9266", size = 58653, upload-time = "2026-08-15T21:56:22.304Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/68e4adc2af22d3ff0c4967d52aaac825d33c20467bfd20348526f925e868/shtab-1.12.0.tar.gz", hash = "sha256:46d0b07e6820e3eaaaf95e437a6e89f66a6141dd8bd92da15321939ac692d44d", size = 65967, upload-time = "2026-08-24T16:39:25.477Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/15/81365f3f0e06614bfabdf5b86bc0c4dc0753bdcce29229a40c5742dee2b2/shtab-1.11.0-py3-none-any.whl", hash = "sha256:87c4ccd586a0d98f41c5d15a4a2da4957ea67ba2ec588561fdb803b612bfd032", size = 17483, upload-time = "2026-08-15T21:56:20.874Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/eb/f45d7689298eaf2a49488cf3135464cb6b30e179e9637f99429cd61db7a0/shtab-1.12.0-py3-none-any.whl", hash = "sha256:e377c1451b68ce40abe63b378a389002f0befb2113796a80b047a2bfba0cfb68", size = 22669, upload-time = "2026-08-24T16:39:24.222Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Update `shtab` to 1.12.0, enabling `cgt-calc --print-completion powershell`.
- Cover PowerShell generation in the parser tests and document loading the generated script from `$PROFILE`.