### PR TITLE
Reject Vanguard exports whose shape would drop transactions

### DIFF
--- a/.harper-ignore.txt
+++ b/.harper-ignore.txt
@@ -20,3 +20,5 @@
 ^main\.py:.*MissingPreposition
 # "CR CR LF" spells out the doubled carriage return; the repeat is the point.
 ^util\.py:.*RepeatedWords
+# "a header that does not match" is a relative clause, not a comparison.
+^vanguard\.md:.*ThatThan

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -55,6 +55,16 @@ class TableType(StrEnum):
     INVESTMENT = "investment"
 
 
+_SECTION_TYPES: Final[dict[str, TableType]] = {
+    "Cash Transactions": TableType.CASH,
+    "Investment Transactions": TableType.INVESTMENT,
+}
+# Errors name a table the way the export does, so both come from one mapping.
+_SECTION_NAMES: Final[dict[TableType, str]] = {
+    table_type: name for name, table_type in _SECTION_TYPES.items()
+}
+
+
 # Backward-compatible alias used by tests
 COLUMNS: Final[list[str]] = [c.value for c in CashColumn]
 
@@ -70,6 +80,10 @@ NAMECHANGE_RE = re.compile(
     r"(?:\s+replaced with\s+([A-Z0-9]+)(?:\.\S+)?)?\s*$"
 )
 INVESTMENT_NAME_RE = re.compile(r"^(.+?)(?:\s*\(([^()]+)\))?$")
+# A cell opening with a date is the Date column of a row whose separators were
+# lost, not decoration, however few cells the row was split into.
+_DATE_PREFIX_RE = re.compile(r"^\d{1,2}/\d{1,2}/\d{4}\b")
+_PAGE_LABEL_RE = re.compile(r"^page\s+\d+(?:\s*(?:of|/)\s*\d+)?$", re.IGNORECASE)
 
 INTEREST_STR = "Cash Account Interest"
 REVERSAL_STR = "Reversal of "
@@ -78,6 +92,9 @@ LOGGER = logging.getLogger(__name__)
 
 def action_from_str(label: str, file: Path) -> ActionType:
     """Convert label to ActionType."""
+
+    if not label:
+        raise ParsingError(file, "Missing action text in Details or TransactionDetails")
 
     if TRANSFER_RE.match(label):
         return ActionType.TRANSFER
