### PR TITLE
Pin the validation the Vanguard investment table gets while read

### DIFF
--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -750,6 +750,10 @@ class VanguardParser(BaseSingleFileParser):
                 )
 
             for row_index, investment_row in investment_rows:
+                # Only a RENAME keeps its transaction, but every row is read:
+                # reading is what rejects an unknown action or an unreadable
+                # number here. Skipping it for the rest would accept them
+                # silently, so do not narrow this call to NameChange rows.
                 try:
                     txn = _make_transaction_from_investment(investment_row, file_path)
                 except ParsingError as err:

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -220,6 +220,54 @@ def test_read_vanguard_transactions_empty_file(tmp_path: Path) -> None:
 INVESTMENT_DATA_DIR = Path("tests/vanguard/data")
 
 
+def _dual_table_csv(investment_row: str) -> str:
+    """Build a minimal two-table export around one Investment Transactions row."""
+    return (
+        "Cash Transactions\n"
+        "Date,Details,Amount,Balance\n"
+        "01/01/2022,Regular Deposit,100,100\n"
+        "Investment Transactions\n"
+        "Date,InvestmentName,TransactionDetails,Quantity,Price,Cost\n"
+        f"{investment_row}\n"
+    )
+
+
+# An investment row is validated while it is read, even though only a RENAME
+# produces a transaction. These pin that, so removing the read stops the suite.
+def test_read_vanguard_investment_row_unknown_action_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Refuse activity in the investment table that the cash table would refuse."""
+    vanguard_file = tmp_path / "unknown_investment_action.csv"
+    vanguard_file.write_text(
+        _dual_table_csv("01/02/2022,Foo Fund (FOO),Frobnicated 10 Foo Fund,10,1,10"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ParsingError, match="row 6: Unknown action: Frobnicated 10 Foo Fund"
+    ):
+        VanguardParser().load_from_file(vanguard_file)
+
+
+def test_read_vanguard_investment_row_invalid_decimal_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Refuse an unreadable investment quantity instead of ignoring the row."""
+    vanguard_file = tmp_path / "invalid_investment_quantity.csv"
+    vanguard_file.write_text(
+        _dual_table_csv(
+            "01/02/2022,Foo Fund (FOO),Bought 10 Foo Fund (FOO),not-a-number,1,10"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ParsingError, match="row 6: Invalid decimal in Quantity: 'not-a-number'"
+    ):
+        VanguardParser().load_from_file(vanguard_file)
+
+
 def test_dual_table_enriches_buy_with_investment_data() -> None:
     """Cash BUY transactions are enriched with precise quantity/price from investment table."""
     transactions = VanguardParser().load_from_file(


### PR DESCRIPTION
An Investment Transactions row is validated as a side effect of being read: only a `NameChange` keeps its transaction, but reading every row is what raises `Unknown action` for unrecognised activity and `Invalid decimal` for an unreadable number. Nothing tested that. Both existing tests for those errors feed cash rows, so narrowing the read to `NameChange` rows — a change that looks safe and leaves enrichment working — dropped the checks with the whole suite still green.

These two tests fail on exactly that change and nothing else, plus a comment at the call site saying why the read cannot be narrowed.