### PR TITLE
Merge overlapping Trading 212 exports without dropping real fills

### DIFF
--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections import Counter, defaultdict
 import csv
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from enum import StrEnum
@@ -318,6 +319,7 @@ class Trading212Transaction(BrokerTransaction):
 
         isin_raw = row[Trading212Column.ISIN]
         isin = Isin(isin_raw) if isin_raw else None
+        self.source_file = file
         self.transaction_id = row.get(Trading212Column.TRANSACTION_ID)
         self.notes = row.get(Trading212Column.NOTES)
         broker = "Trading212"
@@ -380,11 +382,6 @@ class Trading212Transaction(BrokerTransaction):
                 entries.append((fee_column.attribute, bare_amount, fee_currency))
         return entries
 
-    @override
-    def __hash__(self) -> int:
-        """Calculate hash."""
-        return hash(self.transaction_id)
-
 
 class Trading212Parser(BaseDirParser):
     """Trading 212 parser."""
@@ -440,12 +437,53 @@ class Trading212Parser(BaseDirParser):
         # we want to put the buy last to avoid negative balance errors
         return (transaction.datetime, transaction.action == ActionType.BUY)
 
+    @staticmethod
+    def _recorded_fields(
+        transaction: BrokerTransaction,
+    ) -> tuple[object, ...]:
+        """Summarise the fields two rows must agree on to be one trade."""
+        values = (getattr(transaction, field.name) for field in fields(transaction))
+        return tuple(
+            tuple(sorted(value.items())) if isinstance(value, dict) else value
+            for value in values
+        )
+
+    @classmethod
+    def _merge_exports(
+        cls, transactions: list[BrokerTransaction]
+    ) -> list[BrokerTransaction]:
+        """Drop the rows overlapping exports repeat about the same trade.
+
+        A row an export repeats is a second real fill, so a set() cannot do
+        this: rows agreeing on everything compared stand for as many trades
+        as the export listing the most of them reports. Distinct transaction
+        IDs name their trades outright and are kept whatever that count says.
+        """
+        groups: dict[tuple[object, ...], list[Trading212Transaction]] = defaultdict(
+            list
+        )
+        for transaction in transactions:
+            assert isinstance(transaction, Trading212Transaction)
+            groups[cls._recorded_fields(transaction)].append(transaction)
+
+        merged: list[BrokerTransaction] = []
+        for group in groups.values():
+            per_export = Counter(row.source_file for row in group)
+            identified = {
+                row.transaction_id: row for row in group if row.transaction_id
+            }
+            anonymous = [row for row in group if not row.transaction_id]
+            count = max(per_export.values())
+            merged += identified.values()
+            merged += anonymous[: max(count - len(identified), 0)]
+        return merged
+
     @classmethod
     @override
     def post_process_transactions(
         cls, transactions: list[BrokerTransaction]
     ) -> list[BrokerTransaction]:
-        """Remove duplicates and sort."""
-        transactions = list(set(transactions))
+        """Merge overlapping exports and sort."""
+        transactions = cls._merge_exports(transactions)
         transactions.sort(key=cls._by_date_and_action)
         return transactions

--- a/docs/brokers/trading212.md
+++ b/docs/brokers/trading212.md
@@ -38,8 +38,7 @@ trading212/
 
 The base filenames do not matter. cgt-calc reads every CSV file directly inside the directory, but
 it does not search subdirectories. Do not add unrelated CSV files, and make sure there are no gaps
-between date ranges. Overlaps are safe: exact repeated transactions are removed using their Trading
-212 transaction ID.
+between date ranges. Overlaps are safe: a transaction that two exports both list is kept once.
 
 You can compare the structure with this
 [sanitised example export](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/trading212/data/2024/inputs/transactions.csv).

