### PR TITLE
Skip ISINs with no known ticker when building the symbol map

### DIFF
--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -128,11 +128,18 @@ class IsinConverter:
         return result
 
     def get_symbol_to_isin_map(self) -> dict[str, Isin]:
-        """Return a map from symbols to ISINs."""
+        """Return a map from symbols to ISINs.
+
+        An ISIN whose ticker is unknown is recorded with an empty symbol, so
+        empty entries are skipped here. Keeping them would put an "" key in the
+        map, and every transaction without a symbol - interest, transfers, fees
+        - would then resolve to whichever ISIN happened to own that key.
+        """
         symbol_to_isin = {}
         for isin, symbols in self.data.items():
             for symbol in symbols:
-                symbol_to_isin[symbol] = isin
+                if symbol:
+                    symbol_to_isin[symbol] = isin
         return symbol_to_isin
 
     def _read_isin_translation_data(self) -> None:

--- a/tests/general/test_isin_converter.py
+++ b/tests/general/test_isin_converter.py
@@ -233,6 +233,25 @@ def test_add_from_transaction_adds_mapping() -> None:
     assert converter.get_symbol_to_isin_map()["FOO"] == ISIN_A
 
 
+def test_symbol_map_skips_unknown_tickers() -> None:
+    """An ISIN recorded without a ticker must not claim the empty symbol.
+
+    validate_data deliberately allows an ISIN whose ticker is unknown to be
+    stored with an empty symbol. Letting that into the symbol map gives it an
+    "" key, and callers resolving a transaction with no symbol - interest, a
+    transfer, a fee - would then match that ISIN by accident.
+    """
+    converter = IsinConverter()
+    converter.data[ISIN_A] = {""}
+    converter.data[ISIN_B] = {"FOO"}
+
+    symbol_map = converter.get_symbol_to_isin_map()
+
+    assert "" not in symbol_map
+    assert ISIN_A not in symbol_map.values()
+    assert symbol_map["FOO"] == ISIN_B
+
+
 def test_translation_file_roundtrip(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
An ISIN whose ticker is not known is stored with an empty symbol, which validate_data explicitly permits, and initial_isin_translation.csv ships one. get_symbol_to_isin_map passed that straight through, so the map gained an "" key pointing at whichever ISIN happened to hold it.

Callers resolve a transaction's ISIN with isin_map.get(trx.symbol or ""), so every transaction that legitimately has no symbol - credit interest, wire transfers, service fees - matched that arbitrary ISIN. The visible effect was ERI rows for a fund the user has never held being pulled into the transaction set.