### PR TITLE
Tighten type safety after ty audit

### DIFF
--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -6,12 +6,16 @@ import argparse
 import datetime
 import logging
 from pathlib import Path
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from .const import INTERNAL_START_DATE
 from .version import get_version
 
 STDIN_PATH = Path("-")
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any
 
 LOGGER = logging.getLogger(__name__)
 
@@ -133,11 +137,11 @@ class DeprecatedAction(argparse.Action):
     """Print warning when deprecated argument is used."""
 
     @override
-    def __call__(
+    def __call__(  # type: ignore[explicit-any]
         self,
         parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
-        values: object,
+        values: str | Sequence[Any] | None,
         option_string: str | None = None,
     ) -> None:
         """Check if argument is deprecated."""
@@ -173,11 +177,11 @@ class VersionAction(argparse.Action):
     """
 
     @override
-    def __call__(
+    def __call__(  # type: ignore[explicit-any]
         self,
         parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
-        values: object,
+        values: str | Sequence[Any] | None,
         option_string: str | None = None,
     ) -> None:
         """Print the version and exit."""

--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -6,16 +6,12 @@ import argparse
 import datetime
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, override
+from typing import override
 
 from .const import INTERNAL_START_DATE
 from .version import get_version
 
 STDIN_PATH = Path("-")
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Any
 
 LOGGER = logging.getLogger(__name__)
 
@@ -137,14 +133,15 @@ class DeprecatedAction(argparse.Action):
     """Print warning when deprecated argument is used."""
 
     @override
-    def __call__(  # type: ignore[explicit-any]
+    def __call__(
         self,
-        _parser: argparse.ArgumentParser,
+        parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
-        values: str | Sequence[Any] | None,
+        values: object,
         option_string: str | None = None,
     ) -> None:
         """Check if argument is deprecated."""
+        del parser
         assert isinstance(option_string, str), "Positional arguments are not supported"
         replacements: dict[str, str] = {
             "--freetrade": "--freetrade-file",
@@ -176,13 +173,14 @@ class VersionAction(argparse.Action):
     """
 
     @override
-    def __call__(  # type: ignore[explicit-any]
+    def __call__(
         self,
         parser: argparse.ArgumentParser,
-        _namespace: argparse.Namespace,
-        _values: str | Sequence[Any] | None,
-        _option_string: str | None = None,
+        namespace: argparse.Namespace,
+        values: object,
+        option_string: str | None = None,
     ) -> None:
         """Print the version and exit."""
+        del namespace, values, option_string
         print(f"cgt-calc {get_version()}")
         parser.exit()

--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, override
 
 from .const import INTERNAL_START_DATE
-from .version import get_version
+from .version import DISTRIBUTION_NAME, get_version
 
 STDIN_PATH = Path("-")
 
@@ -145,7 +145,6 @@ class DeprecatedAction(argparse.Action):
         option_string: str | None = None,
     ) -> None:
         """Check if argument is deprecated."""
-        del parser
         assert isinstance(option_string, str), "Positional arguments are not supported"
         replacements: dict[str, str] = {
             "--freetrade": "--freetrade-file",
@@ -185,6 +184,5 @@ class VersionAction(argparse.Action):
         option_string: str | None = None,
     ) -> None:
         """Print the version and exit."""
-        del namespace, values, option_string
-        print(f"cgt-calc {get_version()}")
+        print(f"{DISTRIBUTION_NAME} {get_version()}")
         parser.exit()

--- a/cgt_calc/const.py
+++ b/cgt_calc/const.py
@@ -117,7 +117,7 @@ RENAME_DESCRIPTION_PREFIX: Final = "renamed from "
 # Resource files
 # =============================================================================
 
-PACKAGE_NAME: Final = __package__
+PACKAGE_NAME: Final = "cgt_calc"
 
 # LaTeX template for calculations report
 LATEX_TEMPLATE_RESOURCE: Final = "template.tex.j2"

--- a/cgt_calc/const.py
+++ b/cgt_calc/const.py
@@ -117,7 +117,8 @@ RENAME_DESCRIPTION_PREFIX: Final = "renamed from "
 # Resource files
 # =============================================================================
 
-PACKAGE_NAME: Final = "cgt_calc"
+assert __package__ is not None
+PACKAGE_NAME: Final = __package__
 
 # LaTeX template for calculations report
 LATEX_TEMPLATE_RESOURCE: Final = "template.tex.j2"

--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -369,16 +369,18 @@ class TestCurrencyConverter(CurrencyConverter):
     @staticmethod
     @override
     def _write_exchange_rates_file(
-        _: Path | None, __: dict[datetime.date, dict[CurrencyCode, Decimal]]
+        exchange_rates_file: Path | None,
+        data: dict[datetime.date, dict[CurrencyCode, Decimal]],
     ) -> None:
-        return
+        del exchange_rates_file, data
 
 
 class StrictTestCurrencyConverter(CurrencyConverter):
     """Sandboxed variant of CurrencyConverter that is used to run tests in CI."""
 
     @override
-    def _query_hmrc_api(self, _: datetime.date) -> None:
+    def _query_hmrc_api(self, date: datetime.date) -> None:
+        del date
         raise RuntimeError(
             "HMRC values should be provided for tests to avoid flakiness! "
             "Run `pytest` (once) to populate them from HMRC data"
@@ -387,6 +389,7 @@ class StrictTestCurrencyConverter(CurrencyConverter):
     @staticmethod
     @override
     def _write_exchange_rates_file(
-        _: Path | None, __: dict[datetime.date, dict[CurrencyCode, Decimal]]
+        exchange_rates_file: Path | None,
+        data: dict[datetime.date, dict[CurrencyCode, Decimal]],
     ) -> None:
-        return
+        del exchange_rates_file, data

--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -372,7 +372,7 @@ class TestCurrencyConverter(CurrencyConverter):
         exchange_rates_file: Path | None,
         data: dict[datetime.date, dict[CurrencyCode, Decimal]],
     ) -> None:
-        del exchange_rates_file, data
+        pass
 
 
 class StrictTestCurrencyConverter(CurrencyConverter):
@@ -380,9 +380,8 @@ class StrictTestCurrencyConverter(CurrencyConverter):
 
     @override
     def _query_hmrc_api(self, date: datetime.date) -> None:
-        del date
         raise RuntimeError(
-            "HMRC values should be provided for tests to avoid flakiness! "
+            f"HMRC values missing for {date:%Y-%m}! "
             "Run `pytest` (once) to populate them from HMRC data"
         )
 
@@ -392,4 +391,4 @@ class StrictTestCurrencyConverter(CurrencyConverter):
         exchange_rates_file: Path | None,
         data: dict[datetime.date, dict[CurrencyCode, Decimal]],
     ) -> None:
