### PR TITLE
Decode stdin as UTF-8 regardless of the platform locale

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -96,6 +96,7 @@ matchable
 md
 MiKTeX
 MMM
+mojibake
 msg
 mypy
 NameChange

--- a/cgt_calc/logging.py
+++ b/cgt_calc/logging.py
@@ -183,12 +183,14 @@ def bullet(stream: TextIO) -> str:
 
 
 def force_utf8_stdio() -> None:
-    """Emit UTF-8 regardless of the platform's locale.
+    """Read and emit UTF-8 regardless of the platform's locale.
 
     Windows encodes piped output with the legacy code page by default,
-    which cannot hold every character the reports use.
+    which cannot hold every character the reports use, and decodes piped
+    input the same way, turning a UTF-8 broker export read from stdin
+    into mojibake.
     """
-    for stream in (sys.stdout, sys.stderr):
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
         if isinstance(stream, io.TextIOWrapper):
             stream.reconfigure(encoding="utf-8")
 

--- a/tests/general/test_logging.py
+++ b/tests/general/test_logging.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import io
 import logging
+import sys
 from typing import TYPE_CHECKING, TextIO, cast
 
 import colorama
 
-from cgt_calc.logging import ColourMessageFormatter, ConsoleUI
+from cgt_calc.logging import ColourMessageFormatter, ConsoleUI, force_utf8_stdio
 
 if TYPE_CHECKING:
     import pytest
@@ -125,3 +127,14 @@ def test_formatter_plain_info() -> None:
     formatter = ColourMessageFormatter("%(message)s", use_colour=False, use_emoji=False)
 
     assert formatter.format(_record(logging.INFO, "hello")) == "hello"
+
+
+def test_force_utf8_stdio_reconfigures_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Piped input decodes as UTF-8 whatever the platform locale reports."""
+    stream = io.TextIOWrapper(io.BytesIO("CAFÉ".encode()), encoding="cp1252")
+    monkeypatch.setattr(sys, "stdin", stream)
+
+    force_utf8_stdio()
+
+    assert sys.stdin.encoding == "utf-8"
+    assert sys.stdin.read() == "CAFÉ"

--- a/tests/raw/test_raw.py
+++ b/tests/raw/test_raw.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import csv
 from decimal import Decimal
+import io
 import logging
 from pathlib import Path
 import subprocess
+import sys
 
 import pytest
 
+from cgt_calc.args_validators import STDIN_PATH
 from cgt_calc.exceptions import ParsingError
+from cgt_calc.logging import force_utf8_stdio
 from cgt_calc.model import ActionType
 from cgt_calc.parsers.raw import COLUMNS, RawColumn, RawParser, _parse_decimal
 from tests.utils import build_cmd, report_path, stderr_alerts
@@ -114,6 +118,28 @@ def test_run_with_raw_files_stdin(request: pytest.FixtureRequest) -> None:
         "if you added new features update the test with:\n"
         f"cat {csv_file} | {cmd_str} > {expected_file}"
     )
+
+
+def test_stdin_decodes_utf8_under_a_legacy_locale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A UTF-8 export piped in keeps its characters on a legacy code page.
+
+    Windows decodes redirected stdin with the ANSI code page, so a symbol
+    outside ASCII would otherwise arrive as mojibake.
+    """
+    csv_bytes = (
+        "date,action,symbol,quantity,price,fees,currency\n"
+        "2023-02-09,DIVIDEND,CAFÉ,4200,0.80,0.0,USD\n"
+    ).encode()
+    monkeypatch.setattr(
+        sys, "stdin", io.TextIOWrapper(io.BytesIO(csv_bytes), encoding="cp1252")
+    )
+    force_utf8_stdio()
+
+    transactions = RawParser.load_from_file(STDIN_PATH, show_parsing_msg=False)
+
+    assert [txn.symbol for txn in transactions] == ["CAFÉ"]
 
 
 def test_run_with_nonexistent_file() -> None:


### PR DESCRIPTION
Follow-up from #1020/#1021: checking whether `-` behaves on Windows.

It does, mechanically — the sentinel, the parser wiring and the duplicate-stdin check are all platform-neutral. But `force_utf8_stdio` reconfigured only stdout and stderr. Windows decodes *redirected input* with the legacy code page too, and the stdin branch of `BaseSingleFileParser.load_from_file` hands `sys.stdin` straight to the reader, so it never sees the `utf-8` the parsers declare for the file branch:

```python
if file_path == STDIN_PATH:
    transactions = cls.read_transactions(sys.stdin, STDIN_PATH)   # whatever sys.stdin decodes as
else:
    with file_path.open(encoding=cls.encoding) as file:            # explicitly utf-8
```

So `type export.csv | cgt-calc --raw-file -` mojibaked any field outside ASCII, while `cgt-calc --raw-file export.csv` read the same bytes correctly. Adding `sys.stdin` to the loop closes the gap, and covers the interactive spin-off prompts too.

`test_run_with_raw_files_stdin` already exercises the stdin path end to end, but its fixture is pure ASCII, so nothing caught this. Both new tests pin a legacy code page explicitly rather than depending on the runner locale, so they are meaningful on Linux and macOS as well: one asserts the stream is reconfigured, the other reads a non-ASCII symbol through the raw parser and fails with `CAFÃ‰` against the unfixed loop.

Checks: `uv run pytest` 940 passed, with and without `CGT_TEST_MODE_STRICT`, plus `pre-commit run --all-files`.