### PR TITLE
Handle Forex Trade Component as a balance adjustment

### DIFF
--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -82,12 +82,17 @@ def _action_from_str(action_type: str, file_path: Path) -> ActionType:
         return ActionType.SELL
     if action_type == "Foreign Tax Withholding":
         return ActionType.DIVIDEND_TAX
-    if action_type in {"Forex Trade Component", "Other Fee"}:
+    if action_type == "Other Fee":
         return ActionType.FEE
-    # "FX Translations P&L": the revaluation of a foreign currency balance, not
-    # a trade. It moves the cash balance and creates no taxable event, which is
-    # what ADJUSTMENT means here and how the Schwab parser treats its own.
-    if action_type == "Adjustment":
+    # "FX Translations P&L" arrives as an Adjustment: the revaluation of a
+    # foreign currency balance. A "Forex Trade Component" is the base-currency
+    # net of a conversion, filed under the currency pair. Neither is a trade in
+    # a security: both move the cash balance and create no taxable event, which
+    # is what ADJUSTMENT means here and how the Schwab parser treats its own.
+    # Read as a fee instead, a component that brings base currency in is
+    # refused outright, and one that takes some out opens a pooled cost under
+    # the currency pair.
+    if action_type in {"Adjustment", "Forex Trade Component"}:
         return ActionType.ADJUSTMENT
 
     raise ParsingError(file_path, f"Unknown type: '{action_type}'")
@@ -157,6 +162,22 @@ class InteractiveBrokersTransaction(BrokerTransaction):
         # that the internal validation (quantity x price + fees ≈ |amount|) holds.
         if price is not None and price_currency != "GBP" and exchange_rate is not None:
             price = price * exchange_rate
