### PR TITLE
Read Freetrade dates in UK time

### DIFF
--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import csv
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from enum import StrEnum
 import logging
 from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
 
+from cgt_calc.const import UK_TIMEZONE
 from cgt_calc.exceptions import (
     ParsingError,
     UnsupportedBrokerActionError,
@@ -192,8 +193,16 @@ class FreetradeTransaction(BrokerTransaction):
         isin_raw = row.get(FreetradeColumn.ISIN)
         isin = Isin(isin_raw) if isin_raw else None
 
+        # The timestamp is in UTC, but the date that drives the tax year and
+        # the matching rules is the UK one.
+        timestamp = datetime.fromisoformat(row[FreetradeColumn.TIMESTAMP])
+        if timestamp.tzinfo is None:
+            # The export states its times in UTC, so a value without a zone
+            # is read as UTC too rather than as the machine's local time.
+            timestamp = timestamp.replace(tzinfo=UTC)
+
         super().__init__(
-            date=datetime.fromisoformat(row[FreetradeColumn.TIMESTAMP]).date(),
+            date=timestamp.astimezone(UK_TIMEZONE).date(),
             action=action,
             symbol=symbol,
             description=f"{row[FreetradeColumn.TITLE]} {action}",

--- a/docs/brokers/freetrade.md
+++ b/docs/brokers/freetrade.md
@@ -61,6 +61,13 @@ For trades in a foreign instrument currency, cgt-calc uses the price and total a
 the GBP account currency. It records the exported stamp duty and FX fee as costs. Foreign dividend
 amounts and their tax at source are converted to GBP using the exported `Base FX Rate`.
 
+### Dates and time zones
+
+Freetrade timestamps every transaction in UTC. cgt-calc converts each one to UK time, GMT in winter
+and BST in summer, before taking the date. The tax year boundary and the same-day and 30-day
+matching rules all run on UK calendar days, and the boundary always falls inside BST, so a
+transaction stamped after 23:00 UTC on 5 April belongs to the following tax year.
+
 ### Check for missing activity
 
 Freetrade says its Activity Feed CSV is

--- a/docs/brokers/index.md
+++ b/docs/brokers/index.md
@@ -16,5 +16,12 @@ export instructions.
 | [Vanguard](vanguard.md)                       | `--vanguard-file`                      | Client Transactions Listing CSV     |
 | [RAW format](raw.md)                          | `--raw-file`                           | Generic fallback for other brokers  |
 
+## Dates and time zones
+
+UK share matching and the tax year boundary run on UK calendar days. [Freetrade](freetrade.md) and
+[Trading 212](trading212.md) timestamp each transaction in UTC, and cgt-calc converts those to UK
+time before taking the date. Every other export above states a date with no time, so cgt-calc reads
+that date as the broker wrote it and cannot correct one that was recorded in another time zone.
+
 If your broker is not listed, try the [RAW format](raw.md). Contributions for new brokers are very
 welcome — see [Adding a broker](../development/adding-a-broker.md).

--- a/tests/freetrade/test_freetrade.py
+++ b/tests/freetrade/test_freetrade.py
@@ -1,6 +1,7 @@
 """Test Freetrade support."""
 
 import csv
+from datetime import date
 from decimal import Decimal
 import logging
 from pathlib import Path
@@ -238,6 +239,34 @@ def test_read_freetrade_transactions_success(tmp_path: Path) -> None:
     assert transaction.amount == Decimal(-100)
     assert transaction.currency == "GBP"
     assert transaction.isin == "US0378331005"
+
+
+@pytest.mark.parametrize(
+    ("timestamp", "expected"),
+    [
+        # The tax year boundary always falls inside BST, so the last hour
+        # of 5 April in UTC already belongs to the next tax year.
+        ("2025-04-05T22:59:59.000Z", date(2025, 4, 5)),
+        ("2025-04-05T23:00:00.000Z", date(2025, 4, 6)),
+        ("2025-04-05T23:30:00.000", date(2025, 4, 6)),
+        # The clocks go back on 25 October 2026, so the last hour of the
+        # 26th is already GMT.
+        ("2026-10-26T23:30:00.000Z", date(2026, 10, 26)),
+        # Outside summer time UK dates and UTC dates agree.
+        ("2026-01-15T23:30:00.000Z", date(2026, 1, 15)),
+        ("2026-11-01T23:30:00.000Z", date(2026, 11, 1)),
+    ],
+)
+def test_read_freetrade_transactions_uses_uk_dates(
+    tmp_path: Path, timestamp: str, expected: date
+) -> None:
+    """Take the tax date from the UK calendar, not the UTC one."""
+    overrides = {FreetradeColumn.TIMESTAMP.value: timestamp}
+    path = _write_csv(tmp_path, COLUMNS, [_default_row(overrides)])
+
+    transactions = FreetradeParser().load_from_file(path)
+
+    assert transactions[0].date == expected
 
 
 @pytest.mark.parametrize("document_type", ["MONTHLY_STATEMENT", "TAX_CERTIFICATE"])


### PR DESCRIPTION
Fixes #1005.

`FreetradeTransaction.__init__` took the calendar date straight from the UTC timestamp, so a transaction stamped after 23:00 UTC on 5 April was filed in the previous tax year, and the same instant could also land on the wrong side of same-day and 30-day matching.

It now converts to `UK_TIMEZONE` before taking the date, the same way `Trading212Transaction` has since #1000. As there, a zone-less timestamp is read as UTC rather than as the machine's local time: every export carries `Z`, but without that the parsed date would depend on the reader's clock, and `BASE_ROW_VALUES` in the Freetrade tests uses the zone-less shorthand.

The new parametrized test mirrors the Trading 212 one: the 5/6 April boundary (22:59:59 UTC still 5 April, 23:00:00 and 23:30:00 already 6 April, the last of those zone-less), the evening after the clocks go back in October, and two winter dates where UK and UTC agree anyway. I checked each case discriminates by re-running it against the unfixed parser (two boundary cases fail), against a plain `astimezone` with no zone-less handling under `TZ=Pacific/Auckland` (the zone-less case fails), and against a crude "add an hour from April to October" version (the October case fails).

The second half of the issue is documented rather than fixed. `docs/brokers/freetrade.md` gains a "Dates and time zones" section mirroring the Trading 212 one, and `docs/brokers/index.md` says once that every other export states a date with no time, so cgt-calc reads it as the broker wrote it. That seemed better than repeating the same paragraph on six broker pages, but happy to move it if you would rather each page carried it.

Checks: `uv run pytest` 904 passed, and the Freetrade tests also pass under `TZ` set to UTC, Auckland, Los Angeles and Tokyo. Plus ruff format, ruff check, mypy, ty, dprint, codespell and Harper.

Disclosure: written with AI assistance (Claude). The bug was reproduced against `main` first, and the new test was confirmed to fail on the unfixed parser before anything was changed.