### PR TITLE
Attribute withheld tax to the dividend it was taken from

### DIFF
--- a/cgt_calc/const.py
+++ b/cgt_calc/const.py
@@ -103,6 +103,12 @@ INTERNAL_START_DATE: Final = datetime.date(2010, 1, 1)
 # See: https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg51560
 BED_AND_BREAKFAST_DAYS: Final = 30
 
+# How far from a dividend a withholding may be dated and still be treated as
+# taken from it. Brokers post a withholding, or a later correction of one, a
+# few days either side of the payment; beyond this the tax is left out of the
+# report rather than attributed to a payment it may not belong to.
+DIVIDEND_TAX_MATCH_DAYS: Final = 30
+
 UK_CURRENCY: Final = "GBP"
 
 # Tax dates are UK calendar days, so timestamped transactions are read

--- a/cgt_calc/const.py
+++ b/cgt_calc/const.py
@@ -103,11 +103,17 @@ INTERNAL_START_DATE: Final = datetime.date(2010, 1, 1)
 # See: https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg51560
 BED_AND_BREAKFAST_DAYS: Final = 30
 
-# How far from a dividend a withholding may be dated and still be treated as
-# taken from it. Brokers post a withholding, or a later correction of one, a
-# few days either side of the payment; beyond this the tax is left out of the
-# report rather than attributed to a payment it may not belong to.
+# How far back from a withholding its dividend may lie. A broker posts the
+# tax with the payment or in the weeks after it, and a correction of one
+# later still, so the search reaches well back. Beyond this the tax is left
+# out of the report rather than attributed to a payment it may not belong to.
 DIVIDEND_TAX_MATCH_DAYS: Final = 30
+
+# How far forward it may lie, for a broker that posts the tax just ahead of
+# the payment. This is deliberately short: reaching as far forward as back
+# would let the next payment of a monthly holding claim a correction that
+# belongs to the last one.
+DIVIDEND_TAX_LEAD_DAYS: Final = 5
 
 UK_CURRENCY: Final = "GBP"
 

--- a/cgt_calc/const.py
+++ b/cgt_calc/const.py
@@ -110,9 +110,10 @@ BED_AND_BREAKFAST_DAYS: Final = 30
 DIVIDEND_TAX_MATCH_DAYS: Final = 30
 
 # How far forward it may lie, for a broker that posts the tax just ahead of
-# the payment. This is deliberately short: reaching as far forward as back
-# would let the next payment of a monthly holding claim a correction that
-# belongs to the last one.
+# the payment. This is deliberately short: the further it reaches, the more
+# often a monthly holding's next payment is a candidate alongside the last
+# one, and a withholding two payments could claim is left out rather than
+# assigned to either.
 DIVIDEND_TAX_LEAD_DAYS: Final = 5
 
 UK_CURRENCY: Final = "GBP"

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -2345,6 +2345,19 @@ class CapitalGainsCalculator:
             currency = foreign_amount.currency
             assert currency is not None, f"Dividend for {symbol} has no currency"
 
+            # The tax is converted at the dividend's rate below, so the two
+            # have to be in one currency whichever way the tax runs and
+            # whatever the holding is. Checking this only for tax deducted
+            # from an ordinary holding let a refund, or any tax on a bond
+            # fund, be converted as though it were in the dividend's
+            # currency.
+            if tax.amount and tax.currency != currency:
+                raise CalculationError(
+                    f"Dividend and withholding tax currencies do not match "
+                    f"for {symbol} on {date}: dividend "
+                    f"{foreign_amount.currency}, tax {tax.currency}"
+                )
+
             treaty = None
             is_interest_fund = symbol in self.interest_fund_tickers
             if tax.amount < 0:
@@ -2353,12 +2366,6 @@ class CapitalGainsCalculator:
                         "Cannot apply taxation treaty for bond fund %s", symbol
                     )
                 else:
