### PR TITLE
Reject pipes as caches and stop probing pipes at parse time

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -61,6 +61,7 @@ ESPP
 etc
 ETF
 ETFs
+expanduser
 f
 FeesAndCommissions
 FIGI
@@ -128,6 +129,7 @@ restkey
 restval
 roundings
 RowIterator
+RuntimeError
 RuntimeMode
 s105
 s106A

--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -60,6 +60,21 @@ def output_path_type(value: str) -> Path:
     return Path(value)
 
 
+def _expand_user(value: str) -> Path:
+    """Convert to Path, expanding a leading '~'.
+
+    Path.expanduser raises RuntimeError when the home directory cannot be
+    resolved, e.g. for an unknown '~user'. Argument parsing runs outside the
+    exception handling in main(), so that would surface as a traceback.
+    """
+    try:
+        return Path(value).expanduser()
+    except RuntimeError as err:
+        raise argparse.ArgumentTypeError(
+            f"unable to expand user path: '{value}': {err}"
+        ) from err
+
+
 def _ensure_readable_file(path: Path, value: str) -> None:
     """Raise ArgumentTypeError when file cannot be read."""
     try:
@@ -87,17 +102,24 @@ def optional_cache_file_type(value: str) -> Path | None:
 
     An empty value disables the cache. The stdin marker is rejected: a cache is
     read and written, so '-' would create a file literally named '-' and later