+            price_currency = CurrencyCode("GBP")
+
+        # An adjustment moves the cash balance and nothing else: the calculator
+        # reads its amount and never its symbol, quantity or price. IBKR files a
+        # Forex Trade Component under the currency pair and gives it both a
+        # quantity and a price, so clear the columns that describe a security
+        # rather than leave a currency pair looking like a holding. All that is
+        # left is the Net Amount, which is in the account's base currency, so
+        # the transaction currency is that rather than whatever priced the leg:
+        # a row carrying Price Currency without an Exchange Rate keeps its
+        # foreign price_currency above and would otherwise move a USD balance.
+        if action is ActionType.ADJUSTMENT:
+            symbol = None
+            quantity = None
+            price = None
+            fees = Decimal(0)
             price_currency = CurrencyCode("GBP")
 
         super().__init__(

--- a/docs/brokers/interactive-brokers.md
+++ b/docs/brokers/interactive-brokers.md
@@ -53,19 +53,23 @@ check the date range and filters as described in [Troubleshooting](#troubleshoot
 
 The importer recognises these literal values from the CSV's `Transaction Type` column:
 
-| Transaction type                     | How cgt-calc handles it                                                 |
-| ------------------------------------ | ----------------------------------------------------------------------- |
-| `Buy`, `Sell`                        | Share or fund acquisitions and disposals, with commission               |
-| `Dividend`, `Payment in Lieu`        | Dividend income                                                         |
-| `Foreign Tax Withholding`            | Tax deducted at source; treated as dividend tax                         |
-| `Credit Interest`                    | Interest income                                                         |
-| `Deposit`, `Withdrawal`              | Cash movements used by the balance check                                |
-| `Other Fee`, `Forex Trade Component` | Charged against the cash balance as fees; no security is bought or sold |
-| `Adjustment`                         | Cash-balance adjustments such as `FX Translations P&L`                  |
+| Transaction type              | How cgt-calc handles it                                      |
+| ----------------------------- | ------------------------------------------------------------ |
+| `Buy`, `Sell`                 | Share or fund acquisitions and disposals, with commission    |
+| `Dividend`, `Payment in Lieu` | Dividend income                                              |
+| `Foreign Tax Withholding`     | Tax deducted at source; treated as dividend tax              |
+| `Credit Interest`             | Interest income                                              |
+| `Deposit`, `Withdrawal`       | Cash movements used by the balance check                     |
+| `Other Fee`                   | A charge against a holding, added to its pooled cost         |
+| `Adjustment`                  | Cash-balance adjustments such as `FX Translations P&L`       |
+| `Forex Trade Component`       | The base-currency net of a currency conversion; balance only |
 
 For a GBP-base account, IBKR reports gross amounts, commissions and net amounts in GBP. When the CSV
 also supplies `Price Currency` and `Exchange Rate`, cgt-calc converts a foreign-currency unit price
 to GBP before calculating the acquisition or disposal.
+
+cgt-calc does not treat a currency conversion as a disposal. It applies the `Forex Trade Component`
+Net Amount to the cash balance and reports no gain or loss on the conversion itself.
 
 IBKR descriptions for dividends and payments in lieu can put an ISIN in parentheses immediately
 after the symbol. cgt-calc uses that identifier when deciding whether a supported double-taxation

--- a/tests/interactive_brokers/data/test_basic.csv
+++ b/tests/interactive_brokers/data/test_basic.csv
@@ -14,6 +14,7 @@ Transaction History,Data,2025-11-30,U***00000,FX Translations P&L,Adjustment,-,-
 Transaction History,Data,2025-10-01,U***00000,IBKR(US45841N1072) Payment in Lieu of Dividend (Ordinary Dividend),Payment in Lieu,IBKR,-,-,1.0,-,1.0
 Transaction History,Data,2025-10-01,U***00000,IBKR(US45841N1072) Payment in Lieu of Dividend - US Tax,Foreign Tax Withholding,IBKR,-,-,-0.15,-,-0.15
 Transaction History,Data,2025-10-01,U***00000,Net Amount in Base from Forex Trade: 0.8 GBP.USD,Forex Trade Component,GBP.USD,0.8,1.32,-2.637591265E-4,-,-2.637591265E-4
+Transaction History,Data,2025-10-01,U***00000,Net Amount in Base from Forex Trade: -0.8 GBP.USD,Forex Trade Component,GBP.USD,-0.8,1.32,2.902350391E-4,-,2.902350391E-4
 Transaction History,Data,2025-08-15,U***00000,ISHARES NASDAQ 100 USD ACC,Sell,CNX1,-2.0,1001.00,2002.0,-3.0,1999.0
 Transaction History,Data,2025-03-15,U***00000,ISHARES NASDAQ 100 USD ACC,Buy,CNX1,4.0,1000.0,-4000.0,-3.0,-4003.0
 Transaction History,Data,2025-02-08,U***00000,CANCEL WITHHOLDING ON Credit Interest for Feb-2025,Foreign Tax Withholding,-,-,-,3.9,-,3.9

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -327,6 +327,7 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
             str(csv_file),
             "--output",
             str(tmp_path / "out"),
+            keep_tex=True,
         )
         result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
         if result.returncode:

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -221,10 +221,123 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
         assert len(transactions) == 1
         assert transactions[0].action == ActionType.ADJUSTMENT
         assert transactions[0].amount == Decimal("0.55")
-        # No quantity and no price, so it cannot become an acquisition or a
-        # disposal however it is grouped downstream.
+        # No symbol, no quantity and no price, so it cannot become an
+        # acquisition or a disposal however it is grouped downstream. IBKR
+        # writes "-" in all three, and only the numeric columns read that as
+        # absent on their own, so the symbol is pinned here too.
+        assert transactions[0].symbol is None
         assert transactions[0].quantity is None
         assert transactions[0].price is None
+
+    def test_forex_trade_component_is_an_adjustment_not_a_fee(
+        self, tmp_path: Path
+    ) -> None:
+        """A currency conversion is not a charge against a holding.
+
+        IBKR files the base-currency net of an FX trade under the currency
+        pair as a "Forex Trade Component". Its Net Amount is positive when the
+        conversion leaves more base currency behind and negative when it
+        leaves less, and neither direction is a fee: a positive one is refused
+        outright, and a negative one opens a pooled cost for a currency pair.
+        "Other Fee", which really is a charge on a holding, keeps its meaning.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header + "Transaction History,Data,2025-10-01,U***00000,"
+            "Net Amount in Base from Forex Trade: 800 GBP.USD,"
+            "Forex Trade Component,GBP.USD,800,1.32,0.16,-0.02,0.14\n"
+            + "Transaction History,Data,2025-10-02,U***00000,"
+            "Net Amount in Base from Forex Trade: -800 GBP.USD,"
+            "Forex Trade Component,GBP.USD,-800,1.32,-0.18,-,-0.18\n"
+            + "Transaction History,Data,2025-10-03,U***00000,"
+            "CNX1 ADR Fee,Other Fee,CNX1,-,-,-1.5,-,-1.5\n"
+        )
+
+        transactions = InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert [t.action for t in transactions] == [
+            ActionType.ADJUSTMENT,
+            ActionType.ADJUSTMENT,
+            ActionType.FEE,
+        ]
+        assert [t.amount for t in transactions] == [
+            Decimal("0.14"),
+            Decimal("-0.18"),
+            Decimal("-1.5"),
+        ]
+        # Neither direction keeps anything that could be read as a security,
+        # and the description still names the pair the movement came from.
+        for component in transactions[:2]:
+            assert component.symbol is None
+            assert component.quantity is None
+            assert component.price is None
+            assert component.fees == Decimal(0)
+            assert "GBP.USD" in component.description
+        assert transactions[2].symbol == "CNX1"
+
+    def test_forex_trade_component_moves_the_base_currency_balance(
+        self, tmp_path: Path
+    ) -> None:
+        """Net Amount is in the base currency whatever priced the leg.
+
+        In the extended format a currency-pair row can name a Price Currency,
+        and the price is converted to GBP only when the row also carries an
+        Exchange Rate. Without one the price stays foreign, and taking that as
+        the transaction currency would file a GBP Net Amount against a USD
+        balance instead.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header_with_foreign_currency
+            + "Transaction History,Data,2025-10-02,U***00000,"
+            "Net Amount in Base from Forex Trade: 800 GBP.USD,"
+            "Forex Trade Component,GBP.USD,800,1.32,USD,0.18,-,0.18,-\n"
+        )
+
+        transactions = InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert len(transactions) == 1
+        assert transactions[0].action == ActionType.ADJUSTMENT
+        assert transactions[0].currency == CurrencyCode("GBP")
+        assert transactions[0].amount == Decimal("0.18")
+
+    def test_forex_trade_component_leaves_no_fee_in_the_report(
+        self, tmp_path: Path
+    ) -> None:
+        """A currency pair must not reach the report as a holding with a cost.
+
+        The pooled cost a fee opens is invisible in the printed summary while
+        the quantity is zero, so the rendered report is what gives it away: on
+        the fee path this file produces a "Management fee for GBP.USD" section
+        for a symbol that is not a security.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header + "Transaction History,Data,2025-01-01,U***00000,"
+            "Electronic Fund Transfer,Deposit,-,-,-,1000.0,-,1000.0\n"
+            + "Transaction History,Data,2025-10-02,U***00000,"
+            "Net Amount in Base from Forex Trade: -800 GBP.USD,"
+            "Forex Trade Component,GBP.USD,-800,1.32,-0.18,-,-0.18\n"
+        )
+
+        cmd = build_cmd(
+            "--year",
+            "2025",
+            "--interactive-brokers-file",
+            str(csv_file),
+            "--output",
+            str(tmp_path / "out"),
+        )
+        result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
+        if result.returncode:
+            pytest.fail(
+                "Integration test failed\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+        assert stderr_alerts(result.stderr) == []
+        assert "Final balance\n  Interactive Brokers: 999.82 (GBP)" in result.stdout
+        assert "GBP.USD" not in (tmp_path / "out.tex").read_text(encoding="utf-8")
 
     def test_buy_before_same_day_sell_does_not_go_negative(
         self, tmp_path: Path

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,10 +6,16 @@ import sys
 import pytest
 
 
-def build_cmd(*args: str) -> list[str]:
-    """Return CLI command for cgt_calc with optional pdflatex disabled."""
+def build_cmd(*args: str, keep_tex: bool = False) -> list[str]:
+    """Return CLI command for cgt_calc with optional pdflatex disabled.
+
+    Pass keep_tex when the test reads the generated .tex. Rendering a PDF puts
+    the LaTeX source in a temporary file and leaves no .tex next to the report,
+    so a test asserting on the source has to skip pdflatex even where
+    ENABLE_PDFLATEX asks for it.
+    """
     cmd = [sys.executable, "-m", "cgt_calc.main", *args]
-    if not os.getenv("ENABLE_PDFLATEX"):
+    if keep_tex or not os.getenv("ENABLE_PDFLATEX"):
         cmd.append("--no-pdflatex")
     cmd += ["--exchange-rates-file", "tests/exchange_rates_data.csv"]
     return cmd


### PR DESCRIPTION
Fixes #951.

`Forex Trade Component` shared the `ActionType.FEE` branch with `Other Fee`, so the base-currency
net of a currency conversion was read as a charge against a security. A positive Net Amount stopped
the run in `add_management_fee`; a negative one opened a pooled cost under the currency pair, which
the zero quantity keeps out of the printed summary but which grows a `Management fee for GBP.USD`
section in the report — the existing `test_basic.csv` fixture already produced one.

It is now an `ActionType.ADJUSTMENT`, alongside the `FX Translations P&L` adjustment the parser
already handled that way. The literal types are still matched exactly, so FX derivatives stay out.

Adjustments are balance-only, so the columns describing a security are cleared. That leaves the Net
Amount, which is in the base currency, so the transaction currency is set to that as well: a
currency-pair row can name a `Price Currency`, and the price is converted only when the row also
carries an `Exchange Rate`, so without one this would have moved a USD balance. #1006 covers that
more generally.

Clearing the symbol also drops the `-` placeholder on `Adjustment` rows, which survives as a literal
symbol today because only the numeric columns read `-` as absent. #1007 covers the rest of that.

Diagnosis and original fix by @hdimer in #964.