--- a/tests/trading212/test_trading212.py
+++ b/tests/trading212/test_trading212.py
@@ -119,12 +119,16 @@ def _make_row(
     return [row[column_name] for column_name in header]
 
 
-def _prepare_file(tmp_path: Path, rows: list[list[str]]) -> Path:
+def _prepare_files(tmp_path: Path, files: Mapping[str, list[list[str]]]) -> Path:
     folder = tmp_path / "inputs"
     folder.mkdir()
-    csv_file = folder / "trading212.csv"
-    _write_csv(csv_file, rows)
+    for name, rows in files.items():
+        _write_csv(folder / name, rows)
     return folder
+
+
+def _prepare_file(tmp_path: Path, rows: list[list[str]]) -> Path:
+    return _prepare_files(tmp_path, {"trading212.csv": rows})
 
 
 def test_load_from_dir_accepts_uppercase_csv_extension(tmp_path: Path) -> None:
@@ -997,6 +1001,137 @@ def test_read_trading212_transactions_invalid_decimal(tmp_path: Path) -> None:
     message = str(exc.value)
     assert "row 2" in message
     assert "Invalid decimal in Total" in message
+
+
+HEADER_2024_NO_ID = [
+    column for column in HEADER_2024 if column != Trading212Column.TRANSACTION_ID
+]
+
+# One fill, spelled out so tests below can repeat it verbatim across exports.
+BUY_ROW: Mapping[str | Trading212Column, str] = {
+    Trading212Column.ACTION: "Market buy",
+    Trading212Column.TIME: "2024-06-01 10:00:00",
+    Trading212Column.ISIN: "US0000000010",
+    Trading212Column.TICKER: "FOO",
+    Trading212Column.NAME: "Foo Inc",
+    Trading212Column.NO_OF_SHARES: "2",
+    Trading212Column.PRICE_PER_SHARE: "10.00",
+    Trading212Column.CURRENCY_PRICE_PER_SHARE: "GBP",
+    Trading212Column.TOTAL: "20.00",
+    Trading212Column.CURRENCY_TOTAL: "GBP",
+}
+
+
+def _buy(header: list[str], transaction_id: str | None = None) -> list[str]:
+    overrides = dict(BUY_ROW)
+    if transaction_id is not None:
+        overrides[Trading212Column.TRANSACTION_ID] = transaction_id
+    return _make_row(header, overrides)
+
+
+def test_repeated_rows_in_one_export_are_separate_fills(tmp_path: Path) -> None:
+    """An export listing a fill twice recorded two fills, so keep both."""
+    folder = _prepare_file(
+        tmp_path, [HEADER_2024, _buy(HEADER_2024), _buy(HEADER_2024)]
+    )
+
+    transactions = Trading212Parser().load_from_dir(folder)
+
+    assert len(transactions) == 2
+
+
+def test_overlapping_exports_collapse_on_the_shared_id(tmp_path: Path) -> None:
+    """One trade re-exported into a second file stays one trade."""
+    rows = [HEADER_2024, _buy(HEADER_2024, "buy-1")]
+    folder = _prepare_files(tmp_path, {"jan.csv": rows, "feb.csv": rows})
+
+    transactions = Trading212Parser().load_from_dir(folder)
+
+    assert len(transactions) == 1
+
+
+def test_exports_catching_one_fill_each_keep_both(tmp_path: Path) -> None:
+    """Two IDs for one row's worth of detail are two trades, not one."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "jan.csv": [HEADER_2024, _buy(HEADER_2024, "buy-1")],
+            "feb.csv": [HEADER_2024, _buy(HEADER_2024, "buy-2")],
+        },
+    )
+
+    transactions = Trading212Parser().load_from_dir(folder)
+
+    first, second = transactions
+    assert isinstance(first, Trading212Transaction)
+    assert isinstance(second, Trading212Transaction)
+    assert {first.transaction_id, second.transaction_id} == {"buy-1", "buy-2"}
+
+
+def test_overlapping_exports_collapse_without_an_id_column(tmp_path: Path) -> None:
+    """The same trade re-exported by a format that omits IDs is still one."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "jan.csv": [HEADER_2024, _buy(HEADER_2024, "buy-1")],
+            "feb.csv": [HEADER_2024_NO_ID, _buy(HEADER_2024_NO_ID)],
+        },
+    )
+
+    transactions = Trading212Parser().load_from_dir(folder)
+
+    (kept,) = transactions
+    assert isinstance(kept, Trading212Transaction)
+    assert kept.transaction_id == "buy-1"
+
+
+def test_an_id_shared_by_a_buy_and_its_sell_merges_neither(
+    tmp_path: Path,
+) -> None:
+    """Exports reuse one ID across a position, so it cannot stand alone."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "jan.csv": [HEADER_2024, _buy(HEADER_2024, "position-1")],
+            "feb.csv": [
+                HEADER_2024,
+                _make_row(
+                    HEADER_2024,
+                    {
+                        **BUY_ROW,
+                        Trading212Column.ACTION: "Limit sell",
+                        Trading212Column.TIME: "2024-06-02 10:00:00",
+                        Trading212Column.TRANSACTION_ID: "position-1",
+                    },
+                ),
+            ],
+        },
+    )
+
+    transactions = Trading212Parser().load_from_dir(folder)
+
+    assert [t.action for t in transactions] == [ActionType.BUY, ActionType.SELL]
+
+
+def test_partial_overlap_keeps_the_fills_the_wider_export_shows(
+    tmp_path: Path,
+) -> None:
+    """Two ID-less fills reported by one export survive a narrower one."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "jan.csv": [HEADER_2024_NO_ID, _buy(HEADER_2024_NO_ID)],
+            "feb.csv": [
+                HEADER_2024_NO_ID,
+                _buy(HEADER_2024_NO_ID),
+                _buy(HEADER_2024_NO_ID),
+            ],
+        },
+    )
+
+    transactions = Trading212Parser().load_from_dir(folder)
+
+    assert len(transactions) == 2
 
 
 def test_run_with_trading212_2026_files(request: pytest.FixtureRequest) -> None:


