### PR TITLE
Refuse a Cancel Buy that has no matching Buy

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -101,6 +101,7 @@ NVDA
 NVIDIA
 OPRA
 OTGLY
+ParsingError
 pdf
 pdflatex
 pipx

--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -72,6 +72,7 @@ HL
 Hmrc
 IBKR
 IBKR's
+idx
 InvalidTransactionError
 Invesco
 InvestmentName
@@ -161,6 +162,7 @@ tranche's
 TransactionDetails
 transferor
 transferor's
+txn
 ty
 UCITS
 un

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -247,6 +247,11 @@ class ActionType(Enum):
     GIFT = 24
     # The same, to someone who is not a connected person: a loss is ordinary.
     GIFT_UNCONNECTED = 25
+    # A purchase the broker reversed. Parsers are expected to drop it along
+    # with the purchase it reverses, so it never reaches the calculator; it
+    # exists so that a row which slips through is refused rather than booked
+    # as an acquisition.
+    CANCEL_BUY = 26
 
 
 class CalculationType(Enum):

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -646,8 +646,12 @@ def _filter_cancelled_buy_transactions(
                 file,
                 f"Found a {transaction.raw_action} for {transaction.symbol} on "
                 f"{transaction.date} with no Buy to match it in the "
-                f"{CANCEL_BUY_SEARCH_DAYS} days before. Check that the export "
-                "covers the purchase it reverses.",
+                f"{CANCEL_BUY_SEARCH_DAYS} days before. The purchase may be "
+                "missing from the export, older than that window, recorded "
+                "with a different quantity or price, or already reversed by "
+                "another cancellation. Remove this row; remove the purchase "
+                "with it only if the purchase is still in the export and no "
+                "other cancellation reverses it.",
             )
 
     if len(indices_to_remove) > 0:

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -91,8 +91,13 @@ class AwardPrices:
 
 def action_from_str(label: str, file: Path) -> ActionType:
     """Convert string label to ActionType."""
-    if label in {"Buy", "Cancel Buy"}:
+    if label == "Buy":
         return ActionType.BUY
+
+    if label == "Cancel Buy":
+        # Not a purchase: it is dropped along with the Buy it reverses, and
+        # a cancellation with no matching Buy fails the run.
+        return ActionType.CANCEL_BUY
 
     if label == "Sell":
         return ActionType.SELL
