### PR TITLE
Run ty alongside mypy

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -160,6 +160,7 @@ tranche's
 TransactionDetails
 transferor
 transferor's
+ty
 UCITS
 un
 US9220427424

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,12 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      - id: ty
+        name: ty
+        entry: uv run ty check
+        language: system
+        types: [python]
+        pass_filenames: false
       - id: pytest
         name: pytest
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,13 +50,13 @@ repos:
         require_serial: true
       - id: mypy
         name: mypy
-        entry: uv run mypy cgt_calc tests
+        entry: uv run mypy cgt_calc tests scripts
         language: system
         types: [python]
         pass_filenames: false
       - id: ty
         name: ty
-        entry: uv run ty check
+        entry: uv run ty check cgt_calc tests scripts
         language: system
         types: [python]
         pass_filenames: false

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -203,7 +203,8 @@ Environment variables:
         help="show version and exit",
     )
     shtab.add_argument_to(
-        general_group,  # type: ignore[arg-type]  # groups work like parsers here
+        # Argument groups support the same operation as parsers.
+        general_group,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         "--print-completion",
         help="print shell tab completion script and exit",
     )

--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -130,7 +130,7 @@ def set_completer(
     action: argparse.Action, completer: dict[str, str | dict[str, str]]
 ) -> None:
     """Attach shtab completion hint (e.g. shtab.FILE) to an argparse action."""