-                    if tax.currency != foreign_amount.currency:
-                        raise CalculationError(
-                            f"Dividend and withholding tax currencies do not match "
-                            f"for {symbol} on {date}: dividend "
-                            f"{foreign_amount.currency}, tax {tax.currency}"
-                        )
                     country = self.dividend_source_country(symbol, currency)
                     if country is None:
                         LOGGER.warning(

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -9,7 +9,7 @@ import decimal
 from decimal import Decimal
 import logging
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from colorama import Fore, Style
 
@@ -177,6 +177,20 @@ def _match_gifts_to_rows(
     return False
 
 
+class DividendTaxAttribution(NamedTuple):
+    """Withheld tax sorted by whether a dividend was found to carry it."""
+
+    matched: ForeignAmountLog
+    """Keyed by the symbol and date of the dividend the tax was taken from."""
+
+    unmatched: ForeignAmountLog
+    """Keyed by the symbol and date of the withholding itself.
+
+    No dividend row can carry this tax, but the broker took it all the same,
+    so the summary reports it against the year it was taken in.
+    """
+
+
 class CapitalGainsCalculator:
     """Main calculator class."""
 
@@ -239,7 +253,7 @@ class CapitalGainsCalculator:
 
         self.dividend_list: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
         self.dividend_tax_list: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
-        self._attributed_dividend_tax: ForeignAmountLog | None = None
+        self._attributed_dividend_tax: DividendTaxAttribution | None = None
         self.interest_list: dict[
             tuple[str, CurrencyCode, datetime.date], ForeignCurrencyAmount
         ] = defaultdict(ForeignCurrencyAmount)
@@ -1156,8 +1170,15 @@ class CapitalGainsCalculator:
 
         # Withholding belongs to the year of the dividend it was taken from,
         # which is not always the year it was posted in, so the summary reads
-        # it from the same attribution the report is built from.
-        for (symbol, date), tax in self._dividend_tax_attribution().items():
+        # it from the same attribution the report is built from. Tax that
+        # matched no dividend is counted under its own date: no dividend row
+        # can carry it, but the broker took it and the summary says so. The
+        # warning raised for it explains why the report does not show it.
+        attribution = self._dividend_tax_attribution()
+        for (symbol, date), tax in [
+            *attribution.matched.items(),
+            *attribution.unmatched.items(),
+        ]:
             if self.date_in_tax_year(date) and tax.currency is not None:
                 dividends_tax[symbol, tax.currency] += tax.amount
 
@@ -2228,7 +2249,7 @@ class CapitalGainsCalculator:
             within, key=lambda candidate: (abs((candidate - date).days), candidate)
         )
 
-    def _attribute_dividend_tax(self) -> ForeignAmountLog:
+    def _attribute_dividend_tax(self) -> DividendTaxAttribution:
         """Attribute each withholding to the dividend it was taken from.
 
         Brokers do not always date a withholding, or a later correction of
@@ -2245,18 +2266,20 @@ class CapitalGainsCalculator:
         for symbol, date in self.dividend_list:
             dividend_dates[symbol].append(date)
 
-        attributed: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
+        matched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
+        unmatched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
         for (symbol, date), tax in self.dividend_tax_list.items():
             if not tax.amount:
                 continue
             match = self._nearest_dividend_date(date, dividend_dates.get(symbol, []))
             if match is None:
                 self._warn_unattributed_dividend_tax(symbol, date, tax)
+                unmatched[symbol, date] += tax
                 continue
-            attributed[symbol, match] += tax
-        return attributed
+            matched[symbol, match] += tax
+        return DividendTaxAttribution(matched, unmatched)
 
-    def _dividend_tax_attribution(self) -> ForeignAmountLog:
+    def _dividend_tax_attribution(self) -> DividendTaxAttribution:
         """Attribute withholding once, for both the summary and the report.
 
         The two must agree, and attributing twice would warn twice.
@@ -2270,7 +2293,7 @@ class CapitalGainsCalculator:
 
         It updates the interest total for the year if needed.
         """
-        attributed_tax = self._dividend_tax_attribution()
+        attributed_tax = self._dividend_tax_attribution().matched
         for (symbol, date), foreign_amount in self.dividend_list.items():
             # Dividends outside the computed tax year are not reported, so
             # neither are the warnings raised while resolving their treaty.

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -252,7 +252,16 @@ class CapitalGainsCalculator:
         self.rename_list: dict[datetime.date, dict[str, str]] = defaultdict(dict)
 
         self.dividend_list: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
-        self.dividend_tax_list: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
+        # Withholding is matched to a dividend of the same broker as well as
+        # the same symbol, so both are keyed by broker. The dividends stay
+        # merged across brokers in dividend_list, which is what the report
+        # rows are built from.
+        self.dividend_tax_list: dict[
+            tuple[str, str, datetime.date], ForeignCurrencyAmount
+        ] = defaultdict(ForeignCurrencyAmount)
+        self.dividend_dates: dict[tuple[str, str], set[datetime.date]] = defaultdict(
+            set
+        )
         self._attributed_dividend_tax: DividendTaxAttribution | None = None
         self.interest_list: dict[
             tuple[str, CurrencyCode, datetime.date], ForeignCurrencyAmount
@@ -1086,6 +1095,7 @@ class CapitalGainsCalculator:
                 self.dividend_list[symbol, transaction.date] += ForeignCurrencyAmount(
                     amount, currency
                 )
+                self.dividend_dates[transaction.broker, symbol].add(transaction.date)
                 if self.date_in_tax_year(transaction.date):
                     dividends[symbol, currency] += amount
             elif transaction.action is ActionType.DIVIDEND_TAX:
@@ -1093,9 +1103,9 @@ class CapitalGainsCalculator:
                 symbol = get_symbol_or_fail(transaction)
                 currency = transaction.currency
                 new_balance += amount
-                self.dividend_tax_list[symbol, transaction.date] += (
-                    ForeignCurrencyAmount(amount, currency)
-                )
+                self.dividend_tax_list[
+                    transaction.broker, symbol, transaction.date
+                ] += ForeignCurrencyAmount(amount, currency)
             # Cash moves and nothing else: a deposit or withdrawal, a
             # correction, or an incoming wire. No shares change hands.
             elif transaction.action in {
@@ -2232,7 +2242,7 @@ class CapitalGainsCalculator:
 
     @staticmethod
     def _nearest_dividend_date(
-        date: datetime.date, dividend_dates: list[datetime.date]
+        date: datetime.date, dividend_dates: set[datetime.date]
     ) -> datetime.date | None:
         """Return the date of the dividend a withholding was taken from."""
         within = [
@@ -2242,36 +2252,39 @@ class CapitalGainsCalculator:
         ]
         if not within:
             return None
-        # A payment on the day of the withholding is nearest of all. Failing
-        # that the closest one wins, preferring the payment a correction
-        # follows when two are equally close.
-        return min(
-            within, key=lambda candidate: (abs((candidate - date).days), candidate)
-        )
+        # Tax is taken from a payment already made, and a correction corrects
+        # one, so a dividend on or before the withholding is preferred however
+        # much nearer a later payment falls. Choosing by distance alone sends
+        # a late correction to the next payment rather than the one it fixes,
+        # which for a monthly payer is most of them.
+        earlier = [candidate for candidate in within if candidate <= date]
+        if earlier:
+            return max(earlier)
+        # Nothing precedes it: a broker that posts tax before the payment.
+        return min(within)
 
     def _attribute_dividend_tax(self) -> DividendTaxAttribution:
         """Attribute each withholding to the dividend it was taken from.
 
         Brokers do not always date a withholding, or a later correction of
         one such as a Schwab ``NRA Tax Adj``, on the day of the payment it
-        belongs to. Tax is matched to a dividend of the same symbol on the
-        same day where there is one, and otherwise to the nearest dividend
-        of that symbol within ``DIVIDEND_TAX_MATCH_DAYS``.
+        belongs to. Tax is matched to a dividend of the same broker and
+        symbol within ``DIVIDEND_TAX_MATCH_DAYS``, preferring the payment it
+        follows. Holding one symbol at two brokers therefore keeps each
+        broker's withholding with that broker's own payments.
 
         Matching runs over the whole history rather than the reported year,
         so a payment and its withholding either side of 5 April stay
         together, and one withholding cannot be claimed in two years.
         """
-        dividend_dates: dict[str, list[datetime.date]] = defaultdict(list)
-        for symbol, date in self.dividend_list:
-            dividend_dates[symbol].append(date)
-
         matched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
         unmatched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
-        for (symbol, date), tax in self.dividend_tax_list.items():
+        for (broker, symbol, date), tax in self.dividend_tax_list.items():
             if not tax.amount:
                 continue
-            match = self._nearest_dividend_date(date, dividend_dates.get(symbol, []))
+            match = self._nearest_dividend_date(
+                date, self.dividend_dates.get((broker, symbol), set())
+            )
             if match is None:
                 self._warn_unattributed_dividend_tax(symbol, date, tax)
                 unmatched[symbol, date] += tax

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -22,6 +22,7 @@ from .const import (
     DIVIDEND_ALLOWANCES,
     DIVIDEND_CURRENCY_TO_COUNTRY,
     DIVIDEND_DOUBLE_TAXATION_RULES,
+    DIVIDEND_TAX_MATCH_DAYS,
     ERI_TAX_DATE_DELTA,
     INTERNAL_START_DATE,
     ISIN_COUNTRY_CODE_LENGTH,
@@ -2179,39 +2180,82 @@ class CapitalGainsCalculator:
             return isin[:ISIN_COUNTRY_CODE_LENGTH]
         return DIVIDEND_CURRENCY_TO_COUNTRY.get(currency)
 
-    def _warn_unattributed_dividend_tax(self) -> None:
-        """Warn about withheld tax that no dividend of the same date claims.
+    def _warn_unattributed_dividend_tax(
+        self, symbol: str, date: datetime.date, tax: ForeignCurrencyAmount
+    ) -> None:
+        """Warn about withheld tax that belongs to no dividend."""
+        # Withholding of another year is another year's problem, as for the
+        # treaty warnings raised below.
+        if not self.date_in_tax_year(date):
+            return
+        # Tax below half a unit would print as a bare "-0.00", so it is
+        # shown as it stands instead. Whether it is material is a question
+        # about its value in GBP, and answering it here would put a rate
+        # lookup, and the failure of one, in the way of a warning.
+        amount = round_decimal(tax.amount, 2) or tax.amount
+        LOGGER.warning(
+            "Dividend tax of %s %s for %s on %s is not attributed to any "
+            "dividend within %d days, so it is left out of the report!",
+            amount,
+            tax.currency,
+            symbol,
+            date,
+            DIVIDEND_TAX_MATCH_DAYS,
+        )
 
-        Withholding is attributed to a dividend of the same symbol and date.
-        A broker that dates a correction apart from the payment it corrects,
-        such as a Schwab ``NRA Tax Adj``, leaves tax that no dividend claims,
-        and it is reported as if it had never been withheld.
+    @staticmethod
+    def _nearest_dividend_date(
+        date: datetime.date, dividend_dates: list[datetime.date]
+    ) -> datetime.date | None:
+        """Return the date of the dividend a withholding was taken from."""
+        within = [
+            candidate
+            for candidate in dividend_dates
+            if abs((candidate - date).days) <= DIVIDEND_TAX_MATCH_DAYS
+        ]
+        if not within:
+            return None
+        # A payment on the day of the withholding is nearest of all. Failing
+        # that the closest one wins, preferring the payment a correction
+        # follows when two are equally close.
+        return min(
+            within, key=lambda candidate: (abs((candidate - date).days), candidate)
+        )
+
+    def _attribute_dividend_tax(self) -> ForeignAmountLog:
+        """Attribute each withholding to the dividend it was taken from.
+
+        Brokers do not always date a withholding, or a later correction of
+        one such as a Schwab ``NRA Tax Adj``, on the day of the payment it
+        belongs to. Tax is matched to a dividend of the same symbol on the
+        same day where there is one, and otherwise to the nearest dividend
+        of that symbol within ``DIVIDEND_TAX_MATCH_DAYS``.
+
+        Matching runs over the whole history rather than the reported year,
+        so a payment and its withholding either side of 5 April stay
+        together, and one withholding cannot be claimed in two years.
         """
+        dividend_dates: dict[str, list[datetime.date]] = defaultdict(list)
+        for symbol, date in self.dividend_list:
+            dividend_dates[symbol].append(date)
+
+        attributed: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
         for (symbol, date), tax in self.dividend_tax_list.items():
-            if not self.date_in_tax_year(date) or not tax.amount:
+            if not tax.amount:
                 continue
-            if (symbol, date) in self.dividend_list:
+            match = self._nearest_dividend_date(date, dividend_dates.get(symbol, []))
+            if match is None:
+                self._warn_unattributed_dividend_tax(symbol, date, tax)
                 continue
-            # Tax below half a unit would print as a bare "-0.00", so it is
-            # shown as it stands instead. Whether it is material is a question
-            # about its value in GBP, and answering it here would put a rate
-            # lookup, and the failure of one, in the way of a warning.
-            amount = round_decimal(tax.amount, 2) or tax.amount
-            LOGGER.warning(
-                "Dividend tax of %s %s for %s on %s is not attributed to any "
-                "dividend of that date, so it is left out of the report!",
-                amount,
-                tax.currency,
-                symbol,
-                date,
-            )
+            attributed[symbol, match] += tax
+        return attributed
 
     def process_dividends(self) -> None:
         """Process all dividend events and taxes.
 
         It updates the interest total for the year if needed.
         """
-        self._warn_unattributed_dividend_tax()
+        attributed_tax = self._attribute_dividend_tax()
         for (symbol, date), foreign_amount in self.dividend_list.items():
             # Dividends outside the computed tax year are not reported, so
             # neither are the warnings raised while resolving their treaty.
@@ -2219,8 +2263,8 @@ class CapitalGainsCalculator:
                 continue
 
             # Read without inserting: a dividend with no tax must not leave a
-            # zero entry behind in the withholding log.
-            tax = self.dividend_tax_list.get((symbol, date), ForeignCurrencyAmount())
+            # zero entry behind in the attribution.
+            tax = attributed_tax.get((symbol, date), ForeignCurrencyAmount())
             currency = foreign_amount.currency
             assert currency is not None, f"Dividend for {symbol} has no currency"
 

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -239,6 +239,7 @@ class CapitalGainsCalculator:
 
         self.dividend_list: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
         self.dividend_tax_list: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
+        self._attributed_dividend_tax: ForeignAmountLog | None = None
         self.interest_list: dict[
             tuple[str, CurrencyCode, datetime.date], ForeignCurrencyAmount
         ] = defaultdict(ForeignCurrencyAmount)
@@ -1081,8 +1082,6 @@ class CapitalGainsCalculator:
                 self.dividend_tax_list[symbol, transaction.date] += (
                     ForeignCurrencyAmount(amount, currency)
                 )
-                if self.date_in_tax_year(transaction.date):
-                    dividends_tax[symbol, currency] += amount
             # Cash moves and nothing else: a deposit or withdrawal, a
             # correction, or an incoming wire. No shares change hands.
             elif transaction.action in {
@@ -1154,6 +1153,13 @@ class CapitalGainsCalculator:
                 msg += "Tip: If your input file is missing deposits/withdrawals use --no-balance-check."
                 raise CalculationError(msg)
             balance[transaction.broker, transaction.currency] = new_balance
+
+        # Withholding belongs to the year of the dividend it was taken from,
+        # which is not always the year it was posted in, so the summary reads
+        # it from the same attribution the report is built from.
+        for (symbol, date), tax in self._dividend_tax_attribution().items():
+            if self.date_in_tax_year(date) and tax.currency is not None:
+                dividends_tax[symbol, tax.currency] += tax.amount
 
         self.first_pass_report(
             balance,
@@ -2250,12 +2256,21 @@ class CapitalGainsCalculator:
             attributed[symbol, match] += tax
         return attributed
 
+    def _dividend_tax_attribution(self) -> ForeignAmountLog:
+        """Attribute withholding once, for both the summary and the report.
+
+        The two must agree, and attributing twice would warn twice.
+        """
+        if self._attributed_dividend_tax is None:
+            self._attributed_dividend_tax = self._attribute_dividend_tax()
+        return self._attributed_dividend_tax
+
     def process_dividends(self) -> None:
         """Process all dividend events and taxes.
 
         It updates the interest total for the year if needed.
         """
-        attributed_tax = self._attribute_dividend_tax()
+        attributed_tax = self._dividend_tax_attribution()
         for (symbol, date), foreign_amount in self.dividend_list.items():
             # Dividends outside the computed tax year are not reported, so
             # neither are the warnings raised while resolving their treaty.

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -2219,13 +2219,22 @@ class CapitalGainsCalculator:
         return DIVIDEND_CURRENCY_TO_COUNTRY.get(currency)
 
     def _warn_unattributed_dividend_tax(
-        self, symbol: str, date: datetime.date, tax: ForeignCurrencyAmount
+        self,
+        symbol: str,
+        date: datetime.date,
+        tax: ForeignCurrencyAmount,
+        lead_days: int,
     ) -> None:
         """Warn about withheld tax that belongs to no dividend."""
         # Withholding of another year is another year's problem, as for the
         # treaty warnings raised below.
         if not self.date_in_tax_year(date):
             return
+        # Name the window actually searched. It reaches forward only for tax
+        # taken, not for tax given back, so the two read differently.
+        searched = f"the {DIVIDEND_TAX_MATCH_DAYS} days before it"
+        if lead_days:
+            searched += f" or the {lead_days} days after"
         # Tax below half a unit would print as a bare "-0.00", so it is
         # shown as it stands instead. Whether it is material is a question
         # about its value in GBP, and answering it here would put a rate
@@ -2233,17 +2242,17 @@ class CapitalGainsCalculator:
         amount = round_decimal(tax.amount, 2) or tax.amount
         LOGGER.warning(
             "Dividend tax of %s %s for %s on %s is not attributed to any "
-            "dividend within %d days, so it is left out of the report!",
+            "dividend in %s, so it is left out of the report!",
             amount,
             tax.currency,
             symbol,
             date,
-            DIVIDEND_TAX_MATCH_DAYS,
+            searched,
         )
 
     @staticmethod
     def _nearest_dividend_date(
-        date: datetime.date, dividend_dates: set[datetime.date]
+        date: datetime.date, dividend_dates: set[datetime.date], lead_days: int
     ) -> datetime.date | None:
         """Return the date of the dividend a withholding was taken from.
 
@@ -2251,16 +2260,14 @@ class CapitalGainsCalculator:
         things. Tax follows the payment it was taken from, and a correction
         follows it by longer, so the search reaches back weeks. A payment
         after the withholding only means the broker posted the tax early,
-        which it does by days, so the search barely reaches forward. Looking
-        equally far both ways would let a monthly holding's next payment
-        claim a correction belonging to the last one.
+        which it does by days, so ``lead_days`` is short. Looking equally far
+        both ways would let a monthly holding's next payment claim a
+        correction belonging to the last one.
         """
         within = [
             candidate
             for candidate in dividend_dates
-            if -DIVIDEND_TAX_MATCH_DAYS
-            <= (candidate - date).days
-            <= DIVIDEND_TAX_LEAD_DAYS
+            if -DIVIDEND_TAX_MATCH_DAYS <= (candidate - date).days <= lead_days
         ]
         if not within:
             return None
@@ -2288,11 +2295,17 @@ class CapitalGainsCalculator:
         for (broker, symbol, date), tax in self.dividend_tax_list.items():
             if not tax.amount:
                 continue
+            # Tax given back can only answer for a payment already made: a
+            # broker does not refund tax on income it has yet to pay. So a
+            # credit looks no further forward than the day it lands on, which
+            # is what keeps a refund of last month's withholding off next
+            # month's payment when that payment is the nearer of the two.
+            lead_days = 0 if tax.amount > 0 else DIVIDEND_TAX_LEAD_DAYS
             match = self._nearest_dividend_date(
-                date, self.dividend_dates.get((broker, symbol), set())
+                date, self.dividend_dates.get((broker, symbol), set()), lead_days
             )
             if match is None:
-                self._warn_unattributed_dividend_tax(symbol, date, tax)
+                self._warn_unattributed_dividend_tax(symbol, date, tax, lead_days)
                 unmatched[symbol, date] += tax
                 continue
             matched[symbol, match] += tax

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -2223,57 +2223,68 @@ class CapitalGainsCalculator:
         symbol: str,
         date: datetime.date,
         tax: ForeignCurrencyAmount,
-        lead_days: int,
+        candidates: list[datetime.date],
     ) -> None:
-        """Warn about withheld tax that belongs to no dividend."""
+        """Warn about withheld tax that no single dividend can claim."""
         # Withholding of another year is another year's problem, as for the
         # treaty warnings raised below.
         if not self.date_in_tax_year(date):
             return
-        # Name the window actually searched. It reaches forward only for tax
-        # taken, not for tax given back, so the two read differently.
-        searched = f"the {DIVIDEND_TAX_MATCH_DAYS} days before it"
-        if lead_days:
-            searched += f" or the {lead_days} days after"
         # Tax below half a unit would print as a bare "-0.00", so it is
         # shown as it stands instead. Whether it is material is a question
         # about its value in GBP, and answering it here would put a rate
         # lookup, and the failure of one, in the way of a warning.
         amount = round_decimal(tax.amount, 2) or tax.amount
+        if candidates:
+            LOGGER.warning(
+                "Dividend tax of %s %s for %s on %s could have been taken "
+                "from the dividend on %s, so it is left out of the report! "
+                "Date it on the one it belongs to to have it counted.",
+                amount,
+                tax.currency,
+                symbol,
+                date,
+                " or ".join(str(candidate) for candidate in candidates),
+            )
+            return
         LOGGER.warning(
-            "Dividend tax of %s %s for %s on %s is not attributed to any "
-            "dividend in %s, so it is left out of the report!",
+            "Dividend tax of %s %s for %s on %s has no dividend in the %d "
+            "days before it or the %d days after, so it is left out of the "
+            "report!",
             amount,
             tax.currency,
             symbol,
             date,
-            searched,
+            DIVIDEND_TAX_MATCH_DAYS,
+            DIVIDEND_TAX_LEAD_DAYS,
         )
 
     @staticmethod
-    def _nearest_dividend_date(
-        date: datetime.date, dividend_dates: set[datetime.date], lead_days: int
-    ) -> datetime.date | None:
-        """Return the date of the dividend a withholding was taken from.
+    def _dividends_for_tax(
+        date: datetime.date, dividend_dates: set[datetime.date]
+    ) -> list[datetime.date]:
+        """Return the dividends a withholding could have been taken from.
 
-        The window is asymmetric because the two directions mean different
+        A payment on the day of the withholding is not in doubt, whatever
+        else lies nearby. Otherwise, every payment in the window counts as a
+        candidate, and it is for the caller to refuse when there is more
+        than one: which of two payments a correction belongs to cannot be
+        told from a date and a net amount.
+
+        The window is asymmetric because the directions mean different
         things. Tax follows the payment it was taken from, and a correction
-        follows it by longer, so the search reaches back weeks. A payment
-        after the withholding only means the broker posted the tax early,
-        which it does by days, so ``lead_days`` is short. Looking equally far
-        both ways would let a monthly holding's next payment claim a
-        correction belonging to the last one.
+        follows it by longer, so it reaches back weeks; a payment after the
+        withholding only means the broker posted the tax early, which it
+        does by days.
         """
-        within = [
+        if date in dividend_dates:
+            return [date]
+        return sorted(
             candidate
             for candidate in dividend_dates
-            if -DIVIDEND_TAX_MATCH_DAYS <= (candidate - date).days <= lead_days
-        ]
-        if not within:
-            return None
-        # Nearest wins, and a payment on or before the withholding takes a tie.
-        return min(
-            within, key=lambda candidate: (abs((candidate - date).days), candidate)
+            if -DIVIDEND_TAX_MATCH_DAYS
+            <= (candidate - date).days
+            <= DIVIDEND_TAX_LEAD_DAYS
         )
 
     def _attribute_dividend_tax(self) -> DividendTaxAttribution:
@@ -2281,10 +2292,17 @@ class CapitalGainsCalculator:
 
         Brokers do not always date a withholding, or a later correction of
         one such as a Schwab ``NRA Tax Adj``, on the day of the payment it
-        belongs to. Tax is matched to a dividend of the same broker and
-        symbol within ``DIVIDEND_TAX_MATCH_DAYS``, preferring the payment it
-        follows. Holding one symbol at two brokers therefore keeps each
-        broker's withholding with that broker's own payments.
+        belongs to, so tax is matched to a dividend of the same broker and
+        symbol nearby. Holding one symbol at two brokers therefore keeps
+        each broker's withholding with that broker's own payments.
+
+        Tax is attributed only where one payment can claim it. Where two
+        could, the export does not record which, and no arrangement of dates
+        and amounts recovers it: an adjustment reaching back to last month's
+        payment looks exactly like ordinary tax on next month's. Those are
+        left out of the report and warned about instead of guessed at. They
+        still reach the summary, and dating one on its dividend in the input
+        settles it.
 
         Matching runs over the whole history rather than the reported year,
         so a payment and its withholding either side of 5 April stay
@@ -2295,20 +2313,18 @@ class CapitalGainsCalculator:
         for (broker, symbol, date), tax in self.dividend_tax_list.items():
             if not tax.amount:
                 continue
-            # Tax given back can only answer for a payment already made: a
-            # broker does not refund tax on income it has yet to pay. So a
-            # credit looks no further forward than the day it lands on, which
-            # is what keeps a refund of last month's withholding off next
-            # month's payment when that payment is the nearer of the two.
-            lead_days = 0 if tax.amount > 0 else DIVIDEND_TAX_LEAD_DAYS
-            match = self._nearest_dividend_date(
-                date, self.dividend_dates.get((broker, symbol), set()), lead_days
+            candidates = self._dividends_for_tax(
+                date, self.dividend_dates.get((broker, symbol), set())
             )
-            if match is None:
-                self._warn_unattributed_dividend_tax(symbol, date, tax, lead_days)
-                unmatched[symbol, date] += tax
+            if len(candidates) == 1:
+                matched[symbol, candidates[0]] += tax
                 continue
-            matched[symbol, match] += tax
+            # Either nothing is near enough, or two payments are and the
+            # export does not say which one this is. Guessing between them
+            # puts a wrong figure in the report; leaving it out and saying so
+            # does not.
+            self._warn_unattributed_dividend_tax(symbol, date, tax, candidates)
+            unmatched[symbol, date] += tax
         return DividendTaxAttribution(matched, unmatched)
 
     def _dividend_tax_attribution(self) -> DividendTaxAttribution:

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -9,7 +9,7 @@ import decimal
 from decimal import Decimal
 import logging
 import sys
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING
 
 from colorama import Fore, Style
 
@@ -59,6 +59,7 @@ from .model import (
     CapitalGainsReport,
     CurrencyCode,
     Dividend,
+    DividendTaxAttribution,
     ExcessReportedIncome,
     ExcessReportedIncomeDistribution,
     ExcessReportedIncomeDistributionLog,
@@ -176,20 +177,6 @@ def _match_gifts_to_rows(
                 return True
             available[reading] += 1
     return False
-
-
-class DividendTaxAttribution(NamedTuple):
-    """Withheld tax sorted by whether a dividend was found to carry it."""
-
-    matched: ForeignAmountLog
-    """Keyed by the symbol and date of the dividend the tax was taken from."""
-
-    unmatched: ForeignAmountLog
-    """Keyed by the symbol and date of the withholding itself.
-
-    No dividend row can carry this tax, but the broker took it all the same,
-    so the summary reports it against the year it was taken in.
-    """
 
 
 class CapitalGainsCalculator:
@@ -2242,7 +2229,8 @@ class CapitalGainsCalculator:
             LOGGER.warning(
                 "Dividend tax of %s %s for %s on %s could have been taken "
                 "from the dividend on %s, so it is left out of the report! "
-                "Date it on the one it belongs to to have it counted.",
+                "Date it in the export on the one it belongs to to have it "
+                "counted.",
                 amount,
                 tax.currency,
                 symbol,

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -22,6 +22,7 @@ from .const import (
     DIVIDEND_ALLOWANCES,
     DIVIDEND_CURRENCY_TO_COUNTRY,
     DIVIDEND_DOUBLE_TAXATION_RULES,
+    DIVIDEND_TAX_LEAD_DAYS,
     DIVIDEND_TAX_MATCH_DAYS,
     ERI_TAX_DATE_DELTA,
     INTERNAL_START_DATE,
@@ -2244,24 +2245,29 @@ class CapitalGainsCalculator:
     def _nearest_dividend_date(
         date: datetime.date, dividend_dates: set[datetime.date]
     ) -> datetime.date | None:
-        """Return the date of the dividend a withholding was taken from."""
+        """Return the date of the dividend a withholding was taken from.
+
+        The window is asymmetric because the two directions mean different
+        things. Tax follows the payment it was taken from, and a correction
+        follows it by longer, so the search reaches back weeks. A payment
+        after the withholding only means the broker posted the tax early,
+        which it does by days, so the search barely reaches forward. Looking
+        equally far both ways would let a monthly holding's next payment
+        claim a correction belonging to the last one.
+        """
         within = [
             candidate
             for candidate in dividend_dates
-            if abs((candidate - date).days) <= DIVIDEND_TAX_MATCH_DAYS
+            if -DIVIDEND_TAX_MATCH_DAYS
+            <= (candidate - date).days
+            <= DIVIDEND_TAX_LEAD_DAYS
         ]
         if not within:
             return None
-        # Tax is taken from a payment already made, and a correction corrects
-        # one, so a dividend on or before the withholding is preferred however
-        # much nearer a later payment falls. Choosing by distance alone sends
-        # a late correction to the next payment rather than the one it fixes,
-        # which for a monthly payer is most of them.
-        earlier = [candidate for candidate in within if candidate <= date]
-        if earlier:
-            return max(earlier)
-        # Nothing precedes it: a broker that posts tax before the payment.
-        return min(within)
+        # Nearest wins, and a payment on or before the withholding takes a tie.
+        return min(
+            within, key=lambda candidate: (abs((candidate - date).days), candidate)
+        )
 
     def _attribute_dividend_tax(self) -> DividendTaxAttribution:
         """Attribute each withholding to the dividend it was taken from.

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -2226,9 +2226,12 @@ class CapitalGainsCalculator:
         candidates: list[datetime.date],
     ) -> None:
         """Warn about withheld tax that no single dividend can claim."""
-        # Withholding of another year is another year's problem, as for the
-        # treaty warnings raised below.
-        if not self.date_in_tax_year(date):
+        # The tax is missing from the report of every year that holds a
+        # payment which could have carried it, not only from the year it was
+        # taken in, and each of those years is entitled to hear so. A
+        # withholding just after 5 April can leave a payment short on either
+        # side of the boundary.
+        if not any(self.date_in_tax_year(affected) for affected in (date, *candidates)):
             return
         # Tax below half a unit would print as a bare "-0.00", so it is
         # shown as it stands instead. Whether it is material is a question

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from enum import Enum
 import re
 import sys
-from typing import TYPE_CHECKING, Final, Self, override
+from typing import TYPE_CHECKING, Final, NamedTuple, Self, override
 
 from colorama import Style
 
@@ -212,6 +212,20 @@ ExcessReportedIncomeLog = dict[datetime.date, dict[str, ExcessReportedIncome]]
 ExcessReportedIncomeDistributionLog = dict[
     datetime.date, dict[str, ExcessReportedIncomeDistribution]
 ]
+
+
+class DividendTaxAttribution(NamedTuple):
+    """Withheld tax sorted by whether a dividend was found to carry it."""
+
+    matched: ForeignAmountLog
+    """Keyed by the symbol and date of the dividend the tax was taken from."""
+
+    unmatched: ForeignAmountLog
+    """Keyed by the symbol and date of the withholding itself.
+
+    No dividend row can carry this tax, but the broker took it all the same,
+    so the summary reports it against the year it was taken in.
+    """
 
 
 class ActionType(Enum):

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -203,6 +203,29 @@ def test_tax_on_a_payment_day_is_never_in_doubt(
     assert _unattributed_warnings(transactions, caplog) == []
 
 
+def test_ambiguous_tax_warns_in_the_year_of_each_payment(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A payment left short hears about it, in either year it falls in.
+
+    A withholding just after 5 April can belong to a payment on either side
+    of the boundary. Scoping the warning to the year the tax was taken in
+    left the earlier year reporting its dividend with no tax and saying
+    nothing about why.
+    """
+    transactions = [
+        dividend_transaction(datetime.date(2025, 4, 2), "FOO", 100),
+        dividend_tax_transaction(datetime.date(2025, 4, 6), "FOO", 15),
+        dividend_transaction(datetime.date(2025, 4, 10), "FOO", 200),
+    ]
+
+    assert _reported(transactions, tax_year=2024) == [
+        (datetime.date(2025, 4, 2), Decimal(100), Decimal(0), False)
+    ]
+    assert len(_unattributed_warnings(transactions, caplog, tax_year=2024)) == 1
+    assert len(_unattributed_warnings(transactions, caplog, tax_year=2025)) == 1
+
+
 def test_tax_two_payments_could_claim_is_left_out(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -24,21 +24,28 @@ if TYPE_CHECKING:
 
 USD = CurrencyCode("USD")
 
-# The tax year under test, two dates inside it a few days apart, and one in an
-# earlier year, so that withholding can be placed on or off its dividend's date
-# and inside or outside the reported year.
+# The tax year under test, a dividend inside it, and withholding placed at
+# various distances from that dividend: two days away, exactly at the
+# thirty-day limit, one day past it, and far outside.
 TAX_YEAR = 2024
 DIVIDEND_DATE = datetime.date(2024, 6, 3)
-LATER_DATE = datetime.date(2024, 6, 5)
-EARLIER_YEAR_DATE = datetime.date(2022, 6, 3)
+LATER_DATE = DIVIDEND_DATE + datetime.timedelta(days=2)
+LIMIT_DATE = DIVIDEND_DATE + datetime.timedelta(days=30)
+BEYOND_LIMIT_DATE = DIVIDEND_DATE + datetime.timedelta(days=31)
+
+# A payment at the very end of 2024/25 whose withholding posts in 2025/26.
+BORDER_DIVIDEND_DATE = datetime.date(2025, 4, 2)
+BORDER_TAX_DATE = datetime.date(2025, 4, 8)
 
 
-def _calculator(transactions: list[BrokerTransaction]) -> CapitalGainsCalculator:
+def _calculator(
+    transactions: list[BrokerTransaction], tax_year: int = TAX_YEAR
+) -> CapitalGainsCalculator:
     """Create a calculator with a flat 1:1 USD rate for the dates in use."""
     gbp_prices = {t.date: {USD: Decimal(1)} for t in transactions}
     currency_converter = CurrencyConverter(None, gbp_prices)
     return CapitalGainsCalculator(
-        TAX_YEAR,
+        tax_year,
         currency_converter,
         IsinConverter(),
         CurrentPriceFetcher(currency_converter, {}, {}),
@@ -49,12 +56,42 @@ def _calculator(transactions: list[BrokerTransaction]) -> CapitalGainsCalculator
     )
 
 
+def _reported(
+    transactions: list[BrokerTransaction], tax_year: int = TAX_YEAR
+) -> list[tuple[datetime.date, Decimal, Decimal, bool]]:
+    """Return date, amount, tax and whether a treaty applied, per reported row."""
+    calculator = _calculator(transactions, tax_year)
+    calculator.convert_to_hmrc_transactions(transactions)
+    calculator.process_dividends()
+    rows = []
+    for entries in calculator.calculation_log_yields.values():
+        for key, log in entries.items():
+            if not key.startswith("dividend$"):
+                continue
+            for entry in log:
+                dividend = entry.dividend
+                assert dividend is not None
+                rows.append(
+                    (
+                        dividend.date,
+                        dividend.amount,
+                        dividend.tax_at_source,
+                        dividend.tax_treaty is not None,
+                    )
+                )
+    return sorted(rows)
+
+
 def _unattributed_warnings(
     transactions: list[BrokerTransaction],
     caplog: pytest.LogCaptureFixture,
+    tax_year: int = TAX_YEAR,
 ) -> list[str]:
     """Run the dividend pass and return the unattributed tax warnings."""
-    calculator = _calculator(transactions)
+    # A test that also reports the run has already made the calculator warn
+    # once, and those records must not be counted again here.
+    caplog.clear()
+    calculator = _calculator(transactions, tax_year)
     with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
         calculator.convert_to_hmrc_transactions(transactions)
         calculator.process_dividends()
@@ -65,31 +102,102 @@ def _unattributed_warnings(
     ]
 
 
-def test_withholding_on_its_dividend_date_does_not_warn(
+def test_withholding_on_its_dividend_date_is_attributed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Tax taken on the day of its dividend is attributed, so it is silent."""
+    """Tax taken on the day of its dividend belongs to it, as it always did."""
     transactions = [
         dividend_transaction(DIVIDEND_DATE, "FOO", 100),
         dividend_tax_transaction(DIVIDEND_DATE, "FOO", 15),
     ]
 
+    assert _reported(transactions) == [
+        (DIVIDEND_DATE, Decimal(100), Decimal(-15), True)
+    ]
     assert _unattributed_warnings(transactions, caplog) == []
 
 
-def test_withholding_dated_apart_from_its_dividend_warns(
+def test_withholding_dated_apart_from_its_dividend_is_attributed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Tax dated apart from its dividend is left out, so it is reported."""
+    """Tax posted a couple of days late still belongs to its dividend."""
     transactions = [
         dividend_transaction(DIVIDEND_DATE, "FOO", 100),
         dividend_tax_transaction(LATER_DATE, "FOO", 15),
     ]
 
+    assert _reported(transactions) == [
+        (DIVIDEND_DATE, Decimal(100), Decimal(-15), True)
+    ]
+    assert _unattributed_warnings(transactions, caplog) == []
+
+
+def test_correction_of_an_over_withholding_is_attributed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Withholding at 30% later corrected to the treaty rate reports as 15%."""
+    transactions = [
+        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(DIVIDEND_DATE, "FOO", 30),
+        dividend_tax_transaction(LATER_DATE, "FOO", -15),
+    ]
+
+    assert _reported(transactions) == [
+        (DIVIDEND_DATE, Decimal(100), Decimal(-15), True)
+    ]
+    assert _unattributed_warnings(transactions, caplog) == []
+
+
+def test_each_dividend_keeps_its_own_withholding(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tax goes to the nearer payment when two could claim it."""
+    second_date = datetime.date(2024, 9, 5)
+    transactions = [
+        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(DIVIDEND_DATE, "FOO", 15),
+        dividend_transaction(second_date, "FOO", 200),
+        dividend_tax_transaction(second_date + datetime.timedelta(days=4), "FOO", 30),
+    ]
+
+    assert _reported(transactions) == [
+        (DIVIDEND_DATE, Decimal(100), Decimal(-15), True),
+        (second_date, Decimal(200), Decimal(-30), True),
+    ]
+    assert _unattributed_warnings(transactions, caplog) == []
+
+
+def test_withholding_at_the_limit_is_attributed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Thirty days away is still near enough to belong to the dividend."""
+    transactions = [
+        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(LIMIT_DATE, "FOO", 15),
+    ]
+
+    assert _reported(transactions) == [
+        (DIVIDEND_DATE, Decimal(100), Decimal(-15), True)
+    ]
+    assert _unattributed_warnings(transactions, caplog) == []
+
+
+def test_withholding_beyond_the_limit_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A day past the limit is too far to attribute to the dividend."""
+    transactions = [
+        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(BEYOND_LIMIT_DATE, "FOO", 15),
+    ]
+
+    assert _reported(transactions) == [(DIVIDEND_DATE, Decimal(100), Decimal(0), False)]
+
     warnings = _unattributed_warnings(transactions, caplog)
 
     assert len(warnings) == 1
-    assert "-15.00 USD for FOO on 2024-06-05" in warnings[0]
+    assert "-15.00 USD for FOO on 2024-07-04" in warnings[0]
+    assert "within 30 days" in warnings[0]
 
 
 def test_withholding_without_any_dividend_warns(
@@ -104,6 +212,29 @@ def test_withholding_without_any_dividend_warns(
     assert "-15.00 USD for FOO on 2024-06-03" in warnings[0]
 
 
+def test_withholding_across_the_tax_year_end_stays_with_its_dividend() -> None:
+    """A payment on 2 April keeps tax posted on 8 April, in the earlier year."""
+    transactions = [
+        dividend_transaction(BORDER_DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(BORDER_TAX_DATE, "FOO", 15),
+    ]
+
+    assert _reported(transactions, tax_year=2024) == [
+        (BORDER_DIVIDEND_DATE, Decimal(100), Decimal(-15), True)
+    ]
+    # The later year must not claim the same withholding a second time.
+    assert _reported(transactions, tax_year=2025) == []
+
+
+def test_unattributed_withholding_outside_tax_year_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Only withholding of the computed year may warn, as for the treaty."""
+    transactions = [dividend_tax_transaction(datetime.date(2022, 6, 3), "FOO", 15)]
+
+    assert _unattributed_warnings(transactions, caplog) == []
+
+
 def test_unattributed_withholding_below_a_penny_shows_its_own_value(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -113,10 +244,7 @@ def test_unattributed_withholding_below_a_penny_shows_its_own_value(
     this warning deliberately does not work out, so it reports the loss and
     leaves that judgement to the reader.
     """
-    transactions = [
-        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
-        dividend_tax_transaction(LATER_DATE, "FOO", 0.004),
-    ]
+    transactions = [dividend_tax_transaction(DIVIDEND_DATE, "FOO", 0.004)]
 
     warnings = _unattributed_warnings(transactions, caplog)
 
@@ -129,10 +257,7 @@ def test_unattributed_withholding_of_half_a_penny_warns(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Half a penny rounds up to one, which the report can show."""
-    transactions = [
-        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
-        dividend_tax_transaction(LATER_DATE, "FOO", 0.005),
-    ]
+    transactions = [dividend_tax_transaction(DIVIDEND_DATE, "FOO", 0.005)]
 
     warnings = _unattributed_warnings(transactions, caplog)
 
@@ -140,34 +265,11 @@ def test_unattributed_withholding_of_half_a_penny_warns(
     assert "-0.01 USD for FOO" in warnings[0]
 
 
-def test_unattributed_withholding_outside_tax_year_does_not_warn(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Only withholding of the computed year may warn, as for the treaty."""
-    transactions = [
-        dividend_transaction(EARLIER_YEAR_DATE, "FOO", 100),
-        dividend_tax_transaction(
-            EARLIER_YEAR_DATE + datetime.timedelta(days=2), "FOO", 15
-        ),
-    ]
-
-    assert _unattributed_warnings(transactions, caplog) == []
-
-
-def test_dividend_without_withholding_does_not_warn(
+def test_dividend_without_withholding_leaves_no_entry(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A dividend taxed nowhere leaves no zero entry to warn about."""
     transactions = [dividend_transaction(DIVIDEND_DATE, "FOO", 100)]
-    calculator = _calculator(transactions)
 
-    with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
-        calculator.convert_to_hmrc_transactions(transactions)
-        calculator.process_dividends()
-
-    assert [
-        record.message
-        for record in caplog.records
-        if "is not attributed to any dividend" in record.message
-    ] == []
-    assert (("FOO", DIVIDEND_DATE)) not in calculator.dividend_tax_list
+    assert _reported(transactions) == [(DIVIDEND_DATE, Decimal(100), Decimal(0), False)]
+    assert _unattributed_warnings(transactions, caplog) == []

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -255,7 +255,7 @@ def test_tax_two_payments_could_claim_is_left_out(
 
     assert len(warnings) == 1
     assert "the dividend on 2024-06-03 or 2024-07-03" in warnings[0]
-    assert "Date it on the one it belongs to" in warnings[0]
+    assert "Date it in the export on the one it belongs to" in warnings[0]
 
 
 def test_further_withholding_two_payments_could_claim_is_left_out(

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -159,6 +159,38 @@ def test_summary_counts_withholding_dated_apart_from_its_dividend(
     ]
 
 
+def test_summary_reports_withholding_with_no_dividend(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Tax the broker took is summarised even when no dividend can carry it."""
+    transactions = [dividend_tax_transaction(DIVIDEND_DATE, "FOO", 15)]
+
+    assert _summary_dividend_lines(transactions, capsys) == [
+        "  FOO: 0.00, excluding 15.00 taxed at source (USD)"
+    ]
+    assert _reported(transactions) == []
+
+
+def test_summary_reports_withholding_beyond_the_limit(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Tax too far from a dividend is summarised but carried by no row.
+
+    The two views differ here on purpose. The broker took the tax, so the
+    summary says so, while the report cannot say which payment it belongs
+    to and leaves it out. The warning raised for it reconciles the two.
+    """
+    transactions = [
+        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(BEYOND_LIMIT_DATE, "FOO", 15),
+    ]
+
+    assert _summary_dividend_lines(transactions, capsys) == [
+        "  FOO: 100.00, excluding 15.00 taxed at source (USD)"
+    ]
+    assert _reported(transactions) == [(DIVIDEND_DATE, Decimal(100), Decimal(0), False)]
+
+
 def test_withholding_on_its_dividend_date_is_attributed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -179,6 +179,46 @@ def test_late_correction_belongs_to_the_payment_it_corrects(
     assert _unattributed_warnings(transactions, caplog) == []
 
 
+def test_withholding_posted_before_its_dividend_waits_for_it(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tax posted just before a payment belongs to it, not the month before.
+
+    A broker that posts the withholding a day ahead of the payment leaves it
+    near the end of the previous payment's window, so preferring an earlier
+    payment outright would hand it to the wrong month.
+    """
+    first = datetime.date(2024, 6, 3)
+    early_tax = datetime.date(2024, 7, 2)  # 29 days after first, 1 day before second
+    second = datetime.date(2024, 7, 3)
+    transactions = [
+        dividend_transaction(first, "FOO", 100),
+        dividend_tax_transaction(first, "FOO", 15),
+        dividend_tax_transaction(early_tax, "FOO", 30),
+        dividend_transaction(second, "FOO", 200),
+    ]
+
+    assert _reported(transactions) == [
+        (first, Decimal(100), Decimal(-15), True),
+        (second, Decimal(200), Decimal(-30), True),
+    ]
+    assert _unattributed_warnings(transactions, caplog) == []
+
+
+def test_withholding_too_far_before_its_dividend_is_not_claimed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A payment further ahead than the lead window cannot claim the tax."""
+    dividend = DIVIDEND_DATE + datetime.timedelta(days=6)
+    transactions = [
+        dividend_transaction(dividend, "FOO", 100),
+        dividend_tax_transaction(DIVIDEND_DATE, "FOO", 15),
+    ]
+
+    assert _reported(transactions) == [(dividend, Decimal(100), Decimal(0), False)]
+    assert len(_unattributed_warnings(transactions, caplog)) == 1
+
+
 def test_withholding_stays_with_its_own_broker(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -96,7 +96,7 @@ def _unattributed_warnings(
     return [
         record.message
         for record in caplog.records
-        if "is not attributed to any dividend" in record.message
+        if "left out of the report" in record.message
     ]
 
 
@@ -179,22 +179,19 @@ def test_late_correction_belongs_to_the_payment_it_corrects(
     assert _unattributed_warnings(transactions, caplog) == []
 
 
-def test_refund_never_belongs_to_a_payment_still_to_come(
+def test_tax_on_a_payment_day_is_never_in_doubt(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A refund goes back to the payment it corrects, however near the next.
+    """Tax dated on a payment belongs to it, whatever else lies nearby.
 
-    Tax given back can only answer for income already paid, so a credit two
-    days before the next payment still belongs to the last one, even though
-    that payment is four weeks behind it.
+    A monthly payer always has a second payment inside the window, and that
+    must not make the ordinary case ambiguous.
     """
     first = datetime.date(2024, 6, 3)
-    refund = datetime.date(2024, 7, 1)  # 28 days after first, 2 days before second
-    second = datetime.date(2024, 7, 3)
+    second = first + datetime.timedelta(days=30)
     transactions = [
         dividend_transaction(first, "FOO", 100),
-        dividend_tax_transaction(first, "FOO", 30),
-        dividend_tax_transaction(refund, "FOO", -15),
+        dividend_tax_transaction(first, "FOO", 15),
         dividend_transaction(second, "FOO", 200),
         dividend_tax_transaction(second, "FOO", 30),
     ]
@@ -206,45 +203,103 @@ def test_refund_never_belongs_to_a_payment_still_to_come(
     assert _unattributed_warnings(transactions, caplog) == []
 
 
-def test_unmatched_refund_warning_names_only_the_backward_window(
+def test_tax_two_payments_could_claim_is_left_out(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The warning describes the window actually searched, which differs."""
+    """A correction near two payments is refused rather than guessed at.
+
+    A credit four weeks after one payment and two days before the next could
+    be a late correction of the first or ordinary tax on the second. The
+    export does not say which, so neither payment is given it.
+    """
+    first = datetime.date(2024, 6, 3)
+    correction = datetime.date(2024, 7, 1)
+    second = datetime.date(2024, 7, 3)
     transactions = [
-        dividend_transaction(DIVIDEND_DATE + datetime.timedelta(days=6), "FOO", 100),
-        dividend_tax_transaction(DIVIDEND_DATE, "FOO", -15),
+        dividend_transaction(first, "FOO", 100),
+        dividend_tax_transaction(first, "FOO", 30),
+        dividend_tax_transaction(correction, "FOO", -15),
+        dividend_transaction(second, "FOO", 200),
+        dividend_tax_transaction(second, "FOO", 30),
+    ]
+
+    assert _reported(transactions) == [
+        (first, Decimal(100), Decimal(-30), False),
+        (second, Decimal(200), Decimal(-30), True),
     ]
 
     warnings = _unattributed_warnings(transactions, caplog)
 
     assert len(warnings) == 1
-    assert "in the 30 days before it, so" in warnings[0]
+    assert "the dividend on 2024-06-03 or 2024-07-03" in warnings[0]
+    assert "Date it on the one it belongs to" in warnings[0]
 
 
-def test_withholding_posted_before_its_dividend_waits_for_it(
+def test_further_withholding_two_payments_could_claim_is_left_out(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Tax posted just before a payment belongs to it, not the month before.
+    """A second debit near two payments is refused, as a credit would be.
 
-    A broker that posts the withholding a day ahead of the payment leaves it
-    near the end of the previous payment's window, so preferring an earlier
-    payment outright would hand it to the wrong month.
+    Brokers map an adjustment and an ordinary withholding to one action, so
+    a further debit cannot be told from tax on the payment that follows it.
     """
     first = datetime.date(2024, 6, 3)
-    early_tax = datetime.date(2024, 7, 2)  # 29 days after first, 1 day before second
+    adjustment = datetime.date(2024, 7, 1)
+    second = datetime.date(2024, 7, 3)
+    transactions = [
+        dividend_transaction(first, "FOO", 100),
+        dividend_tax_transaction(first, "FOO", 10),
+        dividend_tax_transaction(adjustment, "FOO", 5),
+        dividend_transaction(second, "FOO", 200),
+        dividend_tax_transaction(second, "FOO", 30),
+    ]
+
+    assert _reported(transactions) == [
+        (first, Decimal(100), Decimal(-10), False),
+        (second, Decimal(200), Decimal(-30), True),
+    ]
+    assert len(_unattributed_warnings(transactions, caplog)) == 1
+
+
+def test_tax_left_out_is_still_summarised(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Tax no payment can claim still shows the broker took it."""
+    first = datetime.date(2024, 6, 3)
+    correction = datetime.date(2024, 7, 1)
+    second = datetime.date(2024, 7, 3)
+    transactions = [
+        dividend_transaction(first, "FOO", 100),
+        dividend_tax_transaction(first, "FOO", 10),
+        dividend_tax_transaction(correction, "FOO", 5),
+        dividend_transaction(second, "FOO", 200),
+        dividend_tax_transaction(second, "FOO", 30),
+    ]
+
+    assert _summary_dividend_lines(transactions, capsys) == [
+        "  FOO: 300.00, excluding 45.00 taxed at source (USD)"
+    ]
+
+
+def test_withholding_between_two_payments_is_left_out(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tax a day before one payment and weeks after another is refused."""
+    first = datetime.date(2024, 6, 3)
+    tax = datetime.date(2024, 7, 2)
     second = datetime.date(2024, 7, 3)
     transactions = [
         dividend_transaction(first, "FOO", 100),
         dividend_tax_transaction(first, "FOO", 15),
-        dividend_tax_transaction(early_tax, "FOO", 30),
+        dividend_tax_transaction(tax, "FOO", 30),
         dividend_transaction(second, "FOO", 200),
     ]
 
     assert _reported(transactions) == [
         (first, Decimal(100), Decimal(-15), True),
-        (second, Decimal(200), Decimal(-30), True),
+        (second, Decimal(200), Decimal(0), False),
     ]
-    assert _unattributed_warnings(transactions, caplog) == []
+    assert len(_unattributed_warnings(transactions, caplog)) == 1
 
 
 def test_withholding_too_far_before_its_dividend_is_not_claimed(
@@ -452,7 +507,7 @@ def test_withholding_beyond_the_limit_warns(
 
     assert len(warnings) == 1
     assert "-15.00 USD for FOO on 2024-07-04" in warnings[0]
-    assert "in the 30 days before it or the 5 days after" in warnings[0]
+    assert "has no dividend in the 30 days before it or the 5 days after" in warnings[0]
 
 
 def test_withholding_without_any_dividend_warns(

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -12,15 +12,13 @@ from cgt_calc.current_price_fetcher import CurrentPriceFetcher
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.main import CapitalGainsCalculator
-from cgt_calc.model import CurrencyCode
+from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
 from cgt_calc.spin_off_handler import SpinOffHandler
 
 from .calc_test_data import dividend_tax_transaction, dividend_transaction
 
 if TYPE_CHECKING:
     import pytest
-
-    from cgt_calc.model import BrokerTransaction
 
 USD = CurrencyCode("USD")
 
@@ -118,6 +116,92 @@ def _summary_dividend_lines(
         return []
     section = lines[header + 1 :]
     return section[: section.index("")] if "" in section else section
+
+
+def _dividend_at(date: datetime.date, amount: float, broker: str) -> BrokerTransaction:
+    """Create a dividend held at a named broker."""
+    return BrokerTransaction(
+        date,
+        ActionType.DIVIDEND,
+        symbol="FOO",
+        description="Dividend",
+        quantity=None,
+        price=None,
+        fees=Decimal(0),
+        amount=Decimal(str(amount)),
+        currency=USD,
+        broker=broker,
+    )
+
+
+def _dividend_tax_at(
+    date: datetime.date, amount: float, broker: str
+) -> BrokerTransaction:
+    """Create withholding taken by a named broker."""
+    return BrokerTransaction(
+        date,
+        ActionType.DIVIDEND_TAX,
+        symbol="FOO",
+        description="Dividend tax",
+        quantity=None,
+        price=None,
+        fees=Decimal(0),
+        amount=Decimal(str(-amount)),
+        currency=USD,
+        broker=broker,
+    )
+
+
+def test_late_correction_belongs_to_the_payment_it_corrects(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A correction goes to the payment before it, not the nearer one after.
+
+    A monthly payer leaves a late correction closer to the following payment
+    than to the one it corrects, so matching on distance alone moved it, and
+    both payments then failed the treaty check.
+    """
+    first = datetime.date(2024, 6, 3)
+    correction = datetime.date(2024, 6, 22)  # 19 days after, 11 days before
+    second = datetime.date(2024, 7, 3)
+    transactions = [
+        dividend_transaction(first, "FOO", 100),
+        dividend_tax_transaction(first, "FOO", 30),
+        dividend_tax_transaction(correction, "FOO", -15),
+        dividend_transaction(second, "FOO", 200),
+        dividend_tax_transaction(second, "FOO", 30),
+    ]
+
+    assert _reported(transactions) == [
+        (first, Decimal(100), Decimal(-15), True),
+        (second, Decimal(200), Decimal(-30), True),
+    ]
+    assert _unattributed_warnings(transactions, caplog) == []
+
+
+def test_withholding_stays_with_its_own_broker(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One symbol at two brokers keeps each broker's tax with its payments.
+
+    The other broker's payment is nearer in time than the one the tax was
+    taken from, so matching on symbol alone claimed it.
+    """
+    first = datetime.date(2024, 6, 3)
+    late_tax = datetime.date(2024, 6, 20)
+    other = datetime.date(2024, 6, 25)
+    transactions = [
+        _dividend_at(first, 100, broker="A"),
+        _dividend_tax_at(late_tax, 15, broker="A"),
+        _dividend_at(other, 200, broker="B"),
+        _dividend_tax_at(other, 30, broker="B"),
+    ]
+
+    assert _reported(transactions) == [
+        (first, Decimal(100), Decimal(-15), True),
+        (other, Decimal(200), Decimal(-30), True),
+    ]
+    assert _unattributed_warnings(transactions, caplog) == []
 
 
 def test_summary_and_report_agree_across_the_tax_year_end(

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import datetime
 from decimal import Decimal
 import logging
-from typing import TYPE_CHECKING
+
+import pytest
 
 from cgt_calc.currency_converter import CurrencyConverter
 from cgt_calc.current_price_fetcher import CurrentPriceFetcher
+from cgt_calc.exceptions import CalculationError
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.main import CapitalGainsCalculator
@@ -16,9 +18,6 @@ from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
 from cgt_calc.spin_off_handler import SpinOffHandler
 
 from .calc_test_data import dividend_tax_transaction, dividend_transaction
-
-if TYPE_CHECKING:
-    import pytest
 
 USD = CurrencyCode("USD")
 
@@ -201,6 +200,63 @@ def test_tax_on_a_payment_day_is_never_in_doubt(
         (second, Decimal(200), Decimal(-30), True),
     ]
     assert _unattributed_warnings(transactions, caplog) == []
+
+
+def _tax_in_currency(
+    date: datetime.date, amount: float, currency: CurrencyCode
+) -> BrokerTransaction:
+    """Create withholding denominated in a given currency."""
+    return BrokerTransaction(
+        date,
+        ActionType.DIVIDEND_TAX,
+        symbol="FOO",
+        description="Dividend tax",
+        quantity=None,
+        price=None,
+        fees=Decimal(0),
+        amount=Decimal(str(amount)),
+        currency=currency,
+        broker="A",
+    )
+
+
+@pytest.mark.parametrize(
+    ("amount", "tickers"),
+    [
+        pytest.param(15, [], id="refund"),
+        pytest.param(-15, [], id="withholding"),
+        pytest.param(-15, ["FOO"], id="withholding-on-a-bond-fund"),
+    ],
+)
+def test_tax_in_another_currency_than_its_dividend_is_refused(
+    amount: int, tickers: list[str]
+) -> None:
+    """Tax is converted at the dividend's rate, so the two must agree.
+
+    The check once sat inside the branch for tax deducted from an ordinary
+    holding, so a refund, or any tax on a bond fund, was converted as though
+    it were in the dividend's currency and came out at the wrong figure.
+    """
+    transactions = [
+        _dividend_at(DIVIDEND_DATE, 100, broker="A"),
+        _tax_in_currency(LATER_DATE, amount, CurrencyCode("GBP")),
+    ]
+    gbp_prices = {t.date: {USD: Decimal(2)} for t in transactions}
+    currency_converter = CurrencyConverter(None, gbp_prices)
+    calculator = CapitalGainsCalculator(
+        TAX_YEAR,
+        currency_converter,
+        IsinConverter(),
+        CurrentPriceFetcher(currency_converter, {}, {}),
+        SpinOffHandler(),
+        InitialPrices(),
+        interest_fund_tickers=tickers,
+        balance_check=False,
+    )
+    calculator.convert_to_hmrc_transactions(transactions)
+
+    with pytest.raises(CalculationError, match="currencies do not match"):
+        calculator.process_dividends()
 
 
 def test_ambiguous_tax_warns_in_the_year_of_each_payment(

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -179,6 +179,48 @@ def test_late_correction_belongs_to_the_payment_it_corrects(
     assert _unattributed_warnings(transactions, caplog) == []
 
 
+def test_refund_never_belongs_to_a_payment_still_to_come(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A refund goes back to the payment it corrects, however near the next.
+
+    Tax given back can only answer for income already paid, so a credit two
+    days before the next payment still belongs to the last one, even though
+    that payment is four weeks behind it.
+    """
+    first = datetime.date(2024, 6, 3)
+    refund = datetime.date(2024, 7, 1)  # 28 days after first, 2 days before second
+    second = datetime.date(2024, 7, 3)
+    transactions = [
+        dividend_transaction(first, "FOO", 100),
+        dividend_tax_transaction(first, "FOO", 30),
+        dividend_tax_transaction(refund, "FOO", -15),
+        dividend_transaction(second, "FOO", 200),
+        dividend_tax_transaction(second, "FOO", 30),
+    ]
+
+    assert _reported(transactions) == [
+        (first, Decimal(100), Decimal(-15), True),
+        (second, Decimal(200), Decimal(-30), True),
+    ]
+    assert _unattributed_warnings(transactions, caplog) == []
+
+
+def test_unmatched_refund_warning_names_only_the_backward_window(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The warning describes the window actually searched, which differs."""
+    transactions = [
+        dividend_transaction(DIVIDEND_DATE + datetime.timedelta(days=6), "FOO", 100),
+        dividend_tax_transaction(DIVIDEND_DATE, "FOO", -15),
+    ]
+
+    warnings = _unattributed_warnings(transactions, caplog)
+
+    assert len(warnings) == 1
+    assert "in the 30 days before it, so" in warnings[0]
+
+
 def test_withholding_posted_before_its_dividend_waits_for_it(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -410,7 +452,7 @@ def test_withholding_beyond_the_limit_warns(
 
     assert len(warnings) == 1
     assert "-15.00 USD for FOO on 2024-07-04" in warnings[0]
-    assert "within 30 days" in warnings[0]
+    assert "in the 30 days before it or the 5 days after" in warnings[0]
 
 
 def test_withholding_without_any_dividend_warns(

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -102,6 +102,63 @@ def _unattributed_warnings(
     ]
 
 
+def _summary_dividend_lines(
+    transactions: list[BrokerTransaction],
+    capsys: pytest.CaptureFixture[str],
+    tax_year: int = TAX_YEAR,
+) -> list[str]:
+    """Return the dividend lines of the first pass summary."""
+    # Discard whatever an earlier run in the same test printed.
+    capsys.readouterr()
+    calculator = _calculator(transactions, tax_year)
+    calculator.convert_to_hmrc_transactions(transactions)
+    lines = capsys.readouterr().out.splitlines()
+    header = next((i for i, line in enumerate(lines) if "Dividends" in line), None)
+    if header is None:
+        return []
+    section = lines[header + 1 :]
+    return section[: section.index("")] if "" in section else section
+
+
+def test_summary_and_report_agree_across_the_tax_year_end(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The summary puts withholding in the year the report puts it in.
+
+    The summary used to count withholding in the year it was posted, so a
+    payment and its tax either side of 5 April were reported in different
+    years and contradicted the report.
+    """
+    transactions = [
+        dividend_transaction(BORDER_DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(BORDER_TAX_DATE, "FOO", 15),
+    ]
+
+    assert _summary_dividend_lines(transactions, capsys, tax_year=2024) == [
+        "  FOO: 100.00, excluding 15.00 taxed at source (USD)"
+    ]
+    assert _reported(transactions, tax_year=2024) == [
+        (BORDER_DIVIDEND_DATE, Decimal(100), Decimal(-15), True)
+    ]
+
+    assert _summary_dividend_lines(transactions, capsys, tax_year=2025) == []
+    assert _reported(transactions, tax_year=2025) == []
+
+
+def test_summary_counts_withholding_dated_apart_from_its_dividend(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Tax posted days after its dividend still reaches the summary."""
+    transactions = [
+        dividend_transaction(DIVIDEND_DATE, "FOO", 100),
+        dividend_tax_transaction(LATER_DATE, "FOO", 15),
+    ]
+
+    assert _summary_dividend_lines(transactions, capsys) == [
+        "  FOO: 100.00, excluding 15.00 taxed at source (USD)"
+    ]
+
+
 def test_withholding_on_its_dividend_date_is_attributed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
Closes #990.

Withholding was matched to a dividend of the same symbol and the same date, so tax a broker dated apart from its payment was reported as if it had never been withheld. A Schwab correction of an over-withholding went missing, overstating tax at source and drawing a treaty warning against a rate that had since been corrected; withholding merely posted a few days late went missing too, understating it.

Tax is now matched to a dividend of the same broker and symbol, so holding one ticker at two brokers keeps each broker's withholding with that broker's own payments. Tax dated on a payment belongs to it; otherwise a payment in the 30 days before it or the 5 days after can claim it. The window is asymmetric because the directions mean different things: tax follows the payment it was taken from, and a correction follows it by longer, while a payment after the withholding only means the broker posted the tax early.

Where two payments could claim it, the tax is left out and named rather than given to either. Which of them an adjustment belongs to is not recorded in the export — brokers map an adjustment and an ordinary withholding to one action, so a correction reaching back to last month's payment looks exactly like tax on next month's. Guessing puts a wrong figure in the report; the warning names both candidates and says that dating the entry on its dividend settles it. Tax left out this way still appears in the first pass summary, so the money is never hidden, only its owner left undecided.

Matching runs over the whole history rather than the reported year, so a payment and its withholding either side of 5 April stay together in the earlier year, which is where relief is due, and the later year cannot claim the same withholding twice. The warning follows the same rule: an ambiguous withholding is reported in every year holding a payment it might belong to, not only the year it was taken in. This also removes the limitation noted in #992.

The first pass summary counted withholding by the date it was posted, which would have contradicted the report it precedes. Both now read the same attribution, worked out once.
