### PR TITLE
Let Dependabot update pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: weekly
     labels:
       - "dependencies"
+  - package-ecosystem: pre-commit
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - "dependencies"
   - package-ecosystem: github-actions
     directories:
       # Workflows in .github/workflows


### PR DESCRIPTION
- Add weekly Dependabot updates for revisions in `.pre-commit-config.yaml`.
- Hook update PRs keep the `dependencies` label and use the existing Kodiak minor/patch automerge policy.