-    action.complete = completer  # type: ignore[attr-defined]
+    action.complete = completer  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
 
 
 class DeprecatedAction(argparse.Action):

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -40,6 +40,7 @@ We use:
 
 - [ruff](https://docs.astral.sh/ruff/) — for Python linting and formatting
 - [mypy](https://mypy-lang.org/) — for static type checking
+- [ty](https://docs.astral.sh/ty/) — for additional static type checking
 - [pytest](https://docs.pytest.org/) — for running tests
 - [dprint](https://dprint.dev/) — for formatting Markdown, YAML, TOML, JSON, and Dockerfiles
 - [shfmt](https://github.com/mvdan/sh#shfmt) - for formatting shell scripts
@@ -83,6 +84,7 @@ Or you can run single hook:
 
 ```shell
 prek run mypy --all-files
+prek run ty --all-files
 prek run pytest
 prek run --hook-stage manual python-typing-update --all-files
 ```
@@ -102,6 +104,7 @@ uv run pytest
 uv run pytest -k <expr> -q # run subset
 uv run ruff check .
 uv run mypy cgt_calc
+uv run ty check
 ```
 
 ## Managing dependencies

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -74,6 +74,13 @@ prek install
 
 This will automatically check code style, linting, and types before each commit.
 
+Type suppressions must name the diagnostic for both checkers. When both tools report the same
+intentional violation, keep their targeted comments together:
+
+```python
+value = untyped_value  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+```
+
 You can also run all checks on the repository manually:
 
 ```shell
@@ -103,8 +110,8 @@ You can also run linters and tests directly:
 uv run pytest
 uv run pytest -k <expr> -q # run subset
 uv run ruff check .
-uv run mypy cgt_calc
-uv run ty check
+uv run mypy cgt_calc tests scripts
+uv run ty check cgt_calc tests scripts
 ```
 
 ## Managing dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
   "pytest-xdist>=3.8.0",
   "reportlab>=5.0.1",
   "ruff>=0.16.4",
+  "ty>=0.0.74",
   "types-colorama>=0.4.15.20260508",
   "types-defusedxml>=0.7.0.20260504",
   "types-python-dateutil>=2.9.0.20250822",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
   "pytest-xdist>=3.8.0",
   "reportlab>=5.0.1",
   "ruff>=0.16.4",
-  "ty>=0.0.74",
+  "ty>=0.0.74,<0.1.0",
   "types-colorama>=0.4.15.20260508",
   "types-defusedxml>=0.7.0.20260504",
   "types-python-dateutil>=2.9.0.20250822",
@@ -232,6 +232,12 @@ enable_error_code = [
   "redundant-self",
   "truthy-iterable",
 ]
+
+[tool.ty.environment]
+python-platform = "all"
+
+[tool.ty.rules]
+blanket-ignore-comment = "error"
 
 [tool.codespell]
 quiet-level = 2

--- a/tests/general/test_currency_converter.py
+++ b/tests/general/test_currency_converter.py
@@ -373,7 +373,7 @@ def test_query_hmrc_api_old_endpoint_error_names_rates_file(
         def get(self, url: str, timeout: int) -> NoReturn:
             raise requests_exceptions.ConnectionError(f"offline: {url}")
 
-    converter.session = FailingSession()  # type: ignore[assignment]
+    converter.session = FailingSession()  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
 
     with pytest.raises(ExternalApiError, match=r"rates\.csv") as excinfo:
         converter.currency_to_gbp_rate(CurrencyCode("USD"), datetime.date(2019, 5, 1))
@@ -385,7 +385,7 @@ def test_query_hmrc_api_http_error_includes_snippet() -> None:
     """Include a truncated response body in HTTP errors."""
     converter = CurrencyConverter()
     response = FakeResponse(ok=False, status_code=500, text="x" * 300)
-    converter.session = FakeSession(response)  # type: ignore[assignment]
+    converter.session = FakeSession(response)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
 
     with pytest.raises(ExternalApiError, match="HTTP 500") as excinfo:
         converter.currency_to_gbp_rate(CurrencyCode("USD"), DATE)
@@ -425,7 +425,7 @@ def test_test_converter_records_new_rates(tmp_path: Path) -> None:
     def fake_query(date: datetime.date) -> None:
         converter.cache[date] = {CurrencyCode("USD"): Decimal("1.25")}
 
-    converter._query_hmrc_api = fake_query  # type: ignore[method-assign]  # noqa: SLF001
+    converter._query_hmrc_api = fake_query  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]  # noqa: SLF001
 
     assert converter.currency_to_gbp_rate(CurrencyCode("USD"), DATE) == Decimal("1.25")
     assert "2024-01-01,USD,1.25" in rates_file.read_text(encoding="utf-8")

--- a/tests/general/test_model.py
+++ b/tests/general/test_model.py
@@ -66,7 +66,7 @@ def test_isin_rejects_attribute_assignment() -> None:
     """The value type carries no instance dict."""
     isin = Isin(VALID_ISIN)
     with pytest.raises(AttributeError):
-        isin.symbol = "AAPL"  # type: ignore[attr-defined]
+        isin.symbol = "AAPL"  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
 
 
 def test_isin_parse_returns_none_for_invalid_input() -> None:
@@ -98,12 +98,12 @@ def _transaction(isin: Isin | None, currency: CurrencyCode = USD) -> BrokerTrans
 def test_broker_transaction_rejects_a_bare_invalid_isin() -> None:
     """A caller that skips the type still cannot smuggle in a bad ISIN."""
     with pytest.raises(ValueError, match="Invalid ISIN"):
-        _transaction("NOTANISIN")  # type: ignore[arg-type]
+        _transaction("NOTANISIN")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
 
 def test_broker_transaction_coerces_a_bare_valid_isin() -> None:
     """A valid bare string is normalised into the value type."""
-    transaction = _transaction("us0378331005")  # type: ignore[arg-type]
+    transaction = _transaction("us0378331005")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     assert isinstance(transaction.isin, Isin)
     assert transaction.isin == VALID_ISIN
 
@@ -166,7 +166,7 @@ def test_currency_code_rejects_attribute_assignment() -> None:
     """The value type carries no instance dict."""
     code = CurrencyCode("GBP")
     with pytest.raises(AttributeError):
-        code.symbol = "£"  # type: ignore[attr-defined]
+        code.symbol = "£"  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
 
 
 def test_currency_code_parse_returns_none_for_invalid_input() -> None:
@@ -203,12 +203,12 @@ def test_nonzero_foreign_amount_requires_a_currency() -> None:
 def test_broker_transaction_rejects_a_bare_invalid_currency() -> None:
     """A caller that skips the type still cannot smuggle in a bad currency."""
     with pytest.raises(ValueError, match="Invalid currency code"):
-        _transaction(None, currency="GBp")  # type: ignore[arg-type]
+        _transaction(None, currency="GBp")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
 
 def test_broker_transaction_coerces_a_bare_valid_currency() -> None:
     """A valid bare string is normalised into the value type."""
-    transaction = _transaction(None, currency=" USD ")  # type: ignore[arg-type]
+    transaction = _transaction(None, currency=" USD ")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     assert isinstance(transaction.currency, CurrencyCode)
     assert transaction.currency == "USD"
 
@@ -229,12 +229,12 @@ def _transaction_with_fees(
 def test_broker_transaction_rejects_a_bare_invalid_foreign_fee_currency() -> None:
     """Foreign fee keys are held to the same rule as the transaction currency."""
     with pytest.raises(ValueError, match="Invalid currency code"):
-        _transaction_with_fees({"GBp": Decimal(1)})  # type: ignore[dict-item]
+        _transaction_with_fees({"GBp": Decimal(1)})  # type: ignore[dict-item]  # ty: ignore[invalid-argument-type]
 
 
 def test_broker_transaction_coerces_bare_valid_foreign_fee_currencies() -> None:
     """Valid bare keys are normalised into the value type."""
-    transaction = _transaction_with_fees({" USD ": Decimal(1)})  # type: ignore[dict-item]
+    transaction = _transaction_with_fees({" USD ": Decimal(1)})  # type: ignore[dict-item]  # ty: ignore[invalid-argument-type]
     assert list(transaction.foreign_fees) == [CurrencyCode("USD")]
     assert all(isinstance(key, CurrencyCode) for key in transaction.foreign_fees)
 
@@ -242,7 +242,7 @@ def test_broker_transaction_coerces_bare_valid_foreign_fee_currencies() -> None:
 def test_broker_transaction_sums_foreign_fees_that_coerce_to_one_currency() -> None:
     """Keys that normalise to the same code add up rather than overwrite."""
     transaction = _transaction_with_fees(
-        {" USD ": Decimal(1), "USD": Decimal(2)}  # type: ignore[dict-item]
+        {" USD ": Decimal(1), "USD": Decimal(2)}  # type: ignore[dict-item]  # ty: ignore[invalid-argument-type]
     )
     assert transaction.foreign_fees == {CurrencyCode("USD"): Decimal(3)}
 

--- a/uv.lock
+++ b/uv.lock
@@ -230,7 +230,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "reportlab", specifier = ">=5.0.1" },
     { name = "ruff", specifier = ">=0.16.4" },
-    { name = "ty", specifier = ">=0.0.74" },
+    { name = "ty", specifier = ">=0.0.74,<0.1.0" },
     { name = "types-colorama", specifier = ">=0.4.15.20260508" },
     { name = "types-defusedxml", specifier = ">=0.7.0.20260504" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20250822" },

--- a/uv.lock
+++ b/uv.lock
@@ -189,6 +189,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "reportlab" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "types-colorama" },
     { name = "types-defusedxml" },
     { name = "types-python-dateutil" },
@@ -229,6 +230,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "reportlab", specifier = ">=5.0.1" },
     { name = "ruff", specifier = ">=0.16.4" },
+    { name = "ty", specifier = ">=0.0.74" },
     { name = "types-colorama", specifier = ">=0.4.15.20260508" },
     { name = "types-defusedxml", specifier = ">=0.7.0.20260504" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20250822" },
@@ -1571,6 +1573,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.74"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/0f/c767853e88567a2ec7e996dd95e3105b1bc62c95d103689311ef0f4a603c/ty-0.0.74.tar.gz", hash = "sha256:da14344fc8625fc9ff359bafb856ad575636ea86d9bb6a629b146bff27b380e6", size = 6786318, upload-time = "2026-08-22T15:05:54.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/95/6ded58bc97885c6d88fa1f9cd815031489200738f961cbf0466663213f80/ty-0.0.74-py3-none-linux_armv6l.whl", hash = "sha256:8969ef4e508debf00cf58f9ea85a539f799b1732c59cdfcecd037630b9755b30", size = 12790043, upload-time = "2026-08-22T15:05:05.015Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8a/5e323603b6ab8731144421877ee8a0f8ac5a5511e67857127caa09f6730e/ty-0.0.74-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:51fb6cf5b98e1e1140825b2430943f78d744876a735231656eafbb4c3f7eca3c", size = 12371748, upload-time = "2026-08-22T15:05:08.609Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/ee72e08cb705281e8d8c42917dd577aa598a8a098008495fda5176ee3f6e/ty-0.0.74-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8ebe60b1f0a948c793d6c77fc9e9ddda599e4f023c04ab16e8e03bcb428c3fa0", size = 12282403, upload-time = "2026-08-22T15:05:11.448Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b3/fd935b694ff68bc278af50f7ad04770b36ce6306399baef7e1847b553a9d/ty-0.0.74-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa97f407a695c890a53615966a663c7d2167e2cabe88db7ca1a24d62635cdfc8", size = 12345164, upload-time = "2026-08-22T15:05:14.19Z" },
+    { url = "https://files.pythonhosted.org/packages/54/5c/5b5825268e029ebb164c909780103dbbae367f069801410068bf1cef29b3/ty-0.0.74-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:673ddb733d4a0db31385ba1ed9ff1f6bd9dc5565413ce57b1ca5ac4c7803da5d", size = 12556646, upload-time = "2026-08-22T15:05:16.994Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e7/515914e571d62ce0101744fed3f881936eeb1b30dc37beb72b4f7ca1e289/ty-0.0.74-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1028e7c6b4f6145e9704552f43a5fffdcd51b42263ffdcd9c9677762bc395a4a", size = 13311653, upload-time = "2026-08-22T15:05:20.254Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/07/d1452babb6f9266c2122cabc095180b70ed306fb770b2996753814d2237d/ty-0.0.74-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79841a8890493021fb308772474983316eb91f7b56cb227a6a05a06b262a36f0", size = 13768284, upload-time = "2026-08-22T15:05:23.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/60/8d4a2fc7842a47210a1cb0a16a187d9de39ad5d509a00fb74c1c073afcde/ty-0.0.74-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:94859d321f3c6a6c8f7bfc3f40e8319cda7e6e012e613440f3dfd145d5010e2e", size = 13422306, upload-time = "2026-08-22T15:05:26.248Z" },
+    { url = "https://files.pythonhosted.org/packages/de/76/ebbc269a8c4efcc4d44624993bd188145f20d60ebda9680b15aaec42cc50/ty-0.0.74-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:970a8b2c09ff3be04c8a1c6767332d861be4fce85efe7bb205e4ade7c8655274", size = 12970637, upload-time = "2026-08-22T15:05:29.15Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/dd/b99f7236acbf856780ca1779a48143d2d9f2c24d7f531a0ce15a022b8a87/ty-0.0.74-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:795f763b3ded85574c2c2846a6fb8acf2aa76e9e83d761143e92b1f0c7ffa2cd", size = 13344891, upload-time = "2026-08-22T15:05:32.033Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/9ff7449a4c7e6428f2c6f298e74cf24b70668f29d45c249507a723ff3782/ty-0.0.74-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:dc086db5367d912c31c0cc872deb7387290e779a4b9b54fcb944673a7cd52c7b", size = 12395272, upload-time = "2026-08-22T15:05:34.702Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/dd/b23a5b6b35d37df89dc8dc5daa09efd9245a668b50c4c81c25de21567dc1/ty-0.0.74-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0314d7b391cf684e47c2fa093d2ce4c597cfc9b01d9a315fe204aed6359b271b", size = 12573079, upload-time = "2026-08-22T15:05:37.683Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c5/ccba16239d6129533c8b3603458d0f4dd2ba69478e47059073968e74261d/ty-0.0.74-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c4a45dd2e991e8bdae82ba78c8cd051b253f60bc71a6536598fa3ef580b4fc9b", size = 12832506, upload-time = "2026-08-22T15:05:40.505Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/1c/2390912634dff4f341f97b397f2aee341ff062be0a66cda37d59375454f2/ty-0.0.74-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:210e2eac6b018fb934e2b8dac3956a0ba076a3fb1fa6f135058c825e5b759b81", size = 13154752, upload-time = "2026-08-22T15:05:43.355Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/a8c12188227e6f74f91853a7374e01ed81d6ad21c16c8b70e92dbebfe46a/ty-0.0.74-py3-none-win32.whl", hash = "sha256:db0bb6a8f098ef9bd1be861f73b4f7c0320d40d4c05c7ae0a8677d4e7aa4f6e5", size = 12130002, upload-time = "2026-08-22T15:05:46.058Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5c/064f28ccb9c234cfce5a2f7aa69a256663d5ae5bb0290b3a9706cc4d1e4c/ty-0.0.74-py3-none-win_amd64.whl", hash = "sha256:bebff181515255b3c78bd2e7693ae66fab6064ad4feea2065c68bc01022aa678", size = 12771435, upload-time = "2026-08-22T15:05:48.811Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/06/d6becdaca0315346c26b6df97cb0eafa81de4f870945d6989e88704374ed/ty-0.0.74-py3-none-win_arm64.whl", hash = "sha256:1a3469eaaf8c85b1c0a15bede25d36daea4b09fce1d913e965b24e24b3f1d6c6", size = 12558299, upload-time = "2026-08-22T15:05:51.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add bounded ty as a blocking prek check alongside mypy.
- Enforce targeted suppressions and check cgt_calc, tests, and scripts across all platforms.