### PR TITLE
Refuse reversed Vanguard trades and enrich reversal rows

### DIFF
--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -155,9 +155,21 @@ def _parse_details(
 
 
 def _strip_reversal(details: str) -> tuple[str, bool]:
-    """Strip reversal prefix from details, returning cleaned string and flag."""
+    """Strip the prefix from a reversal of income or of a cash movement.
+
+    Reversing those negates one exported amount and needs no matching. A
+    reversed purchase or disposal instead has to undo an acquisition, so
+    stripping the prefix would import it as a fresh trade in the wrong
+    direction. Leave it prefixed and let it stop as an unknown action.
+    """
     if details.startswith(REVERSAL_STR):
-        return details[len(REVERSAL_STR) :], True
+        reversed_details = details[len(REVERSAL_STR) :]
+        if (
+            DIV_RE.match(reversed_details)
+            or reversed_details == INTEREST_STR
+            or TRANSFER_RE.match(reversed_details)
+        ):
+            return reversed_details, True
     return details, False
 
 
@@ -614,15 +626,18 @@ def _split_tables(
 
 def _find_investment_match(
     txn: VanguardTransaction,
-    investment_lookup: dict[str, list[dict[str, str]]],
+    investment_lookup: dict[tuple[str, bool], list[dict[str, str]]],
 ) -> dict[str, str] | None:
     """Find the best matching investment row for a cash transaction.
+
+    Rows are keyed by their activity text and whether they reverse it, so a
+    reversal is enriched from the matching reversal rather than the original.
 
     When multiple investment rows share the same TransactionDetails key:
     - BUY: earliest investment date on or after the cash date (cash transaction happen first, then investment buy)
     - SELL: latest investment date on or before the cash date (investment sell happen first, then cash in)
     """
-    candidates = investment_lookup.get(txn.details_text)
+    candidates = investment_lookup.get((txn.details_text, txn.is_reversal))
     if not candidates:
         return None
     if len(candidates) == 1:
@@ -717,7 +732,7 @@ class VanguardParser(BaseSingleFileParser):
             )
 
         # RENAMEs emit immediately; other investment rows populate the cash lookup.
-        investment_lookup: dict[str, list[dict[str, str]]] = {}
+        investment_lookup: dict[tuple[str, bool], list[dict[str, str]]] = {}
         transactions: list[VanguardTransaction] = []
         if investment_lines is not None:
             _, investment_header = investment_lines[0]
@@ -749,8 +764,13 @@ class VanguardParser(BaseSingleFileParser):
                 if txn.action is ActionType.RENAME:
                     transactions.append(txn)
                     continue
-                key = investment_row[InvestmentColumn.TRANSACTION_DETAILS]
-                if key:
+                # Key on the same normalisation the cash side looks up with,
+                # otherwise a reversal never finds its investment row.
+                details, is_reversal = _strip_reversal(
+                    investment_row[InvestmentColumn.TRANSACTION_DETAILS]
+                )
+                if details:
+                    key = (details, is_reversal)
                     investment_lookup.setdefault(key, []).append(investment_row)
 
         _, cash_header = cash_lines[0]

--- a/docs/brokers/vanguard.md
+++ b/docs/brokers/vanguard.md
@@ -45,10 +45,11 @@ Selling of account investments for payment of Account Fee for the period ...
 
 That cash row omits the investment and quantity, while the matching Investment Transactions row
 contains them. The importer joins the rows only when `Details` and `TransactionDetails` contain
-exactly the same text. Where several investment rows share that text, it picks the one nearest the
-cash row's own date and skips the join entirely if none qualifies. It copies the quantity and
-derives a unit price from the cash amount, but it does not copy the investment symbol and still
-classifies the result as a cash movement rather than a disposal.
+exactly the same text and both either reverse that activity or neither does. Where several
+investment rows qualify, it picks the one nearest the cash row's own date and skips the join
+entirely if none qualifies. It copies the quantity and derives a unit price from the cash amount,
+but it does not copy the investment symbol and still classifies the result as a cash movement rather
+than a disposal.
 
 Keep the complete, unchanged worksheet so that enrichment is not lost and ticker-renaming events
 remain available. See [Automatic sales to pay fees](#automatic-sales-to-pay-fees).
@@ -72,16 +73,16 @@ reconcile the file and any unsupported activity as described under
 
 The importer recognises these forms in the `Details` or `TransactionDetails` column:
 
-| Exported text or pattern                                           | How cgt-calc handles it                                 |
-| ------------------------------------------------------------------ | ------------------------------------------------------- |
-| `Bought <quantity> <investment> (<ticker>)`                        | A GBP purchase                                          |
-| `Sold <quantity> <investment> (<ticker>)`                          | A GBP disposal                                          |
-| `DIV: <ticker>.<market>... @ <currency> <rate>`                    | Dividend income using the GBP cash amount               |
-| `Reversal of DIV: ...`                                             | A reversing dividend using the exported negative amount |
-| `Cash Account Interest`                                            | GBP interest income                                     |
-| Supported deposit, transfer and payment phrases                    | GBP cash movements used by the balance check            |
-| Text containing `Account fee`, `Account Fee` or `ETF dealing fee`  | GBP cash movements only                                 |
-| `NameChange: <OLD> replaced with <NEW>` in Investment Transactions | A rename between uppercase ticker codes                 |
+| Exported text or pattern                                           | How cgt-calc handles it                             |
+| ------------------------------------------------------------------ | --------------------------------------------------- |
+| `Bought <quantity> <investment> (<ticker>)`                        | A GBP purchase                                      |
+| `Sold <quantity> <investment> (<ticker>)`                          | A GBP disposal                                      |
+| `DIV: <ticker>.<market>... @ <currency> <rate>`                    | Dividend income using the GBP cash amount           |
+| `Reversal of` a dividend, interest or cash movement                | The same activity, using the exported signed amount |
+| `Cash Account Interest`                                            | GBP interest income                                 |
+| Supported deposit, transfer and payment phrases                    | GBP cash movements used by the balance check        |
+| Text containing `Account fee`, `Account Fee` or `ETF dealing fee`  | GBP cash movements only                             |
+| `NameChange: <OLD> replaced with <NEW>` in Investment Transactions | A rename between uppercase ticker codes             |
 
 For ordinary buys and sells in a full worksheet, the cash table supplies the total amount and the
 exported text supplies the quantity and symbol. cgt-calc treats the final text in parentheses as the
@@ -93,9 +94,11 @@ included in that trade's `Amount` is folded into the derived price.
 
 Deposit and withdrawal wording is recognised through phrases such as `Regular Deposit`,
 `Cash transfer`, `Deposit via`, `Deposit for` and `Payment by`. Capitalisation and punctuation can
-matter. Most other text stops the import with `Unknown action`, but `Reversal of` is stripped before
-classification. Only dividend reversals have been validated; a reversed buy or sell can be imported
-incorrectly instead of stopping.
+matter. Most other text stops the import with `Unknown action`. `Reversal of` is stripped only when
+what follows is a dividend, interest or a cash movement, which the exported signed amount alone
+reverses: a reversed dividend is exported as a debit and a reversed fee as a credit. A reversed
+purchase or disposal stops with `Unknown action` rather than being read as a fresh trade in the
+wrong direction.
 
 By contrast, a separate account-fee or ETF-dealing-fee row only changes the tracked cash balance.
 cgt-calc does not assign that row to a purchase or disposal as an allowable cost.
@@ -158,8 +161,8 @@ taxed as interest rather than dividends; see
   `Unknown action`.
 - The dividend reader expects Vanguard's `DIV: ... @ ...` text layout. Changed dividend wording or
   another income type is not mapped merely because it appears in the workbook.
-- `Reversal of` is removed from every details string before classification. Only reversing dividends
-  have been validated; a reversal of a buy, sell or another activity can be silently misclassified.
+- A reversed purchase or disposal stops the import. Undoing one needs the acquisition it cancels,
+  which the row does not identify, so cgt-calc refuses it instead of guessing.
 - The importer treats every transaction amount as GBP. Foreign-currency dividend text has not been
   validated and is not converted.
 - The final text in parentheses is always treated as the ticker. For example, an investment ending
@@ -203,9 +206,12 @@ install it. If it still fails, open a
 [GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new) with your cgt-calc
 version, the complete error and a sanitised copy of the row.
 
-Do not assume that every unsupported row raises this error. A row beginning `Reversal of` can be
-misclassified, and a row with the wrong number of fields stops the import with a different message
-naming its physical file line; check the source workbook as described below.
+A row beginning `Reversal of` reaches this error when it reverses anything other than a dividend,
+interest or a cash movement. Report the row rather than deleting it: undoing a purchase or disposal
+has to be recorded against the acquisition it cancels, which the export does not name.
+
+A row with the wrong number of fields stops the import too, with a different message naming its
+physical file line; check the source workbook as described below.
 
 ### Automatic sales to pay fees
 
@@ -227,10 +233,9 @@ summary now stop the import naming the physical file line, rather than being ski
 inside a table stops the import for the same reason: a transaction that lost its separators arrives
 as a single cell and must not pass as a footer.
 
-Also inspect every `Reversal of` row. Only dividend reversals have been validated; a reversed buy or
-sell can be imported with the wrong action, quantity or amount instead of being rejected. Keep the
-original export unchanged and report an unchanged Vanguard row that behaves this way in a
-[GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new).
+A reversed purchase or disposal no longer imports silently either; it stops with `Unknown action`.
+Keep the original export unchanged and report an unchanged Vanguard row that behaves unexpectedly in
+a [GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new).
 
 ### `Reached a negative balance` or `Tried to sell not owned symbol`
 

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from pathlib import Path
+import re
 import subprocess
 
 import pytest
@@ -11,7 +12,7 @@ import pytest
 from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
 from cgt_calc.model import ActionType
-from cgt_calc.parsers.vanguard import COLUMNS, VanguardParser
+from cgt_calc.parsers.vanguard import COLUMNS, VanguardParser, VanguardTransaction
 from tests.utils import build_cmd, report_path, stderr_alerts
 
 
@@ -341,6 +342,86 @@ def test_dual_table_reversal_handling() -> None:
     assert len(reversals) == 1
     assert reversals[0].action == ActionType.DIVIDEND
     assert reversals[0].amount == Decimal("-170.83")
+
+
+@pytest.mark.parametrize(
+    "details",
+    [
+        "Bought 10 Foo Fund (FOO)",
+        "Sold 10 Foo Fund (FOO)",
+        "Frobnicated 10 Foo Fund (FOO)",
+    ],
+)
+def test_read_vanguard_reversal_of_a_trade_is_rejected(
+    tmp_path: Path, details: str
+) -> None:
+    """Refuse a reversed trade instead of importing it the wrong way round."""
+    vanguard_file = tmp_path / "reversed_trade.csv"
+    vanguard_file.write_text(
+        f"Date,Details,Amount,Balance\n09/03/2022,Reversal of {details},100.00,0\n",
+        encoding="utf-8",
+    )
+
+    expected = re.escape(f"Unknown action: Reversal of {details}")
+    with pytest.raises(ParsingError, match=expected):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+@pytest.mark.parametrize(
+    ("details", "action"),
+    [
+        ("DIV: FOO.XLON.GB @ GBP 0.3106", ActionType.DIVIDEND),
+        ("Cash Account Interest", ActionType.INTEREST),
+        ("Regular Deposit", ActionType.TRANSFER),
+        ("Account Fee", ActionType.TRANSFER),
+    ],
+)
+def test_read_vanguard_reversal_of_income_is_still_read(
+    tmp_path: Path, details: str, action: ActionType
+) -> None:
+    """Keep reading the reversals that only negate one exported amount."""
+    vanguard_file = tmp_path / "reversed_income.csv"
+    vanguard_file.write_text(
+        f"Date,Details,Amount,Balance\n09/03/2022,Reversal of {details},-10.00,0\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert isinstance(transaction, VanguardTransaction)
+    assert transaction.action is action
+    assert transaction.is_reversal is True
+
+
+def test_read_vanguard_reversed_fee_sale_is_enriched(tmp_path: Path) -> None:
+    """Enrich a reversal from its own investment row, not only plain rows."""
+    fee = "Selling of account investments for payment of Account Fee"
+    vanguard_file = tmp_path / "reversed_fee_sale.csv"
+    vanguard_file.write_text(
+        "Cash Transactions\n"
+        "Date,Details,Amount,Balance\n"
+        f"19/07/2022,{fee},-13.91,100\n"
+        f"20/07/2022,Reversal of {fee},13.91,113.91\n"
+        "Investment Transactions\n"
+        "Date,InvestmentName,TransactionDetails,Quantity,Price,Cost\n"
+        f"19/07/2022,Foo Fund (FOO),{fee},1.391,10,13.91\n"
+        f"20/07/2022,Foo Fund (FOO),Reversal of {fee},2.5,20,50\n",
+        encoding="utf-8",
+    )
+
+    transactions = VanguardParser().load_from_file(vanguard_file)
+
+    assert all(isinstance(t, VanguardTransaction) for t in transactions)
+    by_reversal = {
+        transaction.is_reversal: transaction
+        for transaction in transactions
+        if isinstance(transaction, VanguardTransaction)
+    }
+    # Each row takes its own quantity, so neither is enriched from the other.
+    assert by_reversal[False].quantity == Decimal("1.391")
+    assert by_reversal[True].quantity == Decimal("2.5")
 
 
 def test_dual_table_sorted_by_date() -> None:


### PR DESCRIPTION
A reversed purchase or disposal was imported as a fresh trade in the wrong direction: `Reversal of Bought 10 Foo Fund (FOO)` at +£100 became a BUY. Undoing one needs the acquisition it cancels, which the row does not identify, so it now stops with `Unknown action`. Reversals of dividends, interest and cash movements are unaffected — the exported signed amount alone reverses those.

Separately, the enrichment lookup was keyed on the raw `TransactionDetails` while lookups used the reversal-stripped text, so a `Reversal of` row never matched its own investment row. It either went unenriched or, where the original activity's row was also present, silently took that row's quantity instead: in a fee sale exported with quantity 1.391 and its reversal exported with 2.5, the reversal was enriched to 1.391. Both sides now key on the same normalisation, paired by reversal status.

No user has reported either; both were found while reviewing #1026.