-        del exchange_rates_file, data
+        pass

--- a/cgt_calc/parsers/eri/importer/invesco.py
+++ b/cgt_calc/parsers/eri/importer/invesco.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from pdfplumber.page import CroppedPage, Page
+    from pdfplumber.pdf import PDF
 
 from cgt_calc.parsers.eri.model import ERITransaction
 
@@ -192,7 +193,7 @@ class InvescoImporter(ERIImporter):
 
     @staticmethod
     # v1 has headers only on the first page
-    def _parse_v1(pdf: pdfplumber.pdf.PDF, file: Path) -> list[ERITransaction] | None:
+    def _parse_v1(pdf: PDF, file: Path) -> list[ERITransaction] | None:
         first_page = pdf.pages[0]
         prefix = "STATEMENT OF REPORTABLE INCOME FOR INVESCO MARKETS II PLC FOR THE PERIOD ENDED"
         if not first_page.search(prefix):
@@ -224,7 +225,7 @@ class InvescoImporter(ERIImporter):
 
     @staticmethod
     # v2 has headers on all pages, and the headers are slightly different
-    def _parse_v2(pdf: pdfplumber.pdf.PDF, file: Path) -> list[ERITransaction] | None:
+    def _parse_v2(pdf: PDF, file: Path) -> list[ERITransaction] | None:
         first_page = pdf.pages[0]
         if not first_page.search("Invesco Markets II plc"):
             return None

