### PR TITLE
Warn when withheld dividend tax is left out of the report

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -2188,14 +2188,17 @@ class CapitalGainsCalculator:
         and it is reported as if it had never been withheld.
         """
         for (symbol, date), tax in self.dividend_tax_list.items():
-            if not self.date_in_tax_year(date) or not tax.amount:
+            if not self.date_in_tax_year(date):
                 continue
-            if (symbol, date) in self.dividend_list:
+            # Tax that rounds away at report precision cannot change any
+            # figure the report shows, so its absence is not worth a warning.
+            amount = round_decimal(tax.amount, 2)
+            if not amount or (symbol, date) in self.dividend_list:
                 continue
             LOGGER.warning(
                 "Dividend tax of %s %s for %s on %s is not attributed to any "
                 "dividend of that date, so it is left out of the report!",
-                round_decimal(tax.amount, 2),
+                amount,
                 tax.currency,
                 symbol,
                 date,

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -2188,13 +2188,15 @@ class CapitalGainsCalculator:
         and it is reported as if it had never been withheld.
         """
         for (symbol, date), tax in self.dividend_tax_list.items():
-            if not self.date_in_tax_year(date):
+            if not self.date_in_tax_year(date) or not tax.amount:
                 continue
-            # Tax that rounds away at report precision cannot change any
-            # figure the report shows, so its absence is not worth a warning.
-            amount = round_decimal(tax.amount, 2)
-            if not amount or (symbol, date) in self.dividend_list:
+            if (symbol, date) in self.dividend_list:
                 continue