@@ -513,6 +518,7 @@ def _unify_schwab_paired_transactions(
 
 def _filter_cancelled_buy_transactions(
     transactions: list[SchwabTransaction],
+    file: Path,
 ) -> list[SchwabTransaction]:
     """Filter out Cancel Buy transactions and their matching Buy transactions.
 
@@ -532,9 +538,13 @@ def _filter_cancelled_buy_transactions(
 
     Args:
         transactions: List of parsed Schwab transactions, newest-first
+        file: Source file, for error reporting
 
     Returns:
         Filtered list with Cancel Buy pairs removed
+
+    Raises:
+        ParsingError: If a Cancel Buy has no matching Buy
 
     """
     indices_to_remove: set[int] = set()
@@ -549,7 +559,11 @@ def _filter_cancelled_buy_transactions(
             continue
 
         # Search forward (older transactions, since the list is newest-first)
-        # for the matching Buy within the search window
+        # for the matching Buy within the search window. A flag rather than
+        # for/else: the search window check below leaves the loop with a break,
+        # which skips an else clause on any export long enough to contain a row
+        # outside the window - that is, on every real one.
+        matched = False
         for buy_idx in range(cancel_idx + 1, len(transactions)):
             buy_txn = transactions[buy_idx]
 
@@ -561,14 +575,16 @@ def _filter_cancelled_buy_transactions(
             if buy_idx in indices_to_remove:
                 continue
 
-            # Check if this is the matching Buy transaction
+            # Match the raw action, so a cancellation can never pair with
+            # another cancellation.
             if (
-                buy_txn.action == ActionType.BUY
+                buy_txn.raw_action == "Buy"
                 and buy_txn.symbol == transaction.symbol
                 and buy_txn.quantity == transaction.quantity
                 and buy_txn.price == transaction.price
             ):
                 # Found matching pair - mark both for removal
+                matched = True
                 indices_to_remove.add(cancel_idx)
                 indices_to_remove.add(buy_idx)
                 LOGGER.debug(
@@ -581,11 +597,22 @@ def _filter_cancelled_buy_transactions(
                     transaction.date,
                 )
                 break
-        else:
-            # No matching Buy found
-            LOGGER.warning(
-                "Could not find matching Buy for Cancel Buy: %s",
-                transaction,
+
+        if not matched:
+            # A cancellation with nothing to reverse means the export does not
+            # reach back to the purchase, or that purchase settled outside the
+            # window above. Either way the pair cannot be reconciled and the
+            # row cannot be processed, so refuse here, where the row's meaning
+            # is still known. Left in place it would reach the calculator,
+            # which refuses any action it does not handle but can only report
+            # an unprocessed action type, naming neither the cancellation nor
+            # what to do about it.
+            raise ParsingError(
+                file,
+                f"Found a {transaction.raw_action} for {transaction.symbol} on "
+                f"{transaction.date} with no Buy to match it in the "
+                f"{CANCEL_BUY_SEARCH_DAYS} days before. Check that the export "
+                "covers the purchase it reverses.",
             )
 
     if len(indices_to_remove) > 0:
@@ -781,6 +808,6 @@ class SchwabParser(BaseSingleFileParser):
 
             transactions.append(transaction)
         transactions = _unify_schwab_paired_transactions(transactions, file_path)
-        transactions = _filter_cancelled_buy_transactions(transactions)
+        transactions = _filter_cancelled_buy_transactions(transactions, file_path)
         transactions.reverse()
         return list(transactions)

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -516,6 +516,64 @@ def _unify_schwab_paired_transactions(
     return filtered
 
 
+def _is_matching_buy(buy_txn: SchwabTransaction, cancel_txn: SchwabTransaction) -> bool:
+    """Whether buy_txn is the purchase that cancel_txn reverses.
+
+    The raw action is compared rather than the action type, so a cancellation
+    can never pair with another cancellation.
+    """
+    return (
+        buy_txn.raw_action == "Buy"
+        and buy_txn.symbol == cancel_txn.symbol
+        and buy_txn.quantity == cancel_txn.quantity
+        and buy_txn.price == cancel_txn.price
+    )
+
+
+def _find_matching_buy(
+    transactions: list[SchwabTransaction],
+    cancel_idx: int,
+    consumed: set[int],
+) -> int | None:
+    """Find the index of the Buy that the Cancel Buy at cancel_idx reverses.
+
+    The list is newest-first, so the purchase being reversed normally sits at
+    a higher index than the cancellation. When the two share a date the export
+    orders them arbitrarily, so the purchase can equally sit just above it;
+    those rows are searched as well. A purchase on a date later than the
+    cancellation is never a match, because it had not happened yet when the
+    cancellation was recorded.
+
+    Args:
+        transactions: Parsed Schwab transactions, newest-first
+        cancel_idx: Index of the Cancel Buy to reconcile
+        consumed: Indices already claimed by an earlier pair
+
+    Returns:
+        Index of the matching Buy, or None when there is none
+
+    """
+    cancel_txn = transactions[cancel_idx]
+
+    # Older rows, out to the edge of the search window.
+    for buy_idx in range(cancel_idx + 1, len(transactions)):
+        buy_txn = transactions[buy_idx]
+        if abs((buy_txn.date - cancel_txn.date).days) > CANCEL_BUY_SEARCH_DAYS:
+            break
+        if buy_idx not in consumed and _is_matching_buy(buy_txn, cancel_txn):
+            return buy_idx
+
+    # Newer rows, but only the ones sharing the cancellation's own date.
+    for buy_idx in range(cancel_idx - 1, -1, -1):
+        buy_txn = transactions[buy_idx]
+        if buy_txn.date != cancel_txn.date:
+            break
+        if buy_idx not in consumed and _is_matching_buy(buy_txn, cancel_txn):
+            return buy_idx
+
+    return None
+
+
 def _filter_cancelled_buy_transactions(
     transactions: list[SchwabTransaction],
     file: Path,
@@ -532,9 +590,10 @@ def _filter_cancelled_buy_transactions(
     Note: this runs on the raw, newest-first ordered list of transactions as
     read from the Schwab export (before ``transactions.reverse()`` is applied
     by the caller). A Cancel Buy row is chronologically *after* the Buy it
-    cancels, so in a newest-first list the Cancel Buy has a *lower* index than
-    its Buy. We therefore search forward (increasing index = older dates) from
-    the Cancel Buy's index.
+    cancels, so in a newest-first list the Cancel Buy normally has a *lower*
+    index than its Buy. Same-date rows are the exception, since the export
+    orders those arbitrarily; see ``_find_matching_buy`` for how both are
+    searched.
 
     Args:
         transactions: List of parsed Schwab transactions, newest-first
@@ -558,47 +617,23 @@ def _filter_cancelled_buy_transactions(
         if cancel_idx in indices_to_remove:
             continue
 
-        # Search forward (older transactions, since the list is newest-first)
-        # for the matching Buy within the search window. A flag rather than
-        # for/else: the search window check below leaves the loop with a break,
-        # which skips an else clause on any export long enough to contain a row
-        # outside the window - that is, on every real one.
-        matched = False
-        for buy_idx in range(cancel_idx + 1, len(transactions)):
+        buy_idx = _find_matching_buy(transactions, cancel_idx, indices_to_remove)
+
+        if buy_idx is not None:
+            # Found matching pair - mark both for removal
+            indices_to_remove.add(cancel_idx)
+            indices_to_remove.add(buy_idx)
             buy_txn = transactions[buy_idx]
-
-            # Stop if beyond search window
-            if abs((buy_txn.date - transaction.date).days) > CANCEL_BUY_SEARCH_DAYS:
-                break
-
-            # Skip if already marked for removal
-            if buy_idx in indices_to_remove:
-                continue
-
-            # Match the raw action, so a cancellation can never pair with
-            # another cancellation.
-            if (
-                buy_txn.raw_action == "Buy"
-                and buy_txn.symbol == transaction.symbol
-                and buy_txn.quantity == transaction.quantity
-                and buy_txn.price == transaction.price
-            ):
-                # Found matching pair - mark both for removal
-                matched = True
-                indices_to_remove.add(cancel_idx)
-                indices_to_remove.add(buy_idx)
-                LOGGER.debug(
-                    "Matched Cancel Buy with original Buy: symbol=%s, qty=%s, "
-                    "price=%s, buy_date=%s, cancel_date=%s",
-                    buy_txn.symbol,
-                    buy_txn.quantity,
-                    buy_txn.price,
-                    buy_txn.date,
-                    transaction.date,
-                )
-                break
-
-        if not matched:
+            LOGGER.debug(
+                "Matched Cancel Buy with original Buy: symbol=%s, qty=%s, "
+                "price=%s, buy_date=%s, cancel_date=%s",
+                buy_txn.symbol,
+                buy_txn.quantity,
+                buy_txn.price,
+                buy_txn.date,
+                transaction.date,
+            )
+        else:
             # A cancellation with nothing to reverse means the export does not
             # reach back to the purchase, or that purchase settled outside the
             # window above. Either way the pair cannot be reconciled and the

--- a/tests/schwab/test_schwab_cancel_buy.py
+++ b/tests/schwab/test_schwab_cancel_buy.py
@@ -264,3 +264,61 @@ def test_cancel_buy_is_not_typed_as_a_purchase(tmp_path: Path) -> None:
 
     assert cancel.raw_action == "Cancel Buy"
     assert cancel.action is ActionType.CANCEL_BUY
+
+
+def test_identical_cancellations_pair_with_the_buys(tmp_path: Path) -> None:
+    """Two identical cancellations reverse the two purchases, not each other.
+
+    Matching on the action type paired the cancellations with one another,
+    because a Cancel Buy was itself typed as a purchase. Both cancellations
+    dropped out and both purchases stayed, adding cost basis for shares that
+    were never bought. The rows here are deliberately identical in symbol,
+    quantity and price, which is what it takes to reproduce that: the
+    committed multiple-cancellation test varies both, so the pairs can only
+    match the way they are meant to.
+    """
+    csv_file = tmp_path / "transactions.csv"
+    csv_file.write_text(
+        "Date,Action,Symbol,Description,Price,Quantity,Fees & Comm,Amount\n"
+        "01/12/2024,Cancel Buy,AAPL,APPLE INC,$150.00,10,$0.00,$1500.00\n"
+        "01/11/2024,Cancel Buy,AAPL,APPLE INC,$150.00,10,$0.00,$1500.00\n"
+        "01/10/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+        "01/09/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+    )
+
+    assert SchwabParser().load_from_file(csv_file) == []
+
+
+def test_cancel_buy_matches_a_same_date_buy_listed_above_it(tmp_path: Path) -> None:
+    """A same-date purchase is found whichever side of the cancellation it sits.
+
+    The export gives no order to rows sharing a date, so the purchase can be
+    listed either side of the cancellation that reverses it. Searching only
+    older rows refused a file that held the pair all along.
+    """
+    csv_file = tmp_path / "transactions.csv"
+    csv_file.write_text(
+        "Date,Action,Symbol,Description,Price,Quantity,Fees & Comm,Amount\n"
+        "01/10/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+        "01/10/2024,Cancel Buy,AAPL,APPLE INC,$150.00,10,$0.00,$1500.00\n"
+    )
+
+    assert SchwabParser().load_from_file(csv_file) == []
+
+
+def test_cancel_buy_does_not_match_a_later_buy(tmp_path: Path) -> None:
+    """A purchase made after the cancellation is a different purchase.
+
+    Only same-date rows above the cancellation are searched. A Buy on a later
+    date had not happened when the cancellation was recorded, so consuming it
+    would delete a real acquisition.
+    """
+    csv_file = tmp_path / "transactions.csv"
+    csv_file.write_text(
+        "Date,Action,Symbol,Description,Price,Quantity,Fees & Comm,Amount\n"
+        "01/12/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+        "01/10/2024,Cancel Buy,AAPL,APPLE INC,$150.00,10,$0.00,$1500.00\n"
+    )
+
+    with pytest.raises(ParsingError, match="no Buy to match it"):
+        SchwabParser().load_from_file(csv_file)

--- a/tests/schwab/test_schwab_cancel_buy.py
+++ b/tests/schwab/test_schwab_cancel_buy.py
@@ -4,8 +4,10 @@ Tests the filtering of Cancel Buy transactions and their matching with original
 Buy transactions within the search window.
 
 Cancel Buy is a Schwab-specific transaction type that indicates a purchase was
-cancelled. Both the original Buy and the Cancel Buy are mapped to ActionType.BUY,
-and both need to be filtered out to avoid incorrect capital gains calculations.
+cancelled. Both rows have to be filtered out to avoid counting a purchase that
+never stood. The cancellation carries ActionType.CANCEL_BUY rather than the
+type of a purchase, so a row that escapes the filter is refused downstream
+instead of being booked as an acquisition.
 
 Real Schwab exports are ordered newest-first (see
 tests/schwab/data/schwab_transactions.csv, where 2021 rows appear before 2020
@@ -14,13 +16,17 @@ newest-first CSV the Cancel Buy row appears *above* (before) its matching Buy
 row. All CSVs below follow that realistic ordering.
 """
 
+from collections import OrderedDict
+import csv
 import datetime
 from decimal import Decimal
 from pathlib import Path
 
 import pytest
 
-from cgt_calc.parsers.schwab import SchwabParser
+from cgt_calc.exceptions import ParsingError
+from cgt_calc.model import ActionType
+from cgt_calc.parsers.schwab import AwardPrices, SchwabParser, SchwabTransaction
 
 
 class TestCancelBuyFiltering:
@@ -49,12 +55,9 @@ class TestCancelBuyFiltering:
             "01/01/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
         )
 
-        transactions = SchwabParser().load_from_file(csv_file)
-
-        # 9 days apart - Cancel Buy won't match, both should remain
-        assert len(transactions) == 2
-        assert transactions[0].action.name == "BUY"
-        assert transactions[1].action.name == "BUY"  # Cancel Buy mapped to BUY
+        # 9 days apart, so the Buy is outside the window and nothing matches.
+        with pytest.raises(ParsingError, match="no Buy to match it"):
+            SchwabParser().load_from_file(csv_file)
 
     def test_cancel_buy_matches_exact_symbol_quantity_price(
         self, tmp_path: Path
@@ -83,10 +86,9 @@ class TestCancelBuyFiltering:
             "01/10/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
         )
 
-        transactions = SchwabParser().load_from_file(csv_file)
-
-        # Different symbols - no match, both remain
-        assert len(transactions) == 2
+        # Different symbols, so nothing matches the cancellation.
+        with pytest.raises(ParsingError, match="no Buy to match it"):
+            SchwabParser().load_from_file(csv_file)
 
     def test_cancel_buy_with_fractional_shares(self, tmp_path: Path) -> None:
         """Test that Cancel Buy works with fractional shares."""
@@ -168,10 +170,9 @@ class TestCancelBuyFiltering:
             f"{buy_date.strftime('%m/%d/%Y')},Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
         )
 
-        transactions = SchwabParser().load_from_file(csv_file)
-
-        # 6 days apart - no match, both remain
-        assert len(transactions) == 2
+        # 6 days apart, one day outside the window.
+        with pytest.raises(ParsingError, match="no Buy to match it"):
+            SchwabParser().load_from_file(csv_file)
 
     def test_no_cancel_buy_transactions(self, tmp_path: Path) -> None:
         """Test that normal transactions are unaffected when no Cancel Buy present."""
@@ -215,3 +216,51 @@ class TestCancelBuyFiltering:
         # AAPL Buy and Cancel Buy should be matched and removed; MSFT remains.
         assert len(transactions) == 1
         assert transactions[0].symbol == "MSFT"
+
+
+def test_unmatched_cancel_buy_is_refused(tmp_path: Path) -> None:
+    """An unmatched Cancel Buy stops the run, naming the row at fault.
+
+    The pair cannot be reconciled: either the export does not reach the
+    purchase being reversed, or it settled outside the search window. Refusing
+    in the parser names the offending row and what to check, which the
+    calculator cannot do once the row is just an action it does not handle.
+    """
+    csv_file = tmp_path / "transactions.csv"
+    csv_file.write_text(
+        "Date,Action,Symbol,Description,Price,Quantity,Fees & Comm,Amount\n"
+        "01/20/2024,Cancel Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+        "01/01/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+        "01/05/2020,Buy,MSFT,MICROSOFT CORP,$200.00,5,$0.00,-$1000.00\n"
+    )
+
+    with pytest.raises(ParsingError, match="no Buy to match it"):
+        SchwabParser().load_from_file(csv_file)
+
+
+def test_cancel_buy_is_not_typed_as_a_purchase(tmp_path: Path) -> None:
+    """A Cancel Buy row does not carry the action type of a purchase.
+
+    Nothing between parsing and filtering reads the action type, and the
+    filter drops or refuses every cancellation, so typing one as a purchase
+    buys nothing and costs the guarantee: a row reaching the calculator by
+    any other route would be booked as real cost basis. Typed as itself, the
+    calculator refuses it.
+    """
+    csv_file = tmp_path / "transactions.csv"
+    csv_file.write_text(
+        "Date,Action,Symbol,Description,Price,Quantity,Fees & Comm,Amount\n"
+        "01/12/2024,Cancel Buy,AAPL,APPLE INC,$150.00,10,$0.00,$1500.00\n"
+        "01/10/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+    )
+
+    # Reach past the filter to see how the row itself is typed.
+    with csv_file.open(encoding="utf-8") as handle:
+        rows = list(csv.reader(handle))
+    header = rows[0]
+    cancel = SchwabTransaction.create(
+        OrderedDict(zip(header, rows[1], strict=True)), csv_file, AwardPrices({})
+    )
+
+    assert cancel.raw_action == "Cancel Buy"
+    assert cancel.action is ActionType.CANCEL_BUY


### PR DESCRIPTION
Schwab emits a "Cancel Buy" row to reverse a purchase it has already reported, and the parser paired the two so both drop out. Two problems sat in that pairing.

The search for the Buy compared action types. A Cancel Buy was itself mapped to ActionType.BUY, so one cancellation could pair with another and leave both of the purchases they reversed standing. Match on the raw action instead, and mark each Buy as it is consumed so two cancellations cannot claim the same one.

When no Buy was found the parser warned and carried on. The row stayed typed as a purchase, so a reversal silently became cost basis and every later disposal of that symbol was computed against a pool that never existed. A warning is the wrong tool for a wrong number: raise ParsingError naming the row instead.

Give Cancel Buy its own ActionType.CANCEL_BUY as well. Modelling it as a purchase left correctness resting on a filter running first, and made the type say the opposite of what the row means.