### PR TITLE
Warn when a Vanguard symbol has no ISIN mapping

### DIFF
--- a/cgt_calc/parsers/broker_registry.py
+++ b/cgt_calc/parsers/broker_registry.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, ClassVar
 
 from colorama import Fore
 
+from cgt_calc.args_validators import STDIN_PATH
+from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.logging import style_text
 from cgt_calc.model import ActionType
 from cgt_calc.parsers.eri.raw import ERIRawParser
@@ -20,18 +22,63 @@ from cgt_calc.parsers.schwab import SchwabParser
 from cgt_calc.parsers.schwab_equity_award_json import SchwabEquityAwardsJSONParser
 from cgt_calc.parsers.sharesight import SharesightParser
 from cgt_calc.parsers.trading212 import Trading212Parser
-from cgt_calc.parsers.vanguard import VanguardParser
+from cgt_calc.parsers.vanguard import VanguardParser, VanguardTransaction
 
 if TYPE_CHECKING:
     import argparse
     import datetime
 
     from cgt_calc.isin_converter import IsinConverter
-    from cgt_calc.model import BrokerTransaction
+    from cgt_calc.model import BrokerTransaction, Isin
 
     from .base_parsers import BaseParser
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_isins(
+    transactions: list[BrokerTransaction], isin_map: dict[str, Isin]
+) -> tuple[set[Isin], list[str]]:
+    """Resolve the run's ISINs and list Vanguard symbols that have none.
+
+    Both answers come from one pass, so the warning cannot drift from the ERI
+    filter it describes.
+
+    A symbol is matchable when any row carries its ISIN or the cache maps it,
+    even a row from another broker: warning about the Vanguard rows for it
+    would send the user after a mapping that changes nothing. A rename moves
+    the holding to the new symbol, so a mapping for the new name covers the
+    rows still carrying the old one.
+    """
+    isins: set[Isin] = set()
+    resolved: set[str] = set()
+    renamed_to: dict[str, str] = {}
+    vanguard_symbols: set[str] = set()
+
+    for transaction in transactions:
+        symbol = transaction.symbol
+        isin = transaction.isin or (isin_map.get(symbol) if symbol else None)
+        if isin is not None:
+            isins.add(isin)
+            if symbol:
+                resolved.add(symbol)
+        if (
+            transaction.action is ActionType.RENAME
+            and symbol
+            and transaction.description.startswith(RENAME_DESCRIPTION_PREFIX)
+        ):
+            old_symbol = transaction.description[len(RENAME_DESCRIPTION_PREFIX) :]
+            if old_symbol:
+                renamed_to[old_symbol] = symbol
+        if isinstance(transaction, VanguardTransaction) and symbol and symbol.strip():
+            vanguard_symbols.add(symbol)
+
+    unmapped = sorted(
+        symbol
+        for symbol in vanguard_symbols
+        if symbol not in resolved and renamed_to.get(symbol) not in resolved
+    )
+    return isins, unmapped
 
 
 def _transaction_sort_key(
@@ -131,7 +178,29 @@ class BrokerRegistry:
         # ERI Raw is not a broker but is close enough to one to be here
         # Only add ERI for funds that show up in the portfolio
         isin_map = isin_converter.get_symbol_to_isin_map()
-        isins = {trx.isin or isin_map.get(trx.symbol or "") for trx in all_transactions}
+        isins, unmapped_vanguard_symbols = _resolve_isins(all_transactions, isin_map)
+        if unmapped_vanguard_symbols:
+            # Name the cache the converter read. The flag can be cleared, and
+            # the stdin sentinel is not a usable cache location: IsinConverter
+            # treats it as an ordinary relative path and would write a file
+            # literally named "-". Neither is somewhere to send the user.
+            cache_path = isin_converter.isin_translation_file
+            location = (
+                f" at {cache_path}"
+                if cache_path is not None and cache_path != STDIN_PATH
+                else ""
+            )
+            LOGGER.warning(
+                "Vanguard transactions do not contain ISINs, and no ISIN mapping "
+                "was found for: %s. cgt-calc cannot match Excess Reported "
+                "Income for these holdings if it applies; add verified mappings "
+                "to the --isin-translation-file cache%s. Give each ISIN a single "
+                "row listing every symbol it is known by: a row that leaves one "
+                "out replaces the existing mapping and can stop a later run. "
+                "See https://cgt-calc.uk/configuration/",
+                ", ".join(unmapped_vanguard_symbols),
+                location,
+            )
         all_transactions += [
             trx for trx in ERIRawParser.load_from_args(args) if trx.isin in isins
         ]

--- a/docs/brokers/vanguard.md
+++ b/docs/brokers/vanguard.md
@@ -102,7 +102,7 @@ cgt-calc does not assign that row to a purchase or disposal as an allowable cost
 ## Tax information outside the transaction listing
 
 The transaction listing is not a complete tax certificate. In particular, it does not supply Excess
-Reportable Income (ERI). See the
+Reported Income (ERI). See the
 [Vanguard section of the custom ERI data guide](../custom-eri-data.md#vanguard) for Vanguard's
 published reports and the distinction between its traditional funds and ETFs.
 
@@ -136,8 +136,8 @@ file when it learns a mapping from a transaction or a successful Open FIGI looku
 copy of manually curated data if you need an immutable record; see
 [Configuration files](../configuration.md#automatic-data-fetching).
 
-A missing mapping currently produces no warning: ERI for that holding is simply absent. Check the
-report rather than assuming that bundled ERI data was matched. Some bond-fund distributions are
+A missing mapping produces a warning naming each affected Vanguard symbol. Check that warning and
+the report rather than assuming that bundled ERI data was matched. Some bond-fund distributions are
 taxed as interest rather than dividends; see
 [Interest fund tickers](../configuration.md#manual-configuration-files).
 

--- a/tests/general/test_broker_registry.py
+++ b/tests/general/test_broker_registry.py
@@ -2,17 +2,43 @@
 
 from __future__ import annotations
 
+import datetime
+from decimal import Decimal
 import logging
 from typing import TYPE_CHECKING
 
 from cgt_calc.args_parser import create_parser
+from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.isin_converter import IsinConverter
-from cgt_calc.parsers.broker_registry import BrokerRegistry
+from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode, Isin
+from cgt_calc.parsers.broker_registry import BrokerRegistry, _resolve_isins
+from cgt_calc.parsers.vanguard import VanguardTransaction
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     import pytest
+
+
+def _vanguard_warning(caplog: pytest.LogCaptureFixture) -> str:
+    """Return the unmapped-symbol warning, whatever else the run logged."""
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if "no ISIN mapping was found" in record.getMessage()
+    ]
+    assert len(warnings) == 1, f"Expected exactly one warning, got {warnings}"
+    return warnings[0]
+
+
+def _write_vanguard_csv(tmp_path: Path) -> Path:
+    """Write a one-row Vanguard cash table whose symbol is a fund name."""
+    vanguard_file = tmp_path / "vanguard.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n09/03/2022,Bought 10 Foo Fund,-100.00,0\n",
+        encoding="utf-8",
+    )
+    return vanguard_file
 
 
 def test_load_all_transactions_without_files(
@@ -50,3 +76,243 @@ def test_load_all_transactions_from_raw_file(
         "2022-11-14",
         "2023-02-09",
     ]
+
+
+def test_vanguard_symbol_without_isin_mapping_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Warn that ERI cannot be matched to an unmapped Vanguard symbol."""
+    vanguard_file = _write_vanguard_csv(tmp_path)
+    args = create_parser().parse_args(
+        ["--year", "2023", "--vanguard-file", str(vanguard_file)]
+    )
+
+    cache = tmp_path / "isin_translation.csv"
+    converter = IsinConverter(isin_translation_file=cache)
+
+    with caplog.at_level(logging.WARNING):
+        BrokerRegistry.load_all_transactions(args, converter)
+
+    warning = _vanguard_warning(caplog)
+    assert "no ISIN mapping was found for: Foo Fund" in warning
+    assert f"--isin-translation-file cache at {cache}." in warning
+    # Appending a row that drops an alias breaks a later run, so the advice
+    # has to say how the cache is keyed, not just where it lives.
+    assert "single row listing every symbol it is known by" in warning
+    assert "https://cgt-calc.uk/configuration/" in warning
+
+
+def test_vanguard_warning_omits_cache_path_when_flag_is_cleared(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Do not advertise a cache location when the flag was explicitly cleared."""
+    vanguard_file = _write_vanguard_csv(tmp_path)
+    args = create_parser().parse_args(
+        [
+            "--year",
+            "2023",
+            "--vanguard-file",
+            str(vanguard_file),
+            "--isin-translation-file",
+            "",
+        ]
+    )
+
+    converter = IsinConverter(isin_translation_file=args.isin_translation_file)
+
+    with caplog.at_level(logging.WARNING):
+        BrokerRegistry.load_all_transactions(args, converter)
+
+    warning = _vanguard_warning(caplog)
+    assert "no ISIN mapping was found for: Foo Fund" in warning
+    assert "--isin-translation-file cache. " in warning
+
+
+def test_vanguard_warning_omits_stdin_sentinel_as_cache_path(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The stdin sentinel is not a usable cache location, so do not name it."""
+    vanguard_file = _write_vanguard_csv(tmp_path)
+    args = create_parser().parse_args(
+        [
+            "--year",
+            "2023",
+            "--vanguard-file",
+            str(vanguard_file),
+            "--isin-translation-file",
+            "-",
+        ]
+    )
+    converter = IsinConverter(isin_translation_file=args.isin_translation_file)
+
+    with caplog.at_level(logging.WARNING):
+        BrokerRegistry.load_all_transactions(args, converter)
+
+    warning = _vanguard_warning(caplog)
+    assert "--isin-translation-file cache. " in warning
+
+
+def test_vanguard_symbol_with_isin_mapping_does_not_warn(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Do not warn when a Vanguard symbol has an explicit ISIN mapping."""
+    vanguard_file = _write_vanguard_csv(tmp_path)
+    args = create_parser().parse_args(
+        ["--year", "2023", "--vanguard-file", str(vanguard_file)]
+    )
+    converter = IsinConverter()
+    converter.data[Isin("US0378331005")] = {"Foo Fund"}
+
+    with caplog.at_level(logging.WARNING):
+        BrokerRegistry.load_all_transactions(args, converter)
+
+    assert "no ISIN mapping was found" not in caplog.text
+
+
+def test_vanguard_display_name_does_not_define_parser_provenance() -> None:
+    """Ignore a non-Vanguard transaction whose broker label happens to match."""
+    transaction = BrokerTransaction(
+        date=datetime.date(2022, 3, 9),
+        action=ActionType.BUY,
+        symbol="Foo Fund",
+        description="",
+        quantity=Decimal(10),
+        price=Decimal(10),
+        fees=Decimal(0),
+        amount=Decimal(-100),
+        currency=CurrencyCode("GBP"),
+        broker="Vanguard",
+    )
+
+    assert _unmapped([transaction], {}) == []
+
+
+def test_vanguard_symbol_resolved_by_another_broker_does_not_warn() -> None:
+    """Stay quiet when another broker's row already supplies the ISIN.
+
+    ERI matches through that row, so telling the user to add a mapping would
+    send them after a change that makes no difference.
+    """
+    vanguard = VanguardTransaction.from_fields(
+        date=datetime.date(2022, 3, 9),
+        action=ActionType.BUY,
+        symbol="VWRP",
+        quantity=Decimal(10),
+        price=Decimal(10),
+        amount=Decimal(-100),
+        currency=CurrencyCode("GBP"),
+        is_reversal=False,
+    )
+    elsewhere = BrokerTransaction(
+        date=datetime.date(2022, 3, 9),
+        action=ActionType.BUY,
+        symbol="VWRP",
+        description="",
+        quantity=Decimal(5),
+        price=Decimal(10),
+        fees=Decimal(0),
+        amount=Decimal(-50),
+        currency=CurrencyCode("GBP"),
+        broker="Trading212",
+        isin=Isin("IE00BK5BQT80"),
+    )
+
+    assert _unmapped([vanguard, elsewhere], {}) == []
+    assert _unmapped([vanguard], {}) == ["VWRP"]
+
+
+def test_vanguard_blank_symbol_is_not_reported() -> None:
+    """A whitespace-only symbol must not render as a phantom empty entry."""
+    blank = VanguardTransaction.from_fields(
+        date=datetime.date(2022, 3, 9),
+        action=ActionType.BUY,
+        symbol="",
+        quantity=Decimal(1),
+        price=Decimal(1),
+        amount=Decimal(-1),
+        currency=CurrencyCode("GBP"),
+        is_reversal=False,
+    )
+
+    whitespace = VanguardTransaction.from_fields(
+        date=datetime.date(2022, 3, 9),
+        action=ActionType.BUY,
+        symbol=" ",
+        quantity=Decimal(1),
+        price=Decimal(1),
+        amount=Decimal(-1),
+        currency=CurrencyCode("GBP"),
+        is_reversal=False,
+    )
+
+    assert _unmapped([blank], {}) == []
+    assert _unmapped([whitespace], {}) == []
+
+
+def _unmapped(
+    transactions: list[BrokerTransaction], isin_map: dict[str, Isin]
+) -> list[str]:
+    """Return just the unmapped-symbol half of the resolution."""
+    return _resolve_isins(transactions, isin_map)[1]
+
+
+def test_vanguard_symbol_renamed_to_a_mapped_symbol_does_not_warn() -> None:
+    """A mapping for the new name also covers rows carrying the old one."""
+    pre_rename = VanguardTransaction.from_fields(
+        date=datetime.date(2022, 3, 9),
+        action=ActionType.BUY,
+        symbol="VDXX",
+        quantity=Decimal(10),
+        price=Decimal(10),
+        amount=Decimal(-100),
+        currency=CurrencyCode("GBP"),
+        is_reversal=False,
+    )
+    rename = VanguardTransaction.from_fields(
+        date=datetime.date(2022, 3, 10),
+        action=ActionType.RENAME,
+        symbol="VGER",
+        quantity=Decimal(0),
+        price=None,
+        amount=Decimal(0),
+        currency=CurrencyCode("GBP"),
+        is_reversal=False,
+        description=f"{RENAME_DESCRIPTION_PREFIX}VDXX",
+    )
+    mapped = {"VGER": Isin("IE00BK5BQT80")}
+
+    assert _unmapped([pre_rename, rename], mapped) == []
+    # Without the mapping both names are genuinely unmatchable.
+    assert _unmapped([pre_rename, rename], {}) == ["VDXX", "VGER"]
+
+
+def test_resolve_isins_matches_the_eri_filter() -> None:
+    """The resolved set is what the ERI filter consumes, from the same pass."""
+    vanguard = VanguardTransaction.from_fields(
+        date=datetime.date(2022, 3, 9),
+        action=ActionType.BUY,
+        symbol="VWRP",
+        quantity=Decimal(10),
+        price=Decimal(10),
+        amount=Decimal(-100),
+        currency=CurrencyCode("GBP"),
+        is_reversal=False,
+    )
+    elsewhere = BrokerTransaction(
+        date=datetime.date(2022, 3, 9),
+        action=ActionType.BUY,
+        symbol="VWRP",
+        description="",
+        quantity=Decimal(5),
+        price=Decimal(10),
+        fees=Decimal(0),
+        amount=Decimal(-50),
+        currency=CurrencyCode("GBP"),
+        broker="Trading212",
+        isin=Isin("IE00BK5BQT80"),
+    )
+
+    isins, unmapped = _resolve_isins([vanguard, elsewhere], {})
+
+    assert isins == {Isin("IE00BK5BQT80")}
+    assert unmapped == []

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -38,7 +38,9 @@ def test_run_with_vanguard_files(request: pytest.FixtureRequest) -> None:
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
         )
-    assert stderr_alerts(result.stderr) == [], "Run with example files generated errors"
+    alerts = stderr_alerts(result.stderr)
+    assert len(alerts) == 1, f"Unexpected alerts: {alerts}"
+    assert "no ISIN mapping was found" in alerts[0]
     expected_file = Path("tests") / "vanguard" / "data" / "expected_output.txt"
     expected = expected_file.read_text(encoding="utf-8")
     cmd_str = " ".join([param or "''" for param in cmd])


### PR DESCRIPTION
Vanguard rows carry no ISIN, so Excess Reportable Income can only attach when the parsed symbol maps to one. The bundled translations hold exchange tickers, not Vanguard's fund names, so a fund-name holding silently got no ERI.

Warn once, naming each affected symbol and the translation cache to add mappings to.