### PR DESCRIPTION
Fixes #994.

`Trading212Transaction.__hash__` hashed the transaction ID while `__eq__` compared the recorded fields, so `list(set(transactions))` collapsed two genuine fills sharing a second, quantity and price whenever neither carried an ID, and kept a re-exported transaction twice whenever only one copy did.

As the issue concludes, no `__eq__`/`__hash__` pair expresses the rule wanted, so de-duplication moves out of the set. Rows are grouped on the fields equality already compares, and a group is kept in the number the export listing the most of its rows reports: within one export a repeated row is a second real fill, between exports it is one trade seen twice. Rows carrying distinct transaction IDs are kept on top of that count, so two exports each catching a different fill keep both.

The ID cannot carry more weight than that, which is why it stays scoped to a group rather than collapsing rows outright. The sanitised 2024 export under `tests/trading212/data` gives `EOF999999099` to both a buy and the sell that closes it, so an ID tells rows apart only once they already agree on everything recorded. I tried the outright version first and that fixture caught it.

Recording `source_file` is what lets the directory pass see export boundaries: `load_from_dir` calls `post_process_transactions` once per file and once over the combined list, and only the boundaries distinguish a repeat from an overlap.

One judgement call, happy to flip it: the group key is the dataclass fields, so it is day-granular and ignores the time. Two same-day fills in one export are still kept by count, but if you would rather the key were exact I can add `datetime` to it. I left it out because an export that reports the same fill at a different precision would then stop collapsing.

The `docs/brokers/trading212.md` sentence describing the old ID-based behaviour is updated.

Checks: `CGT_TEST_MODE_STRICT=1 uv run pytest` 857 passed, plus ruff, ruff format, mypy, ty, codespell, dprint and harper. The new tests were confirmed to fail on the unfixed parser: the three covering rows 2 and 4 of the issue's table go red, the rest are regression guards that already pass.

Disclosure: written with AI assistance (Claude). The bug was reproduced on `main` through `Trading212Parser.load_from_dir` before anything was changed.