--- a/cgt_calc/parsers/eri/importer/invesco.py
+++ b/cgt_calc/parsers/eri/importer/invesco.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
     import datetime
     from pathlib import Path
 
+    from pdfplumber.page import CroppedPage, Page
+
 from cgt_calc.parsers.eri.model import ERITransaction
 
 from .model import ERIImporter, ERIImporterOutput
@@ -44,9 +46,7 @@ class InvescoImporter(ERIImporter):
         super().__init__(name="Invesco")
 
     @staticmethod
-    def _extract_report_end_date(
-        page: pdfplumber.page.Page, prefix: str
-    ) -> datetime.date | None:
+    def _extract_report_end_date(page: Page, prefix: str) -> datetime.date | None:
         matches = [
             line["text"]
             for line in page.extract_text_lines()
@@ -65,7 +65,7 @@ class InvescoImporter(ERIImporter):
 
     @staticmethod
     def _extract_header(
-        page: pdfplumber.page.Page, file: Path, page_num: int
+        page: Page, file: Path, page_num: int
     ) -> tuple[tuple[float, float, float, float], list[float], dict[int, int]]:
         # Useful for debugging:
         # page.to_image(resolution=100).debug_tablefinder().save(f"full_p{page_num}.png")
@@ -116,7 +116,7 @@ class InvescoImporter(ERIImporter):
     @staticmethod
     def _extract_data_rows(
         page_num: int,  # kept for the debug line below
-        cropped: pdfplumber.page.CroppedPage,
+        cropped: CroppedPage,
         columns: list[float],
         file: Path,
     ) -> list[list[str | None]]:

--- a/cgt_calc/parsers/eri/importer/xtrackers.py
+++ b/cgt_calc/parsers/eri/importer/xtrackers.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from pdfplumber.page import CroppedPage, Page
+    from pdfplumber.pdf import PDF
 
 LOGGER = logging.getLogger(__name__)
 
@@ -212,7 +213,7 @@ class XtrackersImporter(ERIImporter):
 
     @staticmethod
     def _parse_pages(
-        pdf: pdfplumber.pdf.PDF,
+        pdf: PDF,
         reporting_period_end: datetime.date,
         file: Path,
     ) -> list[ERITransaction]:
@@ -232,9 +233,7 @@ class XtrackersImporter(ERIImporter):
         return transactions
 
     @staticmethod
-    def _parse_summary_format(
-        pdf: pdfplumber.pdf.PDF, file: Path
-    ) -> list[ERITransaction] | None:
+    def _parse_summary_format(pdf: PDF, file: Path) -> list[ERITransaction] | None:
         """Parse the summary format used by the main Xtrackers umbrella."""
         first_page = pdf.pages[0]
         prefix = "Period ended"
@@ -252,7 +251,7 @@ class XtrackersImporter(ERIImporter):
 
     @staticmethod
     def _parse_investor_report_format(
-        pdf: pdfplumber.pdf.PDF, file: Path
+        pdf: PDF, file: Path
     ) -> list[ERITransaction] | None:
         """Parse the investor report format used by Xtrackers II and (IE) Plc."""
         first_page = pdf.pages[0]

--- a/cgt_calc/parsers/eri/importer/xtrackers.py
+++ b/cgt_calc/parsers/eri/importer/xtrackers.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
     import datetime
     from pathlib import Path
 
+    from pdfplumber.page import CroppedPage, Page
+
 LOGGER = logging.getLogger(__name__)
 
 # Matches both manually renamed reports and the official download names
@@ -82,9 +84,7 @@ class XtrackersImporter(ERIImporter):
         return result
 
     @staticmethod
-    def _extract_report_end_date(
-        page: pdfplumber.page.Page, prefix: str
-    ) -> datetime.date | None:
+    def _extract_report_end_date(page: Page, prefix: str) -> datetime.date | None:
         matches = [
             line["text"]
             for line in page.extract_text_lines()
@@ -101,7 +101,7 @@ class XtrackersImporter(ERIImporter):
 
     @staticmethod
     def _extract_header(
-        page: pdfplumber.page.Page, file: Path, page_num: int
+        page: Page, file: Path, page_num: int
     ) -> tuple[tuple[float, float, float, float], list[float], dict[int, int]]:
         header_table = page.find_table()
         if header_table is None:
@@ -146,7 +146,7 @@ class XtrackersImporter(ERIImporter):
 
     @staticmethod
     def _extract_data_rows(
-        cropped: pdfplumber.page.CroppedPage,
+        cropped: CroppedPage,
         columns: list[float],
         file: Path,
         page_num: int,

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -429,9 +429,12 @@ class Trading212Parser(BaseDirParser):
 
     @staticmethod
     def _by_date_and_action(
-        transaction: Trading212Transaction,
+        transaction: BrokerTransaction,
     ) -> tuple[datetime, bool]:
         """Sort by date and action type."""
+
+        if not isinstance(transaction, Trading212Transaction):
+            raise TypeError("Trading 212 post-processing received another broker's row")
 
         # If there's a deposit in the same second as a buy
         # (happens with the referral award at least)
@@ -445,5 +448,5 @@ class Trading212Parser(BaseDirParser):
     ) -> list[BrokerTransaction]:
         """Remove duplicates and sort."""
         transactions = list(set(transactions))
-        transactions.sort(key=cls._by_date_and_action)  # type: ignore[arg-type]
+        transactions.sort(key=cls._by_date_and_action)
         return transactions

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -433,8 +433,7 @@ class Trading212Parser(BaseDirParser):
     ) -> tuple[datetime, bool]:
         """Sort by date and action type."""
 
-        if not isinstance(transaction, Trading212Transaction):
-            raise TypeError("Trading 212 post-processing received another broker's row")
+        assert isinstance(transaction, Trading212Transaction)
 
         # If there's a deposit in the same second as a buy
         # (happens with the referral award at least)

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -168,7 +168,7 @@ class VanguardTransaction(BrokerTransaction):
 
     is_reversal: bool
     details_text: str
-    source_file: Path
+    source_file: Path | None
 
     def __init__(
         self,
@@ -236,7 +236,7 @@ class VanguardTransaction(BrokerTransaction):
         txn = object.__new__(cls)
         txn.is_reversal = is_reversal
         txn.details_text = ""
-        txn.source_file = None  # type: ignore[assignment]
+        txn.source_file = None
         BrokerTransaction.__init__(
             txn,
             date,

--- a/cgt_calc/version.py
+++ b/cgt_calc/version.py
@@ -18,6 +18,8 @@ GIT_DESCRIBE_TIMEOUT_SECONDS = 5
 # backup tag left behind by a rebase, would name a version that does not exist.
 RELEASE_TAG_GLOB = "v[0-9]*"
 
+DISTRIBUTION_NAME = "cgt-calc"
+
 # Commits since the latest reachable tag, e.g. "v2.0.0-157-g3473d67".
 COMMITS_SINCE_TAG_RE = re.compile(
     r"^(?P<tag>.+)-(?P<distance>\d+)-g(?P<commit>[0-9a-f]+)$"
@@ -35,7 +37,7 @@ def get_version() -> str:
     source checkout carries the placeholder instead, so describe it with git to
     report something that pins down the exact commit.
     """
-    version = importlib.metadata.version(__package__)
+    version = importlib.metadata.version(DISTRIBUTION_NAME)
     if version != PLACEHOLDER_VERSION:
         return version
     return _describe_source_tree() or PLACEHOLDER_VERSION

--- a/tests/eri_importers/test_invesco.py
+++ b/tests/eri_importers/test_invesco.py
@@ -31,7 +31,7 @@ from tests.eri_importers.helpers import check_transaction
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pdfplumber
+    from pdfplumber.page import Page
 
     from cgt_calc.parsers.eri.model import ERITransaction
 
@@ -366,7 +366,7 @@ class _HeaderlessPage:
 
 def test_empty_extracted_header_fails_loudly(tmp_path: Path) -> None:
     """A detected table that extracts to nothing is reported, not indexed."""
-    page = cast("pdfplumber.page.Page", _HeaderlessPage())
+    page = cast("Page", _HeaderlessPage())
 
     with pytest.raises(ParsingError, match="Table header is empty on page 1"):
         InvescoImporter._extract_header(  # noqa: SLF001

--- a/tests/eri_importers/test_xtrackers.py
+++ b/tests/eri_importers/test_xtrackers.py
@@ -25,7 +25,7 @@ from tests.eri_importers.helpers import check_transaction
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pdfplumber
+    from pdfplumber.page import Page
 
     from cgt_calc.parsers.eri.model import ERITransaction
 
@@ -285,7 +285,7 @@ class _HeaderlessPage:
 
 def test_empty_extracted_header_fails_loudly(tmp_path: Path) -> None:
     """A detected table that extracts to nothing is reported, not indexed."""
-    page = cast("pdfplumber.page.Page", _HeaderlessPage())
+    page = cast("Page", _HeaderlessPage())
 
     with pytest.raises(ParsingError, match="Table header is empty on page 1"):
         XtrackersImporter._extract_header(  # noqa: SLF001

--- a/tests/general/test_currency_converter.py
+++ b/tests/general/test_currency_converter.py
@@ -441,5 +441,5 @@ def test_strict_converter_refuses_to_fetch() -> None:
     """The CI converter never calls the HMRC API."""
     converter = StrictTestCurrencyConverter()
 
-    with pytest.raises(RuntimeError, match="provided for tests"):
+    with pytest.raises(RuntimeError, match="HMRC values missing for 2024-01"):
         converter.currency_to_gbp_rate(CurrencyCode("USD"), DATE)

--- a/tests/general/test_model.py
+++ b/tests/general/test_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 import datetime
 from decimal import Decimal
 
@@ -222,9 +223,7 @@ def _transaction_with_fees(
     foreign_fees: dict[CurrencyCode, Decimal],
 ) -> BrokerTransaction:
     transaction = _transaction(None)
-    return BrokerTransaction(
-        **{**vars(transaction), "foreign_fees": foreign_fees},
-    )
+    return replace(transaction, foreign_fees=foreign_fees)
 
 
 def test_broker_transaction_rejects_a_bare_invalid_foreign_fee_currency() -> None:

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -161,10 +161,14 @@ def test_disposal_before_the_split_is_converted(
     year afterwards.
     """
     sale = on(transactions, datetime.date(2023, 1, 23), ActionType.SELL)
+    quantity = sale.quantity
+    price = sale.price
 
-    assert sale.quantity == Decimal(20)
-    assert sale.price == Decimal("19.193")
-    assert sale.quantity * sale.price == Decimal("383.86")
+    assert quantity is not None
+    assert price is not None
+    assert quantity == Decimal(20)
+    assert price == Decimal("19.193")
+    assert quantity * price == Decimal("383.86")
 
 
 def test_disposal_after_the_split_is_left_alone(


### PR DESCRIPTION
- Align overridden callbacks and parser-specific state with their declared runtime contracts.
- Replace ambiguous package and module lookups and untyped test reconstruction with explicit typed equivalents.