### PR TITLE
Reject '-' for the cache file options

### DIFF
--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -13,7 +13,7 @@ from .args_validators import (
     VersionAction,
     date_type,
     existing_file_type,
-    optional_file_type,
+    optional_cache_file_type,
     output_path_type,
     set_completer,
     ticker_list_type,
@@ -105,7 +105,7 @@ Environment variables:
     set_completer(
         data_group.add_argument(
             "--exchange-rates-file",
-            type=optional_file_type,
+            type=optional_cache_file_type,
             metavar="PATH",
             default=DEFAULT_EXCHANGE_RATES_FILE,
             help="monthly exchange rates in CSV format (generated automatically if missing; default: %(default)s)",
@@ -115,7 +115,7 @@ Environment variables:
     set_completer(
         data_group.add_argument(
             "--isin-translation-file",
-            type=optional_file_type,
+            type=optional_cache_file_type,
             default=DEFAULT_ISIN_TRANSLATION_FILE,
             metavar="PATH",
             help="ISIN to ticker translations in CSV format (generated automatically if missing; default: %(default)s)",
@@ -125,7 +125,7 @@ Environment variables:
     set_completer(
         data_group.add_argument(
             "--spin-offs-file",
-            type=optional_file_type,
+            type=optional_cache_file_type,
             metavar="PATH",
             default=DEFAULT_SPIN_OFF_FILE,
             help="spin-offs data in CSV format (default: %(default)s)",

--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -82,12 +82,17 @@ def _ensure_readable_directory(path: Path, value: str) -> None:
         ) from err
 
 
-def optional_file_type(value: str) -> Path | None:
-    """Convert non-empty value to Path and ensure file semantics."""
+def optional_cache_file_type(value: str) -> Path | None:
+    """Convert non-empty value to a cache Path and ensure file semantics.
+
+    An empty value disables the cache. The stdin marker is rejected: a cache is
+    read and written, so '-' would create a file literally named '-' and later
+    be read back as the cache.
+    """
     if value.strip() == "":
         return None
     if value == "-":
-        return STDIN_PATH
+        raise argparse.ArgumentTypeError("expected file path, got stdin marker: '-'")
     path = Path(value)
     if path.exists():
         if not (path.is_file() or path.is_fifo()):

--- a/cgt_calc/parsers/broker_registry.py
+++ b/cgt_calc/parsers/broker_registry.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, ClassVar
 
 from colorama import Fore
 
-from cgt_calc.args_validators import STDIN_PATH
 from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.logging import style_text
 from cgt_calc.model import ActionType
@@ -180,16 +179,10 @@ class BrokerRegistry:
         isin_map = isin_converter.get_symbol_to_isin_map()
         isins, unmapped_vanguard_symbols = _resolve_isins(all_transactions, isin_map)
         if unmapped_vanguard_symbols:
-            # Name the cache the converter read. The flag can be cleared, and
-            # the stdin sentinel is not a usable cache location: IsinConverter
-            # treats it as an ordinary relative path and would write a file
-            # literally named "-". Neither is somewhere to send the user.
+            # Name the cache the converter actually read; the flag can be
+            # cleared, leaving no location to point the user to.
             cache_path = isin_converter.isin_translation_file
-            location = (
-                f" at {cache_path}"
-                if cache_path is not None and cache_path != STDIN_PATH
-                else ""
-            )
+            location = f" at {cache_path}" if cache_path is not None else ""
             LOGGER.warning(
                 "Vanguard transactions do not contain ISINs, and no ISIN mapping "
                 "was found for: %s. cgt-calc cannot match Excess Reported "

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -20,7 +20,7 @@ from cgt_calc.args_validators import (
     STDIN_PATH,
     existing_directory_type,
     existing_file_type,
-    optional_file_type,
+    optional_cache_file_type,
 )
 from cgt_calc.const import (
     DEFAULT_EXCHANGE_RATES_FILE,
@@ -321,8 +321,8 @@ def test_existing_directory_type_rejects_unreadable_dir(
         ("--spin-offs-file", "spin_offs_file", DEFAULT_SPIN_OFF_FILE),
     ],
 )
-def test_optional_path_arguments_default(option: str, attr: str, default: Path) -> None:
-    """Ensure optional path arguments use their default when not provided."""
+def test_cache_path_arguments_default(option: str, attr: str, default: Path) -> None:
+    """Ensure cache path arguments use their default when not provided."""
     parser = create_parser()
     args = parser.parse_args([])
 
@@ -337,10 +337,10 @@ def test_optional_path_arguments_default(option: str, attr: str, default: Path) 
         ("--spin-offs-file", "spin_offs_file", "custom_spin_offs.csv"),
     ],
 )
-def test_optional_path_arguments_accept_custom_path(
+def test_cache_path_arguments_accept_custom_path(
     option: str, attr: str, value: str
 ) -> None:
-    """Ensure optional path arguments convert provided values to Path."""
+    """Ensure cache path arguments convert provided values to Path."""
     parser = create_parser()
     args = parser.parse_args([option, value])
 
@@ -355,8 +355,8 @@ def test_optional_path_arguments_accept_custom_path(
         ("--spin-offs-file", "spin_offs_file"),
     ],
 )
-def test_optional_path_arguments_allow_empty_string(option: str, attr: str) -> None:
-    """Ensure optional path arguments treat empty values as None."""
+def test_cache_path_arguments_allow_empty_string(option: str, attr: str) -> None:
+    """Ensure cache path arguments treat empty values as None."""
     parser = create_parser()
     args = parser.parse_args([option, ""])
 
@@ -371,10 +371,10 @@ def test_optional_path_arguments_allow_empty_string(option: str, attr: str) -> N
         ("--spin-offs-file", "spin_offs_file"),
     ],
 )
-def test_optional_path_arguments_reject_directory(
+def test_cache_path_arguments_reject_directory(
     tmp_path: Path, option: str, attr: str
 ) -> None:
-    """Ensure optional path arguments reject directories when they exist."""
+    """Ensure cache path arguments reject directories when they exist."""
     parser = create_parser()
     directory = tmp_path / "existing_dir"
     directory.mkdir()
@@ -387,10 +387,36 @@ def test_optional_path_arguments_reject_directory(
     assert getattr(args, attr) is not None
 
 
-def test_optional_file_type_rejects_unreadable_file(
+@pytest.mark.parametrize(
+    "option",
+    ["--exchange-rates-file", "--isin-translation-file", "--spin-offs-file"],
+)
+def test_cache_path_arguments_reject_stdin(
+    option: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Ensure cache path arguments reject '-' instead of writing a file named '-'."""
+    parser = create_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([option, "-"])
+
+    assert exc_info.value.code == 2
+    assert "got stdin marker" in capsys.readouterr().err
+
+
+def test_cache_path_arguments_accept_leading_dash() -> None:
+    """Only the bare stdin marker is rejected, not every leading-dash path."""
+    parser = create_parser()
+
+    args = parser.parse_args(["--exchange-rates-file=-rates.csv"])
+
+    assert args.exchange_rates_file == Path("-rates.csv")
+
+
+def test_optional_cache_file_type_rejects_unreadable_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """optional_file_type raises when file cannot be read."""
+    """optional_cache_file_type raises when file cannot be read."""
     target = tmp_path / "data.csv"
     target.write_text("value,1\n", encoding="utf8")
     original_open = cast(
@@ -413,7 +439,7 @@ def test_optional_file_type_rejects_unreadable_file(
     monkeypatch.setattr(Path, "open", fake_open)
 
     with pytest.raises(argparse.ArgumentTypeError, match="unable to read file path"):
-        optional_file_type(str(target))
+        optional_cache_file_type(str(target))
 
 
 def test_existing_file_type_rejects_unreadable_file(

--- a/tests/general/test_broker_registry.py
+++ b/tests/general/test_broker_registry.py
@@ -128,30 +128,6 @@ def test_vanguard_warning_omits_cache_path_when_flag_is_cleared(
     assert "--isin-translation-file cache. " in warning
 
 
-def test_vanguard_warning_omits_stdin_sentinel_as_cache_path(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
-    """The stdin sentinel is not a usable cache location, so do not name it."""
-    vanguard_file = _write_vanguard_csv(tmp_path)
-    args = create_parser().parse_args(
-        [
-            "--year",
-            "2023",
-            "--vanguard-file",
-            str(vanguard_file),
-            "--isin-translation-file",
-            "-",
-        ]
-    )
-    converter = IsinConverter(isin_translation_file=args.isin_translation_file)
-
-    with caplog.at_level(logging.WARNING):
-        BrokerRegistry.load_all_transactions(args, converter)
-
-    warning = _vanguard_warning(caplog)
-    assert "--isin-translation-file cache. " in warning
-
-
 def test_vanguard_symbol_with_isin_mapping_does_not_warn(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
Fixes #1009.

`optional_file_type` mapped `-` to the stdin sentinel, but all three of its call sites are the read/write caches, where stdin has no meaning. Nothing downstream guarded the sentinel, so `-` created a file literally named `-` in the working directory, and the next run read that file back as the cache while the intended one was never touched.

Since every caller was a cache option, I narrowed that validator in place and renamed it `cache_file_type`, rather than adding a second one and leaving `optional_file_type` with no callers. Happy to split it into two if you would rather keep the general form. An empty value still disables the cache, and `-` still means stdin for the input options through `existing_file_type`.

The guard matches the argument exactly, so `./-` still resolves to `Path("-")` and still writes a file named `-`. That felt like the right line to draw: it is the conventional unambiguous way to name a file called `-`, it is deliberate rather than a surprise, and nothing compares these three options against the sentinel anymore. Say the word if you would rather reject the resolved path instead.

The second half of the issue follows from that: `broker_registry` no longer needs its `STDIN_PATH` check, because `--isin-translation-file` can no longer hold the sentinel. That also leaves `test_vanguard_warning_omits_stdin_sentinel_as_cache_path` asserting something untrue, since `location` would now render `" at -"`, so I removed it rather than reworking it to build the sentinel by hand and pin behaviour the CLI can no longer produce. Both branches of the simplified conditional stay covered by the two neighbouring tests.

The new parser test covers all three options and asserts the parse-time message. I checked it discriminates by running it against the unfixed validator, where all three cases fail with `DID NOT RAISE SystemExit`, and added a companion case for `--exchange-rates-file=-rates.csv` because an over-broad `startswith("-")` guard would otherwise pass the whole suite. While I was in the file I gave the four neighbouring tests over the same three options the same `cache_path_arguments` name, since they all exercise this validator.

Reproducing on `main` first also showed the read-back you describe: writing the ISIN cache to `-` and then constructing `SpinOffHandler` with `-` made it load the ISIN file as its own cache and fail on `invalid columns dict_keys(['ISIN', 'symbol'])`.

Left out of scope, mention it if you want it: `output_path_type` also accepts `-`, so `-o -` writes the report to a file named `-`. That one is write-only and never read back as data, so it is a different bug from the cache round-trip this issue is about.

Checks: `uv run pytest` 910 passed, with and without `CGT_TEST_MODE_STRICT`. Plus ruff format, ruff check, mypy, ty, codespell and Harper.

Disclosure: written with AI assistance (Claude). The bug was reproduced against `main` first, and the new test was confirmed to fail on the unfixed validator before anything was changed.