-    be read back as the cache.
+    be read back as the cache. Anything that is not a regular file is rejected
+    for the same reason.
     """
     if value.strip() == "":
         return None
     if value == "-":
         raise argparse.ArgumentTypeError("expected file path, got stdin marker: '-'")
-    path = Path(value)
+    path = _expand_user(value)
     if path.exists():
-        if not (path.is_file() or path.is_fifo()):
+        if path.is_dir():
             raise argparse.ArgumentTypeError(
                 f"expected file path, got directory: '{value}'"
+            )
+        if not path.is_file():
+            # Every cache is read back through Path.is_file(), so a pipe,
+            # socket or device would be written to and then never read again.
+            raise argparse.ArgumentTypeError(
+                f"expected regular file path, got: '{value}'"
             )
         _ensure_readable_file(path, value)
     return path
@@ -105,7 +127,7 @@ def optional_cache_file_type(value: str) -> Path | None:
 
 def _existing_path_type(value: str, *, require_dir: bool) -> Path:
     """Ensure provided path exists and matches expected type."""
-    path = Path(value).expanduser()
+    path = _expand_user(value)
     if not path.exists():
         raise argparse.ArgumentTypeError(f"path does not exist: '{value}'")
     if require_dir and not path.is_dir():
@@ -114,7 +136,9 @@ def _existing_path_type(value: str, *, require_dir: bool) -> Path:
         raise argparse.ArgumentTypeError(f"expected file path, got: '{value}'")
     if require_dir:
         _ensure_readable_directory(path, value)
-    else:
+    elif not path.is_fifo():
+        # Opening a pipe blocks until a writer attaches, and the probe would
+        # consume from the stream the real read needs.
         _ensure_readable_file(path, value)
     return path
 

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -7,8 +7,10 @@ from collections.abc import Callable, Iterator
 import datetime
 from decimal import localcontext
 import logging
+import os
 from pathlib import Path
 import sys
+import threading
 from typing import IO, TextIO, cast
 
 import pytest
@@ -369,16 +371,10 @@ def test_cache_path_arguments_allow_empty_string(option: str, attr: str) -> None
 
 
 @pytest.mark.parametrize(
-    ("option", "attr"),
-    [
-        ("--exchange-rates-file", "exchange_rates_file"),
-        ("--isin-translation-file", "isin_translation_file"),
-        ("--spin-offs-file", "spin_offs_file"),
-    ],
+    "option",
+    ["--exchange-rates-file", "--isin-translation-file", "--spin-offs-file"],
 )
-def test_cache_path_arguments_reject_directory(
-    tmp_path: Path, option: str, attr: str
-) -> None:
+def test_cache_path_arguments_reject_directory(tmp_path: Path, option: str) -> None:
     """Ensure cache path arguments reject directories when they exist."""
     parser = create_parser()
     directory = tmp_path / "existing_dir"
@@ -388,8 +384,6 @@ def test_cache_path_arguments_reject_directory(
         parser.parse_args([option, str(directory)])
 
     assert exc_info.value.code == 2
-    args = parser.parse_args([])
-    assert getattr(args, attr) is not None
 
 
 @pytest.mark.parametrize(
@@ -409,13 +403,120 @@ def test_cache_path_arguments_reject_stdin(
     assert "got stdin marker" in capsys.readouterr().err
 
 
-def test_cache_path_arguments_accept_leading_dash() -> None:
+@pytest.mark.parametrize(
+    ("option", "attr"),
+    [
+        ("--exchange-rates-file", "exchange_rates_file"),
+        ("--isin-translation-file", "isin_translation_file"),
+        ("--spin-offs-file", "spin_offs_file"),
+    ],
+)
+def test_cache_path_arguments_accept_leading_dash(option: str, attr: str) -> None:
     """Only the bare stdin marker is rejected, not every leading-dash path."""
     parser = create_parser()
 
-    args = parser.parse_args(["--exchange-rates-file=-rates.csv"])
+    args = parser.parse_args([f"{option}=-rates.csv"])
 
-    assert args.exchange_rates_file == Path("-rates.csv")
+    assert getattr(args, attr) == Path("-rates.csv")
+
+
+VALIDATOR_DEADLINE_SECONDS = 10.0
+
+needs_fifo = pytest.mark.skipif(
+    not hasattr(os, "mkfifo"), reason="named pipes are POSIX only"
+)
+
+
+def _validate_without_blocking(
+    validator: Callable[[str], Path | None], value: str
+) -> Path | None:
+    """Run a validator off-thread so a blocking open fails instead of hanging."""
+    done: list[Path | None] = []
+    failed: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            done.append(validator(value))
+        except BaseException as err:  # noqa: BLE001
+            failed.append(err)
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    worker.join(VALIDATOR_DEADLINE_SECONDS)
+
+    assert not worker.is_alive(), f"validation blocked on '{value}'"
+    if failed:
+        raise failed[0]
+    return done[0]
+
+
+@needs_fifo
+def test_cache_path_arguments_reject_fifo(tmp_path: Path) -> None:
+    """A cache is read back with Path.is_file(), so a pipe can never be one."""
+    fifo = tmp_path / "cache.csv"
+    os.mkfifo(fifo)
+
+    with pytest.raises(argparse.ArgumentTypeError, match="expected regular file path"):
+        _validate_without_blocking(optional_cache_file_type, str(fifo))
+
+
+@needs_fifo
+@pytest.mark.parametrize(
+    "validator",
+    [existing_file_or_stdin_type, existing_file_type],
+    ids=["with_stdin", "without_stdin"],
+)
+def test_existing_file_types_accept_fifo_without_blocking(
+    validator: Callable[[str], Path], tmp_path: Path
+) -> None:
+    """Input files may be pipes, and probing one would block or steal data."""
+    fifo = tmp_path / "transactions.csv"
+    os.mkfifo(fifo)
+
+    assert _validate_without_blocking(validator, str(fifo)) == fifo
+
+
+@pytest.mark.parametrize(
+    "validator",
+    [optional_cache_file_type, existing_file_or_stdin_type, existing_file_type],
+    ids=["cache", "with_stdin", "without_stdin"],
+)
+def test_path_validators_reject_unresolvable_home(
+    validator: Callable[[str], Path | None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unresolvable '~user' must be a parse error, not a RuntimeError."""
+
+    def refuse_expansion(self: Path) -> Path:
+        raise RuntimeError("Could not determine home directory.")
+
+    monkeypatch.setattr(Path, "expanduser", refuse_expansion)
+
+    with pytest.raises(argparse.ArgumentTypeError, match="unable to expand user path"):
+        validator("~nonexistent-user/data.csv")
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="'~user' always expands to a sibling path on Windows"
+)
+def test_cache_path_arguments_reject_unknown_user(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The real unknown-user case exits instead of printing a traceback."""
+    parser = create_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--exchange-rates-file", "~nonexistent-user/rates.csv"])
+
+    assert exc_info.value.code == 2
+    assert "unable to expand user path" in capsys.readouterr().err
+
+
+def test_cache_path_arguments_expand_user() -> None:
+    """A quoted '~' must expand, not become a directory literally named '~'."""
+    path = optional_cache_file_type("~/rates.csv")
+
+    assert path == Path.home() / "rates.csv"
+    assert "~" not in path.parts
 
 
 def test_optional_cache_file_type_rejects_unreadable_file(


### PR DESCRIPTION
Stacked on #1020. The remaining follow-ups from the review of #1013.

A named pipe passed to a cache option hung the CLI before parsing finished: `is_fifo()` satisfied the file check, then `_ensure_readable_file` opened it and blocked forever waiting for a writer. Past that it would not have worked anyway — all three caches are read back through `Path.is_file()`, which is false for a pipe, so the cache would be written and then silently never read. Caches now take regular files only; directories keep their existing message.

Input files may legitimately be pipes, and process substitution relies on it, but a readability probe cannot tell a pipe anything useful: opening one blocks until a writer attaches, and it takes bytes the real read needs. `_existing_path_type` now skips the probe for pipes.

`optional_cache_file_type` also built its `Path` without `expanduser`, so a quoted `~/rates.csv` became a directory literally named `~` via `open_with_parents`, leaving the intended cache untouched. The input validator has always expanded.

Also two neighbouring tests kept from the review of #1013: the directory case dropped a tail that re-parsed an empty argv and duplicated `test_cache_path_arguments_default`, and the leading-dash case now covers all three options like the rest of the group.

Checks: `uv run pytest` 933 passed, with and without `CGT_TEST_MODE_STRICT`, plus `pre-commit run --all-files`.