### PR TITLE
Give each pull request a single type label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,27 +1,34 @@
 # Schema reference: https://github.com/actions/labeler#match-object
-# Options inside `all` are AND-ed, so each rule below reads as "touches these
-# files, and touches nothing from the excluded set".
+# Options inside `all` are AND-ed. The rules are mutually exclusive, so a pull
+# request gets at most one of them: each excludes the paths claimed by the rules
+# above it. Dependabot labels its own pull requests, so its branches are skipped
+# here. Anything touching Python source is left for a manual type label.
 
 dependencies:
   - all:
+      - head-branch: ["^(?!dependabot/)"]
       - changed-files:
+          # A dependency update only: nothing outside these files changed.
           - any-glob-to-any-file: "uv.lock"
-          - all-globs-to-all-files: "!**/*.py"
-
-documentation:
-  - all:
-      - changed-files:
-          - any-glob-to-any-file: "**/*.md"
-          - all-globs-to-all-files: ["!**/*.py", "!.github/**/*"]
+          - any-glob-to-all-files: ["uv.lock", "pyproject.toml"]
 
 github structure:
   - all:
+      - head-branch: ["^(?!dependabot/)"]
       - changed-files:
           - any-glob-to-any-file: ".github/**/*"
           - all-globs-to-all-files: "!**/*.py"
 
 testing:
   - all:
+      - head-branch: ["^(?!dependabot/)"]
       - changed-files:
           - any-glob-to-any-file: "tests/**"
-          - all-globs-to-all-files: "!cgt_calc/**"
+          - all-globs-to-all-files: ["!cgt_calc/**", "!.github/**/*"]
+
+documentation:
+  - all:
+      - head-branch: ["^(?!dependabot/)"]
+      - changed-files:
+          - any-glob-to-any-file: "**/*.md"
+          - all-globs-to-all-files: ["!**/*.py", "!.github/**/*", "!tests/**"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,7 +10,10 @@ dependencies:
       - changed-files:
           # A dependency update only: nothing outside these files changed.
           - any-glob-to-any-file: "uv.lock"
-          - any-glob-to-all-files: ["uv.lock", "pyproject.toml"]
+          # One combined pattern: any-glob-to-all-files asks whether a
+          # single glob matches every changed file, so a list of two would
+          # never match the usual pair.
+          - any-glob-to-all-files: "{uv.lock,pyproject.toml}"
 
 github structure:
   - all:


### PR DESCRIPTION
The `dependencies` rule read "touched `uv.lock` and no Python", not "only
touched dependencies", so it also fired on changes that happen to add a
dependency. #1024 got it alongside `github structure`, and the labeler kept
re-adding it after it was removed, because the rule still matched on every sync.

It now requires that nothing outside `uv.lock` and `pyproject.toml` changed,
expressed as a single brace pattern: `any-glob-to-all-files` asks whether one
glob matches every changed file, not whether every changed file matches some
glob, so a two element list would never match the usual pair.

The rules are also mutually exclusive: each excludes the paths claimed by the
rules above it, so at most one of them matches on any given evaluation.

Dependabot branches are skipped. Dependabot already labels its own pull requests
from `dependabot.yml`, and the file rules would otherwise add a second label to
its GitHub Actions updates, which touch `.github/workflows`.

Simulated against the real file lists of merged pull requests, using the v7
matching functions. Three cases produced two labels before and one now; nothing
that had a label loses one:

| Pull request | Before | After |
| --- | --- | --- |
| #1024 | `dependencies`, `github structure` | `github structure` |
| #973 (Dependabot, Actions) | `github structure` | none, keeps its own `dependencies` |
| #1014 (Dependabot, uv) | `dependencies` | none, keeps its own `dependencies` |
| #998 | `github structure` | `github structure` |
| `uv.lock` + `pyproject.toml` | `dependencies` | `dependencies` |
| docs only | `documentation` | `documentation` |
| tests only | `testing` | `testing` |
| test data + docs | `documentation`, `testing` | `testing` |
| `.github` + test data | `github structure`, `testing` | `github structure` |

Two limits worth recording. `sync-labels` stays off, so labels are only added:
a pull request that starts as documentation only and later gains tests keeps
both until one is removed by hand. Turning it on would give the stricter
guarantee, but it removes any configured label that no longer matches, including
ones applied by hand, as `github structure` was on #1017. And `actions/labeler`
cannot see labels applied by hand at all, so a pull request marked `code quality`
that touches only Markdown still gets `documentation` added.