@@ -320,51 +337,279 @@ def by_date_and_action(
 
 def _detect_delimiter(text: str) -> str:
     """Detect whether the file uses comma or tab as delimiter."""
+    for delimiter in (",", "\t"):
+        rows = csv.reader(io.StringIO(text), delimiter=delimiter)
+        for row in rows:
+            stripped = {cell.strip() for cell in row}
+            if stripped >= CASH_COLUMNS or stripped >= INVESTMENT_COLUMNS:
+                return delimiter
+
+    # Header validation still produces the useful column error when the file
+    # does not contain an exported header.
     first_line = text.split("\n", 1)[0]
     if "\t" in first_line:
         return "\t"
     return ","
 
 
-def _split_tables(
-    lines: list[list[str]],
-) -> tuple[list[list[str]] | None, list[list[str]] | None]:
-    """Split parsed CSV lines into cash and investment table sections by header detection."""
-    cash_table: list[list[str]] | None = None
-    investment_table: list[list[str]] | None = None
+def _trim_trailing_empty_cells(row: list[str], minimum_length: int = 0) -> list[str]:
+    """Remove cosmetic empty columns without dropping required blank fields."""
+    end = len(row)
+    while end > minimum_length and not row[end - 1].strip():
+        end -= 1
+    return row[:end]
 
-    current: list[list[str]] = []
-    current_type: TableType | None = None
 
-    def _flush() -> None:
-        nonlocal cash_table, investment_table
-        if current_type == TableType.CASH:
-            cash_table = list(current)
-        elif current_type == TableType.INVESTMENT:
-            investment_table = list(current)
+def _is_table_boundary(row: list[str]) -> bool:
+    """Report whether the row starts a table, as a header or a section title."""
+    stripped = {cell.strip() for cell in row}
+    first = row[0].strip() if row else ""
+    return (
+        stripped >= CASH_COLUMNS
+        or stripped >= INVESTMENT_COLUMNS
+        or first in _SECTION_TYPES
+    )
 
-    for row in lines:
-        stripped = {c.strip() for c in row}
+
+def _decoration_text(row: list[str]) -> str | None:
+    """Return the lone text of a row that carries no transaction fields.
+
+    A row whose separators were lost also collapses to one cell, so a cell
+    opening with a date is reported as data rather than as decoration.
+    """
+    populated = [cell.strip() for cell in row if cell.strip()]
+    if len(populated) != 1 or _DATE_PREFIX_RE.match(populated[0]):
+        return None
+    return populated[0]
+
+
+def _is_collapsed_transaction(row: list[str]) -> bool:
+    """Report whether a lone cell holds a row that lost its field separators.
+
+    Used above the first header, where the columns are still unknown. A report
+    date and a covered period are dated single cells too, so a delimiter after
+    the date is required as evidence: a delimiter survives inside one cell only
+    when the row was quoted whole or written with the wrong separator. Within a
+    table the shape alone is enough, which is what `_decoration_text` reports.
+    """
+    populated = [cell.strip() for cell in row if cell.strip()]
+    if len(populated) != 1:
+        return False
+    match = _DATE_PREFIX_RE.match(populated[0])
+    if match is None:
+        return False
+    remainder = populated[0][match.end() :]
+    return any(delimiter in remainder for delimiter in (",", ";", "\t"))
+
+
+def _trailing_decoration(lines: list[tuple[int, list[str]]]) -> set[int]:
+    """Find the positions of decorative rows that no table data follows.
+
+    Legacy footers sit below the last transaction of their table. A decorative
+    row anywhere above one is only ignored when it is a recognised pagination
+    label, so that a mangled transaction cannot pass as a footer.
+    """
+    trailing: set[int] = set()
+    below_last_row = True
+    for position in reversed(range(len(lines))):
+        row = lines[position][1]
+        if not any(cell.strip() for cell in row):
+            continue
+        if _is_table_boundary(row):
+            below_last_row = True
+        elif _decoration_text(row) is not None:
+            if below_last_row:
+                trailing.add(position)
+        else:
+            below_last_row = False
+    return trailing
+
+
+def _looks_like_transaction(row: list[str]) -> bool:
+    """Report whether the row opens with a parsable date and an activity."""
+    cells = iter(row)
+    date_text = next(cells, "")
+    details = next(cells, "")
+    if not details.strip():
+        return False
+    try:
+        datetime.datetime.strptime(date_text.strip(), "%d/%m/%Y")
+    except ValueError:
+        return False
+    return True
+
+
+class _TableSplitter:
+    """Split an export into its tables, refusing shapes that would lose rows.
+
+    A Vanguard worksheet pages its tables, so section titles, headers, running
+    summaries and footers repeat throughout the file. Each is only accepted
+    where it cannot hide a transaction that the reader would otherwise drop.
+    """
+
+    def __init__(self, lines: list[tuple[int, list[str]]], file_path: Path):
+        """Prepare to read the rows of one exported file."""
+        self.lines = lines
+        self.file_path = file_path
+        self.trailing = _trailing_decoration(lines)
+        self.tables: dict[TableType, list[tuple[int, list[str]]]] = {}
+        self.current: list[tuple[int, list[str]]] = []
+        self.current_type: TableType | None = None
+        # A section title whose header has not been recognised yet.
+        self.closed_type: TableType | None = None
+        self.after_summary = False
+        self.seen_types: set[TableType] = set()
+        self.seen_sections: set[TableType] = set()
+        self.orphan_row_index: int | None = None
+
+    def split(
+        self,
+    ) -> tuple[
+        list[tuple[int, list[str]]] | None,
+        list[tuple[int, list[str]]] | None,
+    ]:
+        """Return the cash and investment tables, or None where absent."""
+        for position, (row_index, row) in enumerate(self.lines):
+            self._read_row(row, position, row_index)
+        self._flush()
+        if self.orphan_row_index is not None and self.tables:
+            raise ParsingError(
+                self.file_path,
+                "Found a transaction row above the first table header",
+                row_index=self.orphan_row_index,
+            )
+        return self.tables.get(TableType.CASH), self.tables.get(TableType.INVESTMENT)
+
+    def _read_row(self, row: list[str], position: int, row_index: int) -> None:
+        stripped = {cell.strip() for cell in row}
+        first = row[0].strip() if row else ""
+        section_type = _SECTION_TYPES.get(first)
         if stripped >= CASH_COLUMNS:
-            _flush()
-            current = [row]
-            current_type = TableType.CASH
+            self._start_table(TableType.CASH, row, row_index)
         elif stripped >= INVESTMENT_COLUMNS:
-            _flush()
-            current = [row]
-            current_type = TableType.INVESTMENT
-        elif current_type and row and any(c.strip() for c in row):
-            first = row[0].strip()
-            if first in _SUMMARY_LABELS:
-                # Summary/footer row (e.g. "Balance,23.59") — end current table.
-                _flush()
-                current = []
-                current_type = None
-            else:
-                current.append(row)
+            self._start_table(TableType.INVESTMENT, row, row_index)
+        elif section_type is not None:
+            self._start_section(section_type, row_index)
+        elif not any(cell.strip() for cell in row):
+            return
+        elif self.current_type is not None:
+            self._add_row(row, position, row_index, first)
+        elif self.closed_type is not None:
+            self._reject_row_under_title(row, position, row_index)
+        elif self.orphan_row_index is None and (
+            _looks_like_transaction(row) or _is_collapsed_transaction(row)
+        ):
+            # Remember rather than raise: when no table is found at all, the
+            # header validator has the more useful message about the columns.
+            self.orphan_row_index = row_index
 
-    _flush()
-    return cash_table, investment_table
+    def _flush(self) -> None:
+        if self.current_type is not None:
+            self.tables[self.current_type] = list(self.current)
+
+    def _start_table(
+        self, table_type: TableType, row: list[str], row_index: int
+    ) -> None:
+        # Header cells become the row keys, so pad them out here rather than
+        # letting a cosmetically spaced heading miss its column.
+        header = [cell.strip() for cell in _trim_trailing_empty_cells(row)]
+        if self.closed_type is not None and self.closed_type is not table_type:
+            raise ParsingError(
+                self.file_path,
+                f"Found the {_SECTION_NAMES[table_type]} table header under the "
+                f"{_SECTION_NAMES[self.closed_type]} section title",
+                row_index=row_index,
+            )
+        if table_type in self.seen_types:
+            if (
+                self.current_type is table_type
+                and self.current
+                and header == self.current[0][1]
+            ):
+                # Paginated exports can repeat the unchanged table header.
+                self.after_summary = False
+                return
+            raise ParsingError(
+                self.file_path,
+                f"Multiple {_SECTION_NAMES[table_type]} table headers found",
+                row_index=row_index,
+            )
+        self._flush()
+        self.seen_types.add(table_type)
+        self.current = [(row_index, header)]
+        self.current_type = table_type
+        self.closed_type = None
+        self.after_summary = False
+
+    def _start_section(self, section_type: TableType, row_index: int) -> None:
+        self.after_summary = False
+        if self.current_type is section_type:
+            # A page can repeat its section title before repeating the
+            # unchanged header. Keep appending to the active table.
+            return
+        if section_type in self.seen_sections or section_type in self.seen_types:
+            raise ParsingError(
+                self.file_path,
+                f"Multiple {_SECTION_NAMES[section_type]} section titles found",
+                row_index=row_index,
+            )
+        self.seen_sections.add(section_type)
+        self._flush()
+        self.current = []
+        self.current_type = None
+        self.closed_type = section_type
+
+    def _add_row(
+        self, row: list[str], position: int, row_index: int, first: str
+    ) -> None:
+        assert self.current_type is not None
+        if first in _SUMMARY_LABELS:
+            # A running summary can end a page. Require a repeated title or
+            # header before accepting more transactions from the same table.
+            self.after_summary = True
+        elif self._is_decoration(row, position):
+            return
+        elif self.after_summary and _looks_like_transaction(row):
+            raise ParsingError(
+                self.file_path,
+                "Found a transaction row after the "
+                f"{_SECTION_NAMES[self.current_type]} summary",
+                row_index=row_index,
+            )
+        else:
+            width = len(self.current[0][1])
+            self.current.append((row_index, _trim_trailing_empty_cells(row, width)))
+
+    def _reject_row_under_title(
+        self, row: list[str], position: int, row_index: int
+    ) -> None:
+        # The section title was announced but its header was not recognised, so
+        # the columns of everything below it are unknown.
+        assert self.closed_type is not None
+        if self._is_decoration(row, position):
+            return
+        raise ParsingError(
+            self.file_path,
+            f"Found a row outside the {_SECTION_NAMES[self.closed_type]} table",
+            row_index=row_index,
+        )
+
+    def _is_decoration(self, row: list[str], position: int) -> bool:
+        text = _decoration_text(row)
+        return text is not None and (
+            position in self.trailing or bool(_PAGE_LABEL_RE.fullmatch(text))
+        )
+
+
+def _split_tables(
+    lines: list[tuple[int, list[str]]],
+    file_path: Path,
+) -> tuple[
+    list[tuple[int, list[str]]] | None,
+    list[tuple[int, list[str]]] | None,
+]:
+    """Split tables while rejecting structures that could discard transactions."""
+    return _TableSplitter(lines, file_path).split()
 
 
 def _find_investment_match(
@@ -403,6 +648,34 @@ class VanguardParser(BaseSingleFileParser):
     deprecated_flags: ClassVar[list[str]] = ["--vanguard"]
 
     @classmethod
+    @override
+    def load_from_file(
+        cls,
+        file_path: Path,
+        *,
+        warn_on_empty: bool = True,
+        show_parsing_msg: bool = True,
+    ) -> list[BrokerTransaction]:
+        """Load a text CSV and report Excel or encoding mistakes clearly."""
+        if file_path.suffix.casefold() in {".xls", ".xlsx", ".xlsm", ".xlsb"}:
+            raise ParsingError(
+                file_path,
+                "Vanguard Excel workbooks are not supported; save the General "
+                "Account worksheet as a CSV file.",
+            )
+        try:
+            return super().load_from_file(
+                file_path,
+                warn_on_empty=warn_on_empty,
+                show_parsing_msg=show_parsing_msg,
+            )
+        except UnicodeDecodeError as err:
+            raise ParsingError(
+                file_path,
+                "Vanguard input must be a UTF-8 CSV text file.",
+            ) from err
+
+    @classmethod
     def _validate_cash_header(cls, header: list[str], file: Path) -> None:
         """Check if header matches the cash transactions columns."""
         expected = [c.value for c in CashColumn]
@@ -422,68 +695,86 @@ class VanguardParser(BaseSingleFileParser):
         cls, file: TextIO, file_path: Path
     ) -> list[BrokerTransaction]:
         """Read Vanguard transactions from exported transaction report file."""
-        raw_text = file.read()
+        raw_text = file.read().removeprefix("\ufeff")
         delimiter = _detect_delimiter(raw_text)
-        lines = list(csv.reader(io.StringIO(raw_text), delimiter=delimiter))
+        csv_reader = csv.reader(io.StringIO(raw_text), delimiter=delimiter)
+        lines = [(csv_reader.line_num, row) for row in csv_reader]
 
         if not lines:
             raise ParsingError(file_path, "Vanguard CSV file is empty")
 
-        cash_lines, investment_lines = _split_tables(lines)
+        cash_lines, investment_lines = _split_tables(lines, file_path)
 
-        if cash_lines is None and investment_lines is None:
-            # Fallback: treat entire file as a plain cash table (old format)
-            cls._validate_cash_header(lines[0], file_path)
-            cash_lines = lines
+        if cash_lines is None:
+            if investment_lines is None:
+                cls._validate_cash_header(
+                    _trim_trailing_empty_cells(lines[0][1]), file_path
+                )
+            raise ParsingError(
+                file_path,
+                "Vanguard input must include the Cash Transactions table; "
+                "an Investment Transactions table cannot be calculated alone.",
+            )
 
-        # RENAMEs emit immediately; other rows go to lookup (cash mode) or directly (investment-only).
+        # RENAMEs emit immediately; other investment rows populate the cash lookup.
         investment_lookup: dict[str, list[dict[str, str]]] = {}
         transactions: list[VanguardTransaction] = []
         if investment_lines is not None:
-            investment_header = investment_lines[0]
-            for index, row in enumerate(investment_lines[1:], start=2):
+            _, investment_header = investment_lines[0]
+            investment_rows: list[tuple[int, dict[str, str]]] = []
+            for row_index, row in investment_lines[1:]:
                 if len(row) != len(investment_header):
-                    continue
-                investment_row = dict(zip(investment_header, row, strict=False))
+                    raise UnexpectedColumnCountError(
+                        row,
+                        len(investment_header),
+                        file_path,
+                        row_index=row_index,
+                    )
+                investment_rows.append(
+                    (row_index, dict(zip(investment_header, row, strict=False)))
+                )
+
+            for row_index, investment_row in investment_rows:
                 try:
                     txn = _make_transaction_from_investment(investment_row, file_path)
                 except ParsingError as err:
-                    err.add_row_context(index)
+                    err.add_row_context(row_index)
                     raise
                 except ValueError as err:
-                    raise ParsingError(file_path, str(err), row_index=index) from err
+                    raise ParsingError(
+                        file_path, str(err), row_index=row_index
+                    ) from err
                 if txn is None:
                     continue  # zero-out half of a NameChange pair
                 if txn.action is ActionType.RENAME:
                     transactions.append(txn)
                     continue
-                if cash_lines is not None:
-                    key = investment_row[InvestmentColumn.TRANSACTION_DETAILS]
-                    if key:
-                        investment_lookup.setdefault(key, []).append(investment_row)
-                else:
-                    transactions.append(txn)
+                key = investment_row[InvestmentColumn.TRANSACTION_DETAILS]
+                if key:
+                    investment_lookup.setdefault(key, []).append(investment_row)
 
-        if cash_lines is not None:
-            cash_header = cash_lines[0]
-            for index, row in enumerate(cash_lines[1:], start=2):
-                if len(row) != len(cash_header):
-                    continue
-                try:
-                    transactions.append(
-                        VanguardTransaction(cash_header, row, file_path)
-                    )
-                except ParsingError as err:
-                    err.add_row_context(index)
-                    raise
-                except ValueError as err:
-                    raise ParsingError(file_path, str(err), row_index=index) from err
+        _, cash_header = cash_lines[0]
+        for row_index, row in cash_lines[1:]:
+            if len(row) != len(cash_header):
+                raise UnexpectedColumnCountError(
+                    row,
+                    len(cash_header),
+                    file_path,
+                    row_index=row_index,
+                )
+            try:
+                transactions.append(VanguardTransaction(cash_header, row, file_path))
+            except ParsingError as err:
+                err.add_row_context(row_index)
+                raise
+            except ValueError as err:
+                raise ParsingError(file_path, str(err), row_index=row_index) from err
 
-            # Resolve missing quantity/price with values from the investment table, see
-            # https://github.com/cgt-calc/capital-gains-calculator/issues/758
-            for txn in transactions:
-                matched_inv = _find_investment_match(txn, investment_lookup)
-                txn.enrich_details(matched_inv)
+        # Resolve missing quantity/price with values from the investment table, see
+        # https://github.com/cgt-calc/capital-gains-calculator/issues/758
+        for txn in transactions:
+            matched_inv = _find_investment_match(txn, investment_lookup)
+            txn.enrich_details(matched_inv)
 
         transactions.sort(key=by_date_and_action)
         return cast("list[BrokerTransaction]", transactions)

--- a/docs/brokers/vanguard.md
+++ b/docs/brokers/vanguard.md
@@ -30,7 +30,8 @@ calculation.
 
 You can compare the expected worksheet structure with the
 [sanitised example](https://github.com/cgt-calc/capital-gains-calculator/blob/main/tests/vanguard/data/cash_investment_report.csv).
-The filename does not matter. Use commas: tab-separated full worksheets are not reliably detected.
+The filename does not matter. Both comma- and tab-separated files are accepted, including the byte
+order mark written by the **CSV UTF-8** format in Excel.
 
 ### Why both tables matter
 
@@ -164,28 +165,30 @@ taxed as interest rather than dividends; see
 - The final text in parentheses is always treated as the ticker. For example, an investment ending
   in `(Accumulation)` is assigned the symbol `Accumulation`, which can silently combine different
   funds in one holding.
-- Rows whose number of fields differs from their table header are silently skipped. A malformed or
-  ragged CSV can therefore omit transactions without an error.
-- A legacy cash-only table can be calculated, but an investment-only table cannot. Although its rows
-  parse, the unsigned `Cost` of a purchase fails the calculator's amount check. Use the complete
-  worksheet with its Cash Transactions table.
+- A row cgt-calc cannot place stops the import instead of being skipped, and the error names the
+  file line. That covers a row with the wrong number of fields, a header that does not match the
+  section title above it, a conflicting header or section title, a transaction row above the first
+  header or after a `Balance` or `Cost` summary, and stray text inside a table.
+- Cosmetic rows are still ignored: trailing empty columns, a repeated page title or header, a
+  `Page 1 of 2` label in any column, and a text footer below the last row of its table.
+- A legacy cash-only table can be calculated, but an investment-only table is rejected because its
+  unsigned `Cost` values do not provide usable cash movements. Use the complete worksheet with its
+  Cash Transactions table.
 
 ## Troubleshooting
 
-### `Vanguard CSV file is empty`, a header error or `UnicodeDecodeError`
+### `Vanguard CSV file is empty` or a file-format error
 
 Pass the CSV saved from the General Account worksheet, not the `.xlsx` workbook, a PDF statement or
-the Consolidated Tax Certificate. An `.xlsx` file is binary and can produce a raw
-`UnicodeDecodeError` rather than a friendly file-type message. Keep the headings unchanged. A usable
-export must contain the `Date,Details,Amount,Balance` Cash Transactions header; retain the
+the Consolidated Tax Certificate. Excel workbooks are rejected before parsing; save the General
+Account worksheet as CSV. Keep the headings unchanged. A usable export must contain the
+`Date,Details,Amount,Balance` Cash Transactions header; retain the
 `Date,InvestmentName,TransactionDetails,Quantity,Price,Cost` Investment Transactions table as well.
 
-The current parser requires a comma-separated UTF-8 file. A tab-separated full worksheet can fail
-because cgt-calc chooses the delimiter from the first line only. A byte order mark is harmless in a
-full worksheet, where it lands on the title cell, but breaks a legacy cash-only export whose first
-line is the header: if an error says that column 1 should be `Date` but found what appears to be the
-same `Date`, save that file again as UTF-8 without a BOM. Do not manually concatenate rows from
-different account worksheets.
+The parser accepts UTF-8 with or without a byte order mark and detects comma- or tab-separated table
+headers throughout a full worksheet. A semicolon-delimited or another non-UTF-8 file is rejected. Do
+not manually concatenate rows from different account worksheets. Cosmetic trailing empty columns do
+not need to be preserved.
 
 ### `Unknown action`
 
@@ -201,8 +204,8 @@ install it. If it still fails, open a
 version, the complete error and a sanitised copy of the row.
 
 Do not assume that every unsupported row raises this error. A row beginning `Reversal of` can be
-misclassified, and a row with the wrong number of fields is skipped; check the source workbook as
-described below.
+misclassified, and a row with the wrong number of fields stops the import with a different message
+naming its physical file line; check the source workbook as described below.
 
 ### Automatic sales to pay fees
 
@@ -217,9 +220,12 @@ Make sure the disposal appears exactly once and retain the original workbook as 
 
 ### Transactions are missing without an error
 
-Compare the activity and row counts in both CSV tables with the original workbook. cgt-calc silently
-skips a row whose number of fields differs from its table header, including a short or overlong row
-created by an incomplete spreadsheet conversion.
+Compare the activity and row counts in both CSV tables with the original workbook. A row whose field
+count differs from its table header, a header that does not match the section title above it, a
+conflicting header or section title, and a transaction-shaped row above the first header or after a
+summary now stop the import naming the physical file line, rather than being skipped. Stray text
+inside a table stops the import for the same reason: a transaction that lost its separators arrives
+as a single cell and must not pass as a footer.
 
 Also inspect every `Reversal of` row. Only dividend reversals have been validated; a reversed buy or
 sell can be imported with the wrong action, quantity or amount instead of being rejected. Keep the

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -9,7 +9,7 @@ import subprocess
 import pytest
 
 from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
-from cgt_calc.exceptions import ParsingError
+from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
 from cgt_calc.model import ActionType
 from cgt_calc.parsers.vanguard import COLUMNS, VanguardParser
 from tests.utils import build_cmd, report_path, stderr_alerts
@@ -375,54 +375,6 @@ def test_dual_table_blank_transaction_details_does_not_crash(tmp_path: Path) -> 
     assert buys[0].quantity == Decimal(10)
 
 
-def test_investment_only_blank_transaction_details_uses_quantity_sign(
-    tmp_path: Path,
-) -> None:
-    """With no TransactionDetails, action comes from Quantity's sign and symbol from InvestmentName."""
-    content = (
-        "Investment Transactions\n"
-        "\n"
-        "Date,InvestmentName,TransactionDetails,Quantity,Price,Cost\n"
-        "10/03/2022,Foo ETF (FOO),,10,9.5,95\n"
-        "15/03/2022,Foo ETF (FOO),,-5,10.0,50\n"
-    )
-    vanguard_file = tmp_path / "inv_only_blank.csv"
-    vanguard_file.write_text(content, encoding="utf-8")
-
-    transactions = VanguardParser().load_from_file(vanguard_file)
-
-    assert len(transactions) == 2
-    assert transactions[0].action == ActionType.BUY
-    assert transactions[0].symbol == "FOO"
-    assert transactions[0].quantity == Decimal(10)
-    assert transactions[0].price == Decimal("9.5")
-
-    assert transactions[1].action == ActionType.SELL
-    assert transactions[1].symbol == "FOO"
-    assert transactions[1].quantity == Decimal(5)
-
-
-def test_investment_only_table(tmp_path: Path) -> None:
-    """File with only an Investment Transactions table is parsed correctly."""
-    content = (
-        "Investment Transactions\n"
-        "\n"
-        "Date,InvestmentName,TransactionDetails,Quantity,Price,Cost\n"
-        "10/03/2022,Foo ETF (FOO),Bought 10 Foo ETF (FOO),10,9.5,95\n"
-        "15/03/2022,Foo ETF (FOO),Sold 5 Foo ETF (FOO),5,10.0,50\n"
-    )
-    vanguard_file = tmp_path / "inv_only.csv"
-    vanguard_file.write_text(content, encoding="utf-8")
-
-    transactions = VanguardParser().load_from_file(vanguard_file)
-
-    assert len(transactions) == 2
-    assert transactions[0].action == ActionType.BUY
-    assert transactions[0].quantity == Decimal(10)
-    assert transactions[0].price == Decimal("9.5")
-    assert transactions[1].action == ActionType.SELL
-
-
 def test_namechange_emits_rename_transaction(tmp_path: Path) -> None:
     """NameChange in dual-table CSV emits one RENAME; pre-rename BUY stays under OLD."""
     content = (
@@ -453,26 +405,498 @@ def test_namechange_emits_rename_transaction(tmp_path: Path) -> None:
     assert buys[0].symbol == "VDXX"
 
 
-def test_namechange_in_investment_only_table(tmp_path: Path) -> None:
-    """NameChange in investment-only CSV emits one RENAME, not a BUY/SELL."""
+@pytest.mark.parametrize(
+    "transaction_details",
+    ["", "Bought 10 Foo ETF (FOO)"],
+)
+def test_investment_only_table_is_rejected(
+    tmp_path: Path, transaction_details: str
+) -> None:
+    """Reject an investment-only table because it has no signed cash amounts."""
     content = (
         "Investment Transactions\n"
         "\n"
         "Date,InvestmentName,TransactionDetails,Quantity,Price,Cost\n"
-        "01/03/2022,Old Fund (VDXX),Bought 10 Old Fund (VDXX),10,10,100\n"
-        "15/03/2022,Old Fund (VDXX),NameChange: VDXX,0,0,0\n"
-        "15/03/2022,New Fund (VGER),NameChange: VDXX replaced with VGER,0,0,0\n"
+        f"10/03/2022,Foo ETF (FOO),{transaction_details},10,9.5,95\n"
     )
-    vanguard_file = tmp_path / "namechange_inv.csv"
+    vanguard_file = tmp_path / "inv_only.csv"
     vanguard_file.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ParsingError, match="must include the Cash Transactions table"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_conflicting_repeated_header_is_rejected(tmp_path: Path) -> None:
+    """Reject a repeated header whose column order differs from the active table."""
+    vanguard_file = tmp_path / "conflicting_repeated_header.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "Date,Amount,Details,Balance\n"
+        "02/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ParsingError, match="Multiple Cash Transactions table headers"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_date_shaped_row_is_not_treated_as_footer(
+    tmp_path: Path,
+) -> None:
+    """Report a malformed dated row instead of closing the table before it."""
+    vanguard_file = tmp_path / "padded_date.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "02/01/2022,,50,150\n"
+        "03/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ParsingError, match=r"row 3: Missing action text"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_error_uses_physical_line_after_quoted_newline(
+    tmp_path: Path,
+) -> None:
+    """Count embedded CSV newlines when reporting the later malformed row."""
+    vanguard_file = tmp_path / "quoted_newline.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        '01/01/2022,Regular Deposit,100,"100\n'
+        'continued"\n'
+        "02/01/2022,Regular Deposit,50\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(UnexpectedColumnCountError, match=r"row 4:"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+@pytest.mark.parametrize("suffix", [".xls", ".xlsx", ".xlsm", ".xlsb"])
+def test_read_vanguard_excel_workbook_has_clear_error(
+    tmp_path: Path, suffix: str
+) -> None:
+    """Reject an Excel workbook before attempting to decode it as CSV text."""
+    vanguard_file = tmp_path / f"vanguard{suffix}"
+    vanguard_file.write_bytes(b"PK\x03\x04\xff")
+
+    with pytest.raises(ParsingError, match="Excel workbooks are not supported"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_ignores_cosmetic_trailing_empty_cells(tmp_path: Path) -> None:
+    """Accept rows with or without the export header's empty padding columns."""
+    vanguard_file = tmp_path / "trailing_empty_cells.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance,,\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "02/01/2022,Regular Deposit,50,150,,\n",
+        encoding="utf-8",
+    )
 
     transactions = VanguardParser().load_from_file(vanguard_file)
 
-    renames = [t for t in transactions if t.action is ActionType.RENAME]
-    assert len(renames) == 1
-    assert renames[0].symbol == "VGER"
-    assert renames[0].description == f"{RENAME_DESCRIPTION_PREFIX}VDXX"
+    assert [transaction.amount for transaction in transactions] == [
+        Decimal(100),
+        Decimal(50),
+    ]
 
-    buys = [t for t in transactions if t.action is ActionType.BUY]
-    assert len(buys) == 1
-    assert buys[0].symbol == "VDXX"
+
+def test_read_vanguard_invalid_utf8_has_clear_error(tmp_path: Path) -> None:
+    """Wrap decoding failures in the normal parsing error type."""
+    vanguard_file = tmp_path / "vanguard.csv"
+    vanguard_file.write_bytes(b"Date,Details,Amount,Balance\n\xff")
+
+    with pytest.raises(ParsingError, match="must be a UTF-8 CSV text file"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_legacy_footer_is_ignored(tmp_path: Path) -> None:
+    """Ignore a single-cell footer after a legacy cash-only table."""
+    vanguard_file = tmp_path / "legacy_footer.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "This report is not advice\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert len(transactions) == 1
+    assert transactions[0].amount == Decimal(100)
+
+
+def test_read_vanguard_page_footer_between_transactions_is_ignored(
+    tmp_path: Path,
+) -> None:
+    """Do not let a pagination label truncate an active table."""
+    vanguard_file = tmp_path / "page_footer.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "Page 1 of 2\n"
+        "02/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert [transaction.amount for transaction in transactions] == [
+        Decimal(100),
+        Decimal(50),
+    ]
+
+
+def test_read_vanguard_collapsed_cash_row_is_rejected(tmp_path: Path) -> None:
+    """Reject a transaction whose lost separators leave it in a single cell."""
+    vanguard_file = tmp_path / "collapsed_cash.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        '"02/01/2022,Regular Deposit,50,150"\n'
+        "03/01/2022,Regular Deposit,25,175\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(UnexpectedColumnCountError, match="row 3"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_collapsed_final_cash_row_is_rejected(tmp_path: Path) -> None:
+    """Do not accept a collapsed last row as the trailing footer it resembles."""
+    vanguard_file = tmp_path / "collapsed_last.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        '"02/01/2022,Regular Deposit,50,150"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(UnexpectedColumnCountError, match="row 3"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_unlabelled_mid_table_text_is_rejected(tmp_path: Path) -> None:
+    """Only pagination labels may interrupt a table; other text is not skipped."""
+    vanguard_file = tmp_path / "mid_table_text.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "Continued overleaf\n"
+        "02/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(UnexpectedColumnCountError, match="row 3"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_page_label_outside_first_column_is_ignored(
+    tmp_path: Path,
+) -> None:
+    """Recognise a pagination label wherever the export centres it."""
+    vanguard_file = tmp_path / "centred_label.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        ",,Page 1 of 2,\n"
+        "02/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert [transaction.amount for transaction in transactions] == [
+        Decimal(100),
+        Decimal(50),
+    ]
+
+
+def test_read_vanguard_header_under_wrong_section_title_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Do not read a cash table announced as the Investment Transactions one."""
+    vanguard_file = tmp_path / "mismatched_section.csv"
+    vanguard_file.write_text(
+        "Investment Transactions\n"
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ParsingError,
+        match="Cash Transactions table header under the Investment Transactions",
+    ):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_unrecognised_header_under_title_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Reject an announced table whose header lost a column."""
+    vanguard_file = tmp_path / "lost_column.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "Investment Transactions\n"
+        "InvestmentName,TransactionDetails,Quantity,Price,Cost\n"
+        "Foo Fund (FOO),Sold 1 Foo Fund (FOO),1,10,10\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ParsingError, match="row 4: Found a row outside the Investment Transactions"
+    ):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_transaction_above_first_header_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Reject an export that lost the header above its opening transactions."""
+    vanguard_file = tmp_path / "lost_first_header.csv"
+    vanguard_file.write_text(
+        "01/01/2022,Regular Deposit,100,100\n"
+        "Date,Details,Amount,Balance\n"
+        "02/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ParsingError,
+        match="row 1: Found a transaction row above the first table header",
+    ):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_collapsed_row_above_first_header_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Reject a collapsed transaction above the header, which has no fields."""
+    vanguard_file = tmp_path / "collapsed_above_header.csv"
+    vanguard_file.write_text(
+        '"01/01/2022,Regular Deposit,100,100"\n'
+        "Date,Details,Amount,Balance\n"
+        "02/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ParsingError,
+        match="row 1: Found a transaction row above the first table header",
+    ):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    ["01/01/2022", "01/01/2022 - 31/12/2022", "Statement produced 01/01/2022"],
+)
+def test_read_vanguard_dated_metadata_above_header_is_accepted(
+    tmp_path: Path, metadata: str
+) -> None:
+    """Keep accepting the dated preamble an export prints above its table."""
+    vanguard_file = tmp_path / "dated_preamble.csv"
+    vanguard_file.write_text(
+        f"{metadata}\nDate,Details,Amount,Balance\n02/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert [transaction.amount for transaction in transactions] == [Decimal(50)]
+
+
+def test_read_vanguard_missing_header_still_reports_the_columns(
+    tmp_path: Path,
+) -> None:
+    """Keep the column error when no table header is recognised at all."""
+    vanguard_file = tmp_path / "no_header.csv"
+    vanguard_file.write_text(
+        "Date,Detail,Amount,Balance\n01/01/2022,Regular Deposit,100,100\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ParsingError, match="Expected column 2 to be 'Details'"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_padded_header_cells_are_accepted(tmp_path: Path) -> None:
+    """Match column names that the export spaced out for readability."""
+    vanguard_file = tmp_path / "padded_header.csv"
+    vanguard_file.write_text(
+        "Date, Details, Amount, Balance\n01/01/2022,Regular Deposit,100,100\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert [transaction.amount for transaction in transactions] == [Decimal(100)]
+
+
+def test_read_vanguard_repeated_page_header_tolerates_spacing(tmp_path: Path) -> None:
+    """Treat a respaced repeat of the same header as pagination, not a conflict."""
+    vanguard_file = tmp_path / "respaced_header.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "Date,Details,Amount,Balance \n"
+        "02/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert [transaction.amount for transaction in transactions] == [
+        Decimal(100),
+        Decimal(50),
+    ]
+
+
+def test_read_vanguard_ragged_cash_row_is_rejected(tmp_path: Path) -> None:
+    """Do not silently omit a cash row with the wrong field count."""
+    vanguard_file = tmp_path / "ragged_cash.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n09/03/2022,Bought 10 Foo Fund (FOO),-100.00\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(UnexpectedColumnCountError, match="doesn't have 4 columns"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_ragged_investment_row_is_rejected(tmp_path: Path) -> None:
+    """Do not silently omit an investment row with the wrong field count."""
+    vanguard_file = tmp_path / "ragged_investment.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "09/03/2022,Bought 10 Foo Fund (FOO),-100.00,0\n"
+        "\n"
+        "Investment Transactions\n"
+        "\n"
+        "Date,InvestmentName,TransactionDetails,Quantity,Price,Cost\n"
+        "10/03/2022,Foo Fund (FOO),Bought 10 Foo Fund (FOO),10,10\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        UnexpectedColumnCountError, match=r"row 7:.*doesn't have 6 columns"
+    ):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_repeated_page_header_continues_table(tmp_path: Path) -> None:
+    """Append rows after repeated pagination titles and unchanged headers."""
+    vanguard_file = tmp_path / "repeated_header.csv"
+    vanguard_file.write_text(
+        "Cash Transactions\n"
+        "Date,Details,Amount,Balance,,\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "Page 1 of 2\n"
+        "Cash Transactions\n"
+        "Date,Details,Amount,Balance\n"
+        "02/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert [transaction.amount for transaction in transactions] == [
+        Decimal(100),
+        Decimal(50),
+    ]
+
+
+def test_read_vanguard_running_summary_before_page_header_continues_table(
+    tmp_path: Path,
+) -> None:
+    """Treat a summary followed by a repeated page header as pagination."""
+    vanguard_file = tmp_path / "running_summary.csv"
+    vanguard_file.write_text(
+        "Cash Transactions\n"
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "Balance,100\n"
+        "Page 1 of 2\n"
+        "Cash Transactions\n"
+        "Date,Details,Amount,Balance\n"
+        "02/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert [transaction.amount for transaction in transactions] == [
+        Decimal(100),
+        Decimal(50),
+    ]
+
+
+def test_read_vanguard_section_title_updates_error_context(tmp_path: Path) -> None:
+    """Name the section containing a transaction row that lacks its table header."""
+    vanguard_file = tmp_path / "missing_investment_header.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "Balance,100\n"
+        "Investment Transactions\n"
+        "02/01/2022,Foo Fund (FOO),Bought 1 Foo Fund (FOO),1,1,1\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ParsingError, match="outside the Investment Transactions"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_tab_delimited_full_export(tmp_path: Path) -> None:
+    """Detect tabs from a table header even when the title row has one cell."""
+    vanguard_file = tmp_path / "vanguard.tsv"
+    vanguard_file.write_text(
+        "Bob's General investment\n"
+        "\n"
+        "Cash Transactions\n"
+        "\n"
+        "Date\tDetails\tAmount\tBalance\n"
+        "09/03/2022\tBought 10 Foo Fund (FOO)\t-100.00\t0\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert len(transactions) == 1
+    assert transactions[0].symbol == "FOO"
+
+
+def test_read_vanguard_transaction_after_summary_is_rejected(tmp_path: Path) -> None:
+    """Do not discard a transaction-shaped row after a premature summary."""
+    vanguard_file = tmp_path / "mid_table_summary.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "Balance,100\n"
+        "02/01/2022,Regular Deposit,50,150\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ParsingError, match="transaction row after the Cash"):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_utf8_bom(tmp_path: Path) -> None:
+    """Accept the BOM written by Excel's CSV UTF-8 format."""
+    vanguard_file = tmp_path / "bom.csv"
+    vanguard_file.write_text(
+        "\ufeffDate,Details,Amount,Balance\n"
+        "09/03/2022,Bought 10 Foo Fund (FOO),-100.00,0\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert len(transactions) == 1
+    assert transactions[0].symbol == "FOO"


### PR DESCRIPTION
Vanguard exports could lose transactions without an error: a row whose field count differed from its table header was skipped, a summary row truncated everything after it, and a repeated header replaced what came before. An investment-only table parsed but its unsigned `Cost` values give no usable cash movement.

Those now stop the import, naming the physical file line. What a real export legitimately contains is tolerated instead: pagination labels, repeated identical headers and section titles, single-cell footers, and cosmetic trailing empty cells. Excel workbooks are refused before parsing, and a byte order mark or tab separator no longer defeats header detection.

Row semantics — symbols, reversals and `NameChange` — are unchanged here and follow separately.