### PR TITLE
Point repository URLs at the cgt-calc organisation

### DIFF
--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   autolabel:
     name: Autolabeler
-    if: github.repository_owner == 'KapJI'
+    if: github.repository_owner == 'cgt-calc'
     runs-on: ubuntu-latest
     steps:
       - name: Run release-drafter autolabeler

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,12 +15,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE: ghcr.io/kapji/capital-gains-calculator
+  IMAGE: ghcr.io/cgt-calc/capital-gains-calculator
 
 jobs:
   build-amd64:
     name: Build amd64 image
-    if: github.repository_owner == 'KapJI'
+    if: github.repository_owner == 'cgt-calc'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -82,7 +82,7 @@ jobs:
 
   build-arm64:
     name: Build arm64 image
-    if: github.repository_owner == 'KapJI'
+    if: github.repository_owner == 'cgt-calc'
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ghcr
-      url: https://github.com/KapJI/capital-gains-calculator/pkgs/container/capital-gains-calculator
+      url: https://github.com/cgt-calc/capital-gains-calculator/pkgs/container/capital-gains-calculator
     permissions:
       packages: write
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   triage:
     name: Triage
-    if: github.repository_owner == 'KapJI'
+    if: github.repository_owner == 'cgt-calc'
     runs-on: ubuntu-latest
     steps:
       - name: Run Pull Request Labeler

--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   labeler:
     name: Update labels
-    if: github.repository_owner == 'KapJI'
+    if: github.repository_owner == 'cgt-calc'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   publish:
     name: Publish
-    if: github.repository_owner == 'KapJI'
+    if: github.repository_owner == 'cgt-calc'
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   draft_release:
     name: Release Drafter
