### PR TITLE
Accept '-' only where stdin can be read, and only once

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -13,6 +13,7 @@ ArgumentParser
 ArgumentTypeError
 arm64
 autosale
+BaseSingleFileParser
 BGF
 BGIF
 blackrock
@@ -49,6 +50,7 @@ CSVs
 CurrencyConverter
 currentPrice
 cusip
+dest
 DictReader
 DictReader's
 dprint
@@ -62,6 +64,7 @@ ETFs
 f
 FeesAndCommissions
 FIGI
+FileNotFoundError
 freetrade
 FX
 GA
@@ -148,6 +151,7 @@ Shareworks
 shfmt
 shtab
 SIPP
+SLF001
 SOLV
 SpinOff
 SpinOffs

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -9,9 +9,11 @@ import logging
 import shtab
 
 from .args_validators import (
+    STDIN_PATH,
     DeprecatedAction,
     VersionAction,
     date_type,
+    existing_file_or_stdin_type,
     existing_file_type,
     optional_cache_file_type,
     output_path_type,
@@ -221,6 +223,33 @@ Environment variables:
         help=argparse.SUPPRESS,
     )
     return parser
+
+
+def reject_duplicate_stdin(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> None:
+    """Reject the stdin marker passed to more than one option.
+
+    Only one option can consume stdin. Whichever parser runs second sees an
+    exhausted stream and fails with an error naming the wrong file, or reports
+    no transactions at all.
+    """
+    # existing_file_or_stdin_type is exactly the set of options wired to a stdin
+    # consumer, so the parser itself is the source of truth here.
+    options: dict[str, str] = {}
+    for action in parser._actions:  # noqa: SLF001
+        if action.type is not existing_file_or_stdin_type:
+            continue
+        if getattr(args, action.dest, None) != STDIN_PATH:
+            continue
+        # Deprecated aliases share a dest, so keep the canonical flag only.
+        options.setdefault(action.dest, action.option_strings[0])
+    if len(options) > 1:
+        named = ", ".join(sorted(options.values()))
+        parser.error(
+            "'-' reads from stdin and can only be given to one option, "
+            f"but was given to {named}"
+        )
 
 
 def resolve_reporting_period(

--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -119,10 +119,22 @@ def _existing_path_type(value: str, *, require_dir: bool) -> Path:
     return path
 
 
-def existing_file_type(value: str) -> Path:
+def existing_file_or_stdin_type(value: str) -> Path:
     """Validate that provided value points to an existing file, or '-' for stdin."""
     if value == "-":
         return STDIN_PATH
+    return _existing_path_type(value, require_dir=False)
+
+
+def existing_file_type(value: str) -> Path:
+    """Validate that provided value points to an existing file.
+
+    The stdin marker is rejected: options using this validator open the path
+    directly instead of going through BaseSingleFileParser, so '-' would raise
+    FileNotFoundError mid-run, or silently read a file literally named '-'.
+    """
+    if value == "-":
+        raise argparse.ArgumentTypeError("expected file path, got stdin marker: '-'")
     return _existing_path_type(value, require_dir=False)
 
 

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from colorama import Fore, Style
 
 from . import render_latex
-from .args_parser import create_parser, resolve_reporting_period
+from .args_parser import create_parser, reject_duplicate_stdin, resolve_reporting_period
 from .const import (
     BALANCE_CHECK_CONTEXT_ROWS,
     BED_AND_BREAKFAST_DAYS,
@@ -2728,6 +2728,7 @@ def main() -> int:
         return 0
 
     args = parser.parse_args()
+    reject_duplicate_stdin(parser, args)
     resolve_reporting_period(parser, args)
 
     if args.verbose:

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -15,7 +15,7 @@ from cgt_calc.args_validators import (
     STDIN_PATH,
     DeprecatedAction,
     existing_directory_type,
-    existing_file_type,
+    existing_file_or_stdin_type,
     set_completer,
 )
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
@@ -65,7 +65,7 @@ class BaseSingleFileParser(BaseParser):
         set_completer(
             arg_group.add_argument(
                 f"--{cls.full_arg}",
-                type=existing_file_type,
+                type=existing_file_or_stdin_type,
                 default=None,
                 metavar="PATH",
                 help=f"{cls.pretty_name} transaction history "
@@ -78,7 +78,7 @@ class BaseSingleFileParser(BaseParser):
                 deprecated_flag,
                 action=DeprecatedAction,
                 dest=cls.full_arg.replace("-", "_"),
-                type=existing_file_type,
+                type=existing_file_or_stdin_type,
                 help=argparse.SUPPRESS,
             )
 

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable, Iterator
 import datetime
+from decimal import localcontext
 import logging
 from pathlib import Path
+import sys
 from typing import IO, TextIO, cast
 
 import pytest
@@ -14,11 +16,13 @@ import pytest
 from cgt_calc.args_parser import (
     create_parser,
     get_last_elapsed_tax_year,
+    reject_duplicate_stdin,
     resolve_reporting_period,
 )
 from cgt_calc.args_validators import (
     STDIN_PATH,
     existing_directory_type,
+    existing_file_or_stdin_type,
     existing_file_type,
     optional_cache_file_type,
 )
@@ -29,6 +33,7 @@ from cgt_calc.const import (
     DEFAULT_SPIN_OFF_FILE,
     INTERNAL_START_DATE,
 )
+from cgt_calc.main import main
 
 ReturnType = TextIO | IO[bytes]
 DirIterator = Iterator[Path]
@@ -442,10 +447,10 @@ def test_optional_cache_file_type_rejects_unreadable_file(
         optional_cache_file_type(str(target))
 
 
-def test_existing_file_type_rejects_unreadable_file(
+def test_existing_file_or_stdin_type_rejects_unreadable_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """existing_file_type raises when file cannot be read."""
+    """existing_file_or_stdin_type raises when file cannot be read."""
     target = tmp_path / "data.csv"
     target.write_text("value,1\n", encoding="utf8")
     original_open = cast(
@@ -468,7 +473,7 @@ def test_existing_file_type_rejects_unreadable_file(
     monkeypatch.setattr(Path, "open", fake_open)
 
     with pytest.raises(argparse.ArgumentTypeError, match="unable to read file path"):
-        existing_file_type(str(target))
+        existing_file_or_stdin_type(str(target))
 
 
 def test_no_report_alone_works() -> None:
@@ -610,9 +615,9 @@ def test_interest_fund_tickers_empty_items_filtered() -> None:
     assert args.interest_fund_tickers == ["VGOV", "VBMFX"]
 
 
-def test_existing_file_type_stdin() -> None:
-    """Ensure existing_file_type returns STDIN_PATH when passed '-'."""
-    assert existing_file_type("-") == STDIN_PATH
+def test_existing_file_or_stdin_type_accepts_stdin() -> None:
+    """Ensure existing_file_or_stdin_type returns STDIN_PATH when passed '-'."""
+    assert existing_file_or_stdin_type("-") == STDIN_PATH
 
 
 def test_raw_file_stdin() -> None:
@@ -620,6 +625,112 @@ def test_raw_file_stdin() -> None:
     parser = create_parser()
     args = parser.parse_args(["--raw-file", "-"])
     assert args.raw_file == STDIN_PATH
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        "--initial-prices-file",
+        "--initial-prices",
+        "--schwab-award-file",
+        "--schwab-award",
+    ],
+)
+def test_options_without_a_stdin_consumer_reject_stdin(
+    option: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Ensure options that never read stdin reject '-' at parse time."""
+    parser = create_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([option, "-"])
+
+    assert exc_info.value.code == 2
+    assert "got stdin marker" in capsys.readouterr().err
+
+
+def test_existing_file_type_rejects_stdin() -> None:
+    """Ensure existing_file_type refuses the stdin marker."""
+    with pytest.raises(argparse.ArgumentTypeError, match="got stdin marker"):
+        existing_file_type("-")
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--raw-file", "-", "--schwab-file", "-"],
+        ["--raw-file", "-", "--eri-raw-file", "-"],
+        ["--vanguard-file", "-", "--freetrade-file", "-", "--raw-file", "-"],
+    ],
+)
+def test_reject_duplicate_stdin_rejects_several_options(
+    argv: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Ensure '-' given to more than one option fails with a helpful error."""
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    with pytest.raises(SystemExit) as exc_info:
+        reject_duplicate_stdin(parser, args)
+
+    assert exc_info.value.code == 2
+    message = capsys.readouterr().err
+    assert "can only be given to one option" in message
+    for option in argv[::2]:
+        assert option in message
+
+
+def test_reject_duplicate_stdin_allows_a_single_option() -> None:
+    """Ensure a single '-' is still accepted."""
+    parser = create_parser()
+    args = parser.parse_args(["--raw-file", "-"])
+
+    reject_duplicate_stdin(parser, args)
+
+    assert args.raw_file == STDIN_PATH
+
+
+def test_reject_duplicate_stdin_allows_an_option_and_its_alias() -> None:
+    """A deprecated alias shares its dest, so it is not a second stdin reader."""
+    parser = create_parser()
+    args = parser.parse_args(["--schwab-file", "-", "--schwab", "-"])
+
+    reject_duplicate_stdin(parser, args)
+
+    assert args.schwab_file == STDIN_PATH
+
+
+def test_reject_duplicate_stdin_ignores_ordinary_paths(tmp_path: Path) -> None:
+    """Ensure real paths never count towards the stdin limit."""
+    first = tmp_path / "raw.csv"
+    first.write_text("", encoding="utf-8")
+    second = tmp_path / "schwab.csv"
+    second.write_text("", encoding="utf-8")
+    parser = create_parser()
+    args = parser.parse_args(["--raw-file", str(first), "--schwab-file", str(second)])
+
+    reject_duplicate_stdin(parser, args)
+
+    assert args.raw_file == first
+
+
+def test_main_rejects_stdin_given_to_several_options(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The duplicate stdin check runs before any work is done."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["cgt-calc", "--year", "2021", "--raw-file", "-", "--schwab-file", "-"],
+    )
+
+    # main() enables the FloatOperation trap on the active decimal context;
+    # keep that from leaking into other tests in the same worker.
+    with localcontext(), pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 2
+    assert "can only be given to one option" in capsys.readouterr().err
 
 
 def test_initial_prices_alias_warns_deprecated(


### PR DESCRIPTION
Follow-ups from the review of #1013.

`--initial-prices-file` and `--schwab-award-file` took `-` through the shared file validator, but they open the path directly instead of going through `BaseSingleFileParser`. Passing `-` raised an uncaught `FileNotFoundError` mid-run, or silently read a file literally named `-` — exactly the file the bug in #1009 used to create.

That validator is now split in two:

- `existing_file_type` is the strict default and rejects the marker at parse time, next to the message `optional_cache_file_type` already prints.
- `existing_file_or_stdin_type` keeps the old behaviour for the broker inputs that do reach a stdin consumer.

Naming the permissive one explicitly means a new option has to opt in to stdin rather than inherit it by default.

`-` was also accepted by several options at once, but only one of them can consume stdin. Whichever parser ran second saw an exhausted stream: `--raw-file - --eri-raw-file -` reported `ERI data file is empty`, and `--raw-file - --schwab-file -` reported missing Schwab columns for the raw CSV that Schwab had already swallowed. `reject_duplicate_stdin` now names the offending options instead.

The stdin-capable set is read off the parser rather than a hand-kept list, so a new broker is covered the moment it registers with `existing_file_or_stdin_type`. Deprecated aliases share a dest and count once.

Checks: `uv run pytest` 928 passed, with and without `CGT_TEST_MODE_STRICT`, plus `pre-commit run --all-files`.