+            # Tax below half a unit would print as a bare "-0.00", so it is
+            # shown as it stands instead. Whether it is material is a question
+            # about its value in GBP, and answering it here would put a rate
+            # lookup, and the failure of one, in the way of a warning.
+            amount = round_decimal(tax.amount, 2) or tax.amount
             LOGGER.warning(
                 "Dividend tax of %s %s for %s on %s is not attributed to any "
                 "dividend of that date, so it is left out of the report!",

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -2179,18 +2179,43 @@ class CapitalGainsCalculator:
             return isin[:ISIN_COUNTRY_CODE_LENGTH]
         return DIVIDEND_CURRENCY_TO_COUNTRY.get(currency)
 
+    def _warn_unattributed_dividend_tax(self) -> None:
+        """Warn about withheld tax that no dividend of the same date claims.
+
+        Withholding is attributed to a dividend of the same symbol and date.
+        A broker that dates a correction apart from the payment it corrects,
+        such as a Schwab ``NRA Tax Adj``, leaves tax that no dividend claims,
+        and it is reported as if it had never been withheld.
+        """
+        for (symbol, date), tax in self.dividend_tax_list.items():
+            if not self.date_in_tax_year(date) or not tax.amount:
+                continue
+            if (symbol, date) in self.dividend_list:
+                continue
+            LOGGER.warning(
+                "Dividend tax of %s %s for %s on %s is not attributed to any "
+                "dividend of that date, so it is left out of the report!",
+                round_decimal(tax.amount, 2),
+                tax.currency,
+                symbol,
+                date,
+            )
+
     def process_dividends(self) -> None:
         """Process all dividend events and taxes.
 
         It updates the interest total for the year if needed.
         """
+        self._warn_unattributed_dividend_tax()
         for (symbol, date), foreign_amount in self.dividend_list.items():
             # Dividends outside the computed tax year are not reported, so
             # neither are the warnings raised while resolving their treaty.
             if not self.date_in_tax_year(date):
                 continue
 
-            tax = self.dividend_tax_list[symbol, date]
+            # Read without inserting: a dividend with no tax must not leave a
+            # zero entry behind in the withholding log.
+            tax = self.dividend_tax_list.get((symbol, date), ForeignCurrencyAmount())
             currency = foreign_amount.currency
             assert currency is not None, f"Dividend for {symbol} has no currency"
 

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -1,0 +1,137 @@
+"""Tests for attributing withheld tax to the dividend it was taken from."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+import logging
+from typing import TYPE_CHECKING
+
+from cgt_calc.currency_converter import CurrencyConverter
+from cgt_calc.current_price_fetcher import CurrentPriceFetcher
+from cgt_calc.initial_prices import InitialPrices
+from cgt_calc.isin_converter import IsinConverter
+from cgt_calc.main import CapitalGainsCalculator
+from cgt_calc.model import CurrencyCode
+from cgt_calc.spin_off_handler import SpinOffHandler
+
+from .calc_test_data import dividend_tax_transaction, dividend_transaction
+
+if TYPE_CHECKING:
+    import pytest
+
+    from cgt_calc.model import BrokerTransaction
+
+USD = CurrencyCode("USD")
+
+# The tax year under test, two dates inside it a few days apart, and one in an
+# earlier year, so that withholding can be placed on or off its dividend's date
+# and inside or outside the reported year.
+TAX_YEAR = 2024
+DIVIDEND_DATE = datetime.date(2024, 6, 3)
+LATER_DATE = datetime.date(2024, 6, 5)
+EARLIER_YEAR_DATE = datetime.date(2022, 6, 3)
+
+
+def _calculator(transactions: list[BrokerTransaction]) -> CapitalGainsCalculator:
+    """Create a calculator with a flat 1:1 USD rate for the dates in use."""
+    gbp_prices = {t.date: {USD: Decimal(1)} for t in transactions}
+    currency_converter = CurrencyConverter(None, gbp_prices)
+    return CapitalGainsCalculator(
+        TAX_YEAR,
+        currency_converter,
+        IsinConverter(),
+        CurrentPriceFetcher(currency_converter, {}, {}),
+        SpinOffHandler(),
+        InitialPrices(),
+        interest_fund_tickers=[],
+        balance_check=False,
+    )
+
+
+def _unattributed_warnings(
+    transactions: list[BrokerTransaction],
+    caplog: pytest.LogCaptureFixture,
+) -> list[str]:
+    """Run the dividend pass and return the unattributed tax warnings."""
+    calculator = _calculator(transactions)
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
+        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.process_dividends()
+    return [
+        record.message
+        for record in caplog.records
+        if "is not attributed to any dividend" in record.message
+    ]
+
+
+def test_withholding_on_its_dividend_date_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tax taken on the day of its dividend is attributed, so it is silent."""
+    transactions = [
+        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(DIVIDEND_DATE, "FOO", 15),
+    ]
+
+    assert _unattributed_warnings(transactions, caplog) == []
+
+
+def test_withholding_dated_apart_from_its_dividend_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tax dated apart from its dividend is left out, so it is reported."""
+    transactions = [
+        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(LATER_DATE, "FOO", 15),
+    ]
+
+    warnings = _unattributed_warnings(transactions, caplog)
+
+    assert len(warnings) == 1
+    assert "-15.00 USD for FOO on 2024-06-05" in warnings[0]
+
+
+def test_withholding_without_any_dividend_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tax for a symbol that paid no dividend at all is reported."""
+    transactions = [dividend_tax_transaction(DIVIDEND_DATE, "FOO", 15)]
+
+    warnings = _unattributed_warnings(transactions, caplog)
+
+    assert len(warnings) == 1
+    assert "-15.00 USD for FOO on 2024-06-03" in warnings[0]
+
+
+def test_unattributed_withholding_outside_tax_year_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Only withholding of the computed year may warn, as for the treaty."""
+    transactions = [
+        dividend_transaction(EARLIER_YEAR_DATE, "FOO", 100),
+        dividend_tax_transaction(
+            EARLIER_YEAR_DATE + datetime.timedelta(days=2), "FOO", 15
+        ),
+    ]
+
+    assert _unattributed_warnings(transactions, caplog) == []
+
+
+def test_dividend_without_withholding_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A dividend taxed nowhere leaves no zero entry to warn about."""
+    transactions = [dividend_transaction(DIVIDEND_DATE, "FOO", 100)]
+    calculator = _calculator(transactions)
+
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
+        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.process_dividends()
+
+    assert [
+        record.message
+        for record in caplog.records
+        if "is not attributed to any dividend" in record.message
+    ] == []
+    assert (("FOO", DIVIDEND_DATE)) not in calculator.dividend_tax_list

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -104,16 +104,25 @@ def test_withholding_without_any_dividend_warns(
     assert "-15.00 USD for FOO on 2024-06-03" in warnings[0]
 
 
-def test_unattributed_withholding_rounding_away_does_not_warn(
+def test_unattributed_withholding_below_a_penny_shows_its_own_value(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Tax below report precision cannot change what the report shows."""
+    """Tax too small to round to a penny is shown as it stands, not as zero.
+
+    Whether such an amount is material depends on its value in GBP, which
+    this warning deliberately does not work out, so it reports the loss and
+    leaves that judgement to the reader.
+    """
     transactions = [
         dividend_transaction(DIVIDEND_DATE, "FOO", 100),
         dividend_tax_transaction(LATER_DATE, "FOO", 0.004),
     ]
 
-    assert _unattributed_warnings(transactions, caplog) == []
+    warnings = _unattributed_warnings(transactions, caplog)
+
+    assert len(warnings) == 1
+    assert "of -0.00 USD" not in warnings[0]
+    assert "-0.004" in warnings[0]
 
 
 def test_unattributed_withholding_of_half_a_penny_warns(

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -104,6 +104,33 @@ def test_withholding_without_any_dividend_warns(
     assert "-15.00 USD for FOO on 2024-06-03" in warnings[0]
 
 
+def test_unattributed_withholding_rounding_away_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tax below report precision cannot change what the report shows."""
+    transactions = [
+        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(LATER_DATE, "FOO", 0.004),
+    ]
+
+    assert _unattributed_warnings(transactions, caplog) == []
+
+
+def test_unattributed_withholding_of_half_a_penny_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Half a penny rounds up to one, which the report can show."""
+    transactions = [
+        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(LATER_DATE, "FOO", 0.005),
+    ]
+
+    warnings = _unattributed_warnings(transactions, caplog)
+
+    assert len(warnings) == 1
+    assert "-0.01 USD for FOO" in warnings[0]
+
+
 def test_unattributed_withholding_outside_tax_year_does_not_warn(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
Withholding is attributed to a dividend of the same symbol and date, so tax a broker dates apart from the payment it corrects is silently reported as if it had never been withheld. This warns instead, naming the symbol, date and amount.

Scoped to the computed tax year, as the treaty warning already is. The withholding lookup also stops inserting zero entries for dividends that were never taxed, so an untaxed dividend leaves nothing behind to warn about.

Any non-zero amount is reported. Tax below half a unit is printed as it stands rather than as `-0.00`; whether such an amount is material depends on its value in GBP, and working that out here would put a rate lookup, and the failure of one, in the way of a warning.

Known limitation: withholding dated outside the computed tax year is not warned about, so a dividend paid on 2 April with tax posted on 8 April still reports zero tax silently when computing the earlier year. Attributing the tax correctly, which requires matching independent of tax year, is tracked in #990.
