### PR TITLE
Make automatic labelling work again

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,15 +1,27 @@
+# Schema reference: https://github.com/actions/labeler#match-object
+# Options inside `all` are AND-ed, so each rule below reads as "touches these
+# files, and touches nothing from the excluded set".
+
 dependencies:
-  - any: ["uv.lock"]
-    all: ["!**/*.py"]
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: "uv.lock"
+          - all-globs-to-all-files: "!**/*.py"
 
 documentation:
-  - any: ["**/*.md"]
-    all: ["!**/*.py", "!.github/**/*"]
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: "**/*.md"
+          - all-globs-to-all-files: ["!**/*.py", "!.github/**/*"]
 
 github structure:
-  - any: [".github/**/*"]
-    all: ["!**/*.py"]
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: ".github/**/*"
+          - all-globs-to-all-files: "!**/*.py"
 
 testing:
-  - any: ["tests/**"]
-    all: ["!cgt_calc/**"]
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: "tests/**"
+          - all-globs-to-all-files: "!cgt_calc/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Pull Request Labeler
-        uses: actions/labeler@main
+        uses: actions/labeler@v7
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
`actions/labeler` redesigned its config in v5 and this file was never migrated, so the action loads a v4 config, matches nothing and exits clean. That is why Triage reports success while applying no label: the path-based labels this workflow is meant to apply have been added by hand instead. Dependabot pull requests are unaffected, since those labels come from `dependabot.yml`.

Same four rules in the current schema, and the action moves from `@main` to a version tag so the next schema change arrives as a Dependabot pull request rather than silently.