-    if: github.repository_owner == 'KapJI'
+    if: github.repository_owner == 'cgt-calc'
     runs-on: ubuntu-latest
     steps:
       - name: Run release-drafter

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![PyPI version](https://img.shields.io/pypi/v/cgt-calc)](https://pypi.org/project/cgt-calc/)
-[![CI](https://github.com/KapJI/capital-gains-calculator/actions/workflows/ci.yml/badge.svg)](https://github.com/KapJI/capital-gains-calculator/actions)
-[![codecov](https://codecov.io/gh/KapJI/capital-gains-calculator/graph/badge.svg)](https://app.codecov.io/gh/KapJI/capital-gains-calculator)
+[![CI](https://github.com/cgt-calc/capital-gains-calculator/actions/workflows/ci.yml/badge.svg)](https://github.com/cgt-calc/capital-gains-calculator/actions)
+[![codecov](https://codecov.io/gh/cgt-calc/capital-gains-calculator/graph/badge.svg)](https://app.codecov.io/gh/cgt-calc/capital-gains-calculator)
 
 # <img src="https://cgt-calc.uk/assets/logo.svg" alt="" width="34" valign="middle"> UK Capital Gains Calculator
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,6 @@ Security fixes are provided for the latest release and the `main` branch.
 Please do not report security vulnerabilities through public GitHub issues.
 
 Use
-[GitHub private vulnerability reporting](https://github.com/KapJI/capital-gains-calculator/security/advisories/new)
+[GitHub private vulnerability reporting](https://github.com/cgt-calc/capital-gains-calculator/security/advisories/new)
 instead. You will get a response as soon as possible, and you'll be kept informed of the progress
 towards a fix and disclosure.

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -235,7 +235,7 @@ def action_from_str(label: str, file: Path) -> ActionType:
         "Journal",
         "Cash In Lieu",
         # Proceeds of the historical autosale programme wired out of the
-        # account, see https://github.com/KapJI/capital-gains-calculator/issues/488
+        # account, see https://github.com/cgt-calc/capital-gains-calculator/issues/488
         "Forced Disbursement",
     }:
         return ActionType.TRANSFER

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -480,7 +480,7 @@ class VanguardParser(BaseSingleFileParser):
                     raise ParsingError(file_path, str(err), row_index=index) from err
 
             # Resolve missing quantity/price with values from the investment table, see
-            # https://github.com/KapJI/capital-gains-calculator/issues/758
+            # https://github.com/cgt-calc/capital-gains-calculator/issues/758
             for txn in transactions:
                 matched_inv = _find_investment_match(txn, investment_lookup)
                 txn.enrich_details(matched_inv)

--- a/docs/brokers/freetrade.md
+++ b/docs/brokers/freetrade.md
@@ -24,7 +24,7 @@ is the safest range for UK share matching; see [Before you start](../usage.md#be
 
 Use the Activity Feed CSV, not a monthly statement PDF or a yearly tax statement. Keep the exported
 columns unchanged. You can compare the layout with this
-[sanitised example export](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/freetrade/data/transactions.csv).
+[sanitised example export](https://github.com/cgt-calc/capital-gains-calculator/blob/main/tests/freetrade/data/transactions.csv).
 
 ## Generate the report
 
@@ -110,8 +110,8 @@ Identify any other named row in Freetrade before deciding what to do with it:
 
 If the row is an executed transaction not covered by [Supported activity](#supported-activity),
 first upgrade cgt-calc using the same method you used to install it. If it still fails, open a
-[GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new) with the complete error
-and a sanitised copy of the row.
+[GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new) with the complete
+error and a sanitised copy of the row.
 
 ### `Missing columns` or `Unknown columns`
 

--- a/docs/brokers/hargreaves-lansdown.md
+++ b/docs/brokers/hargreaves-lansdown.md
@@ -38,7 +38,7 @@ PDF for each reference. If HL downloaded it under another name, retain the origi
 and rename a copy; do not edit or convert the PDF itself.
 
 You can compare the CSV layout with the
-[sanitised example](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/hl/data/inputs/hl-transaction-summary.csv).
+[sanitised example](https://github.com/cgt-calc/capital-gains-calculator/blob/main/tests/hl/data/inputs/hl-transaction-summary.csv).
 The tests create synthetic contract notes rather than publishing real account PDFs.
 
 ## Generate the report
@@ -121,7 +121,7 @@ Keep the original export unchanged. For activity whose complete details and UK t
 independently verify, make a separate working copy without the unsupported row and add one
 equivalent transaction through another supported export or the [RAW format](raw.md). Make sure the
 activity appears exactly once. Otherwise, open a
-[GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new) with your cgt-calc
+[GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new) with your cgt-calc
 version, the complete error and a sanitised copy of the row.
 
 ### `Could not find the 'Trade date' header` or `CSV header mismatch`

--- a/docs/brokers/interactive-brokers.md
+++ b/docs/brokers/interactive-brokers.md
@@ -32,7 +32,7 @@ Do not substitute an Activity Statement or a Flex Query CSV: their sections and 
 different even though they are also available from **Performance & Reports**.
 
 You can compare the file's structure with the
-[synthetic example CSV](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/interactive_brokers/data/test_basic.csv).
+[synthetic example CSV](https://github.com/cgt-calc/capital-gains-calculator/blob/main/tests/interactive_brokers/data/test_basic.csv).
 
 ## Generate the report
 
@@ -111,7 +111,7 @@ columns. `Price Currency` and `Exchange Rate` are accepted optional columns.
 
 If an unchanged export still fails, first upgrade cgt-calc using the same method you used to install
 it. If the error remains, open a
-[GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new) with:
+[GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new) with:
 
 - your cgt-calc version from `cgt-calc --version`;
 - the complete error message; and

--- a/docs/brokers/morgan-stanley.md
+++ b/docs/brokers/morgan-stanley.md
@@ -29,7 +29,7 @@ tax year you are calculating. Earlier vesting establishes the cost and quantity 
 later, and acquisitions in the following 30 days can affect UK share matching.
 
 You can compare the two recognised files with the
-[sanitised example reports](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/morgan_stanley/data).
+[sanitised example reports](https://github.com/cgt-calc/capital-gains-calculator/tree/main/tests/morgan_stanley/data).
 
 ## Generate the report
 
@@ -94,7 +94,7 @@ Keep the downloaded reports unchanged: do not delete the row, change its proceed
 guessed RAW transactions.
 
 First upgrade cgt-calc using the same method you used to install it. If the error remains, open a
-[GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new) with your cgt-calc
+[GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new) with your cgt-calc
 version, the complete error, and sanitised copies of the failing release row and its corresponding
 Autosale record.
 

--- a/docs/brokers/raw.md
+++ b/docs/brokers/raw.md
@@ -4,14 +4,14 @@ You will need:
 
 - **CSV using the RAW format.** If your broker isn't natively supported you might choose to convert
   whatever report you can produce into this basic format.
-  [See example](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/raw/data/test_data_2.csv).
+  [See example](https://github.com/cgt-calc/capital-gains-calculator/blob/main/tests/raw/data/test_data_2.csv).
   Include the header row shown below (lower-case column names in this order). The parser can infer
   the column order when the header is missing, but it will emit a warning so you can update your
   export the next time.
 
   - `date` – transaction date in `YYYY-MM-DD` format.
   - `action` – one of the supported broker actions (see
-    [`ActionType`](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/model.py)).
+    [`ActionType`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/model.py)).
   - `symbol` – instrument ticker; leave blank for cash movements if not applicable.
   - `quantity` – number of shares or units involved (blank for cash-only transactions).
   - `price` – price per unit in the transaction currency (blank when not applicable).

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -5,7 +5,7 @@ You will need:
 - **Exported transaction history in CSV format.** Schwab only allows you to download transactions
   for the last 4 years. If you require more, you can download the history in 4-year chunks and
   combine them.
-  [See example](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/schwab/data/schwab_transactions.csv).
+  [See example](https://github.com/cgt-calc/capital-gains-calculator/blob/main/tests/schwab/data/schwab_transactions.csv).
 - **Exported transaction history from Schwab Equity Awards in CSV format.** Only applicable if you
   receive equity awards in your account (e.g. for Alphabet/Google employees). Follow the same
   procedure as in the normal transaction history but selecting your Equity Award account.
@@ -18,7 +18,7 @@ cgt-calc --year 2020 --schwab-file schwab_transactions.csv --schwab-award-file s
 
 _Note: For historic reasons, it is possible to provide the Equity Awards history in JSON format with
 `--schwab-equity-award-json`. Instructions are available at the top of this
-[parser file](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/parsers/schwab_equity_award_json.py).
+[parser file](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/parsers/schwab_equity_award_json.py).
 Please use the CSV method above if possible._
 
 ## NVIDIA equity awards
@@ -58,7 +58,7 @@ a share that fell that far looks the same.
 export becomes a mix of units and has to be downloaded again in full.
 
 Covered by
-[`tests/schwab/test_schwab_equity_award_nvda.py`](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/schwab/test_schwab_equity_award_nvda.py),
+[`tests/schwab/test_schwab_equity_award_nvda.py`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/tests/schwab/test_schwab_equity_award_nvda.py),
 against a synthetic portfolio with real dates and prices and invented share counts.
 
 ## Gifted shares

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -53,7 +53,7 @@ files or search subdirectories.
 Do not rename or delete columns when converting the worksheets. In addition to the legacy headings,
 cgt-calc accepts aliases including `Market Code`, `Qty`, `Instrument Currency` and `Exch. Rate`. You
 can compare the legacy structure with the
-[sanitised example reports](https://github.com/KapJI/capital-gains-calculator/tree/main/tests/sharesight/data/inputs).
+[sanitised example reports](https://github.com/cgt-calc/capital-gains-calculator/tree/main/tests/sharesight/data/inputs).
 
 ## Generate the report
 
@@ -118,7 +118,8 @@ cgt-calc found the report's header row but not every column it needs. This happe
 were edited during conversion, or when Sharesight has changed the report format.
 
 First upgrade cgt-calc using the same method you used to install it and try again. If the error
-remains, open a [GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new) with:
+remains, open a [GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new)
+with:
 
 - your cgt-calc version from `cgt-calc --version`;
 - the complete error message; and

--- a/docs/brokers/trading212.md
+++ b/docs/brokers/trading212.md
@@ -42,7 +42,7 @@ between date ranges. Overlaps are safe: exact repeated transactions are removed 
 212 transaction ID.
 
 You can compare the structure with this
-[sanitised example export](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/trading212/data/2024/inputs/transactions.csv).
+[sanitised example export](https://github.com/cgt-calc/capital-gains-calculator/blob/main/tests/trading212/data/2024/inputs/transactions.csv).
 
 ## Generate the report
 
@@ -96,7 +96,7 @@ activity could make the resulting holdings and gains incorrect.
 
 Trading 212 occasionally changes its export format. First, upgrade cgt-calc using the same method
 you used to install it and try again. If the error remains, open a
-[GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new) containing:
+[GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new) containing:
 
 - your cgt-calc version from `cgt-calc --version`;
 - the complete error message;

--- a/docs/brokers/vanguard.md
+++ b/docs/brokers/vanguard.md
@@ -29,7 +29,7 @@ summarises dividends and tax deducted at source, but does not provide a Capital 
 calculation.
 
 You can compare the expected worksheet structure with the
-[sanitised example](https://github.com/KapJI/capital-gains-calculator/blob/main/tests/vanguard/data/cash_investment_report.csv).
+[sanitised example](https://github.com/cgt-calc/capital-gains-calculator/blob/main/tests/vanguard/data/cash_investment_report.csv).
 The filename does not matter. Use commas: tab-separated full worksheets are not reliably detected.
 
 ### Why both tables matter
@@ -197,7 +197,7 @@ Keep the original export unchanged. A name-based `NameChange` row is unsupported
 ticker-based rename is recognised. If the row is another real transaction not listed under
 [Supported activity](#supported-activity), first upgrade cgt-calc using the same method you used to
 install it. If it still fails, open a
-[GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new) with your cgt-calc
+[GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new) with your cgt-calc
 version, the complete error and a sanitised copy of the row.
 
 Do not assume that every unsupported row raises this error. A row beginning `Reversal of` can be
@@ -224,7 +224,7 @@ created by an incomplete spreadsheet conversion.
 Also inspect every `Reversal of` row. Only dividend reversals have been validated; a reversed buy or
 sell can be imported with the wrong action, quantity or amount instead of being rejected. Keep the
 original export unchanged and report an unchanged Vanguard row that behaves this way in a
-[GitHub issue](https://github.com/KapJI/capital-gains-calculator/issues/new).
+[GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new).
 
 ### `Reached a negative balance` or `Tried to sell not owned symbol`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ The following configuration files and options allow you to customize the calcula
   `out/isin_translation.csv`; `--isin-translation-file` selects a different cache path. Existing
   entries are read, and cgt-calc can create or rewrite the file after a successful Open FIGI lookup
   or after learning a mapping from broker transactions. Pre-packaged mappings are available in
-  [`initial_isin_translation.csv`](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/resources/initial_isin_translation.csv),
+  [`initial_isin_translation.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_isin_translation.csv),
   which you can extend using the cache file. A cache entry for an existing ISIN replaces the bundled
   symbol set for that ISIN, so put every verified alias in additional columns on the same CSV row.
 
@@ -24,7 +24,7 @@ The following configuration files and options allow you to customize the calcula
 
 - **Initial stock prices.** Required for special events like vesting, splits, or spin-offs when
   historical prices aren't available from your broker. Prices should be in USD.
-  [`initial_prices.csv`](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/resources/initial_prices.csv)
+  [`initial_prices.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_prices.csv)
   comes pre-packaged. The program will inform you when a required price is missing, and you can
   supply custom data with `--initial-prices-file`.
 

--- a/docs/custom-eri-data.md
+++ b/docs/custom-eri-data.md
@@ -7,7 +7,7 @@ the [bundled data](offshore-funds.md#bundled-data) first.
 
 - **CSV using the ERI_RAW format.** This is currently the only format supported for excess reported
   income.
-  [See example.](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/resources/eri/vanguard_eri.csv)
+  [See example.](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/eri/vanguard_eri.csv)
 
 Example usage for the tax year 2024/25:
 

--- a/docs/development/adding-a-broker.md
+++ b/docs/development/adding-a-broker.md
@@ -1,9 +1,9 @@
 # Adding a Broker
 
 1. Add a new parser class in
-   [`cgt_calc/parsers/`](https://github.com/KapJI/capital-gains-calculator/tree/main/cgt_calc/parsers)
+   [`cgt_calc/parsers/`](https://github.com/cgt-calc/capital-gains-calculator/tree/main/cgt_calc/parsers)
 2. Register it in
-   [`cgt_calc/parsers/broker_registry.py`](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/parsers/broker_registry.py)
+   [`cgt_calc/parsers/broker_registry.py`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/parsers/broker_registry.py)
 3. Add tests in `tests/`
 4. Add a docs page under `docs/brokers/` and a nav entry in `zensical.toml`, and add the broker to
    the table in [Brokers](../brokers/index.md) and the list in the README. All three are sorted by

--- a/docs/development/eri-data.md
+++ b/docs/development/eri-data.md
@@ -7,24 +7,24 @@ is described in [Providing custom ERI data](../custom-eri-data.md#where-provider
 ## Importing provider reports
 
 For most providers you can import reports automatically. Run the
-[`import_eri_reports.py`](https://github.com/KapJI/capital-gains-calculator/blob/main/scripts/import_eri_reports.py)
+[`import_eri_reports.py`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/scripts/import_eri_reports.py)
 script pointing to either the file or the folder containing the downloaded ERI reports. The tool
 recognizes the funds provider from the filename and imports the data into the matching resource CSV
 under
-[`cgt_calc/resources/eri/`](https://github.com/KapJI/capital-gains-calculator/tree/main/cgt_calc/resources/eri).
+[`cgt_calc/resources/eri/`](https://github.com/cgt-calc/capital-gains-calculator/tree/main/cgt_calc/resources/eri).
 Vanguard, BlackRock, iShares, Xtrackers and Invesco reports are all supported this way. The script
 also records any new ISIN translations into
-[`initial_isin_translation.csv`](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/resources/initial_isin_translation.csv).
+[`initial_isin_translation.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_isin_translation.csv).
 
 Amundi reports have no automatic importer — add their data manually as described below.
 
 ## Manual additions and ISIN translations
 
 To add data by hand, append the rows at the bottom of the provider's resource CSV under
-[`cgt_calc/resources/eri/`](https://github.com/KapJI/capital-gains-calculator/tree/main/cgt_calc/resources/eri).
+[`cgt_calc/resources/eri/`](https://github.com/cgt-calc/capital-gains-calculator/tree/main/cgt_calc/resources/eri).
 Then run the tool once to generate any new ISIN translations (if needed) and copy them from your own
 ISIN translation file (default `out/isin_translation.csv`) into
-[`initial_isin_translation.csv`](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/resources/initial_isin_translation.csv).
+[`initial_isin_translation.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_isin_translation.csv).
 
 ## Pull request checklist
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in improving **cgt-calc** — contributions of all kinds are welcome! If you
 find a bug or have feature ideas, please open an
-[issue](https://github.com/KapJI/capital-gains-calculator/issues) or pull request.
+[issue](https://github.com/cgt-calc/capital-gains-calculator/issues) or pull request.
 
 ## Getting started
 
@@ -19,7 +19,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ### 2. Clone the repository
 
 ```shell
-git clone https://github.com/KapJI/capital-gains-calculator.git
+git clone https://github.com/cgt-calc/capital-gains-calculator.git
 cd capital-gains-calculator
 ```
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,7 +7,7 @@ shell with `cgt-calc` installed on `$PATH`:
 
 ```shell
 $ cd ~/Taxes/Transactions
-$ docker run --rm -it -v "$PWD":/data ghcr.io/kapji/capital-gains-calculator
+$ docker run --rm -it -v "$PWD":/data ghcr.io/cgt-calc/capital-gains-calculator
 a4800eca1914:/data# cgt-calc [...]
 ```
 
@@ -19,7 +19,7 @@ host, with your output report PDF etc.
 You can also run a single command directly:
 
 ```shell
-$ docker run --rm -v "$PWD":/data ghcr.io/kapji/capital-gains-calculator -lc "cgt-calc [...]"
+$ docker run --rm -v "$PWD":/data ghcr.io/cgt-calc/capital-gains-calculator -lc "cgt-calc [...]"
 ```
 
 ## Available tags

--- a/docs/offshore-funds.md
+++ b/docs/offshore-funds.md
@@ -7,7 +7,7 @@ find the full list of funds that requires this at
 [HMRC](https://www.gov.uk/government/publications/offshore-funds-list-of-reporting-funds).
 
 The tool already includes such yearly history in the
-[resources folder](https://github.com/KapJI/capital-gains-calculator/tree/main/cgt_calc/resources/eri).
+[resources folder](https://github.com/cgt-calc/capital-gains-calculator/tree/main/cgt_calc/resources/eri).
 You can check if your fund is already included, or provide a custom ERI history file following the
 instructions in [Providing custom ERI data](custom-eri-data.md). We strongly suggest sharing
 compiled ERI data so it can be added to the package as it can save significant time to other users
@@ -17,11 +17,11 @@ that hold the same fund.
 
 Currently bundled data:
 
-- [Vanguard Funds Plc 2018-2025](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/resources/eri/vanguard_eri.csv)
-- [Blackrock Funds 2019-2025](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/resources/eri/blackrock_eri.csv)
-- [iShares Funds 2018-2025](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/resources/eri/ishares_eri.csv)
-- [Invesco Funds 2018-2024](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/resources/eri/invesco_eri.csv)
-- [Xtrackers Funds 2024](https://github.com/KapJI/capital-gains-calculator/blob/main/cgt_calc/resources/eri/xtrackers_eri.csv)
+- [Vanguard Funds Plc 2018-2025](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/eri/vanguard_eri.csv)
+- [Blackrock Funds 2019-2025](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/eri/blackrock_eri.csv)
+- [iShares Funds 2018-2025](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/eri/ishares_eri.csv)
+- [Invesco Funds 2018-2024](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/eri/invesco_eri.csv)
+- [Xtrackers Funds 2024](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/eri/xtrackers_eri.csv)
 
 The ERI funds are indexed by ISIN and the tool provides automatic translation from ISIN to tickers,
 in case your broker doesn't supply the ISIN in their transaction history. For instructions on how to

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -23,4 +23,4 @@ You are responsible for providing complete data and checking the figures against
 current HMRC guidance before using them in a tax return. For unusual or uncertain circumstances,
 consider consulting a suitably qualified tax adviser. The software is provided "as is", without
 warranty of any kind; see the
-[MIT License](https://github.com/KapJI/capital-gains-calculator/blob/main/LICENSE).
+[MIT License](https://github.com/cgt-calc/capital-gains-calculator/blob/main/LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ dependencies = [
 
 [project.urls]
 "Homepage" = "https://cgt-calc.uk"
-"Repository" = "https://github.com/KapJI/capital-gains-calculator"
-"Bug Tracker" = "https://github.com/KapJI/capital-gains-calculator/issues"
-"Release Notes" = "https://github.com/KapJI/capital-gains-calculator/releases"
+"Repository" = "https://github.com/cgt-calc/capital-gains-calculator"
+"Bug Tracker" = "https://github.com/cgt-calc/capital-gains-calculator/issues"
+"Release Notes" = "https://github.com/cgt-calc/capital-gains-calculator/releases"
 
 [project.scripts]
 cgt-calc = "cgt_calc.main:init"

--- a/tests/general/test_current_price_fetcher.py
+++ b/tests/general/test_current_price_fetcher.py
@@ -49,7 +49,7 @@ def test_uses_current_price_when_present(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_falls_back_to_regular_market_price(monkeypatch: pytest.MonkeyPatch) -> None:
     """ETFs like VTI lack currentPrice but carry regularMarketPrice and navPrice.
 
-    See https://github.com/KapJI/capital-gains-calculator/issues/801.
+    See https://github.com/cgt-calc/capital-gains-calculator/issues/801.
     """
     monkeypatch.setattr(
         "cgt_calc.current_price_fetcher.yf.Ticker",

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -266,7 +266,7 @@ def test_dual_table_enriches_fee_sale_with_positive_price(tmp_path: Path) -> Non
 
     Quantity comes from the investment table and the derived unit price must
     be positive even though the cash amount is an outflow.
-    See https://github.com/KapJI/capital-gains-calculator/issues/758.
+    See https://github.com/cgt-calc/capital-gains-calculator/issues/758.
     """
     fee_sale_details = (
         "Selling of account investments for payment of Account Fee "

--- a/zensical.toml
+++ b/zensical.toml
@@ -3,8 +3,8 @@ site_name = "UK Capital Gains Calculator"
 site_url = "https://cgt-calc.uk/"
 site_description = "Calculate UK capital gains from your investment transaction history and generate a detailed PDF report."
 site_author = "Ruslan Sayfutdinov"
-repo_url = "https://github.com/KapJI/capital-gains-calculator"
-repo_name = "KapJI/capital-gains-calculator"
+repo_url = "https://github.com/cgt-calc/capital-gains-calculator"
+repo_name = "cgt-calc/capital-gains-calculator"
 edit_uri = "edit/main/docs/"
 
 nav = [
@@ -87,7 +87,7 @@ toggle.name = "Switch to system preference"
 
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
-link = "https://github.com/KapJI/capital-gains-calculator"
+link = "https://github.com/cgt-calc/capital-gains-calculator"
 
 [project.markdown_extensions]
 admonition = {}


### PR DESCRIPTION
Updates 63 references to the old owner across 31 files: workflow owner guards, the GHCR image path, project URLs, badges and documentation links.

The Docker image moves to `ghcr.io/cgt-calc/capital-gains-calculator`. The old path is frozen and will be removed once the next release has published there.

Existing clones keep working through GitHub's redirect. To update a remote anyway:

```sh
git remote set-url origin git@github.com:cgt-calc/capital-gains-calculator.git
# HTTPS clones
git remote set-url origin https://github.com/cgt-calc/capital-gains-calculator.git
```

If you work from a fork, update `upstream` rather than `origin`.
