### PR TITLE
Explain why a reversed Vanguard trade cannot be imported

### DIFF
--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -111,6 +111,24 @@ def action_from_str(label: str, file: Path) -> ActionType:
     if label == INTEREST_STR:
         return ActionType.INTEREST
 
+    if label.startswith(REVERSAL_STR):
+        reversed_label = label[len(REVERSAL_STR) :]
+        # Supported reversals were stripped before this, so a trade reaching
+        # here is one nothing can be done with. The row itself is understood,
+        # unlike an unknown action, so say what is actually missing from it.
+        if BOUGHT_RE.match(reversed_label) or SOLD_RE.match(reversed_label):
+            raise ParsingError(
+                file,
+                f"Cannot import a reversed trade: {label}. A reversed purchase "
+                "or disposal has to be reconciled with the original trade, "
+                "which this row does not identify, and no export containing "
+                "one has been examined, so cgt-calc cannot establish the "
+                "correct treatment. Keep the export unchanged and please "
+                "report this row so that the format can be supported. See "
+                "https://cgt-calc.uk/brokers/vanguard/"
+                "#a-reversed-purchase-or-disposal",
+            )
+
     raise ParsingError(file, f"Unknown action: {label}")
 
 
@@ -158,9 +176,10 @@ def _strip_reversal(details: str) -> tuple[str, bool]:
     """Strip the prefix from a reversal of income or of a cash movement.
 
     Reversing those negates one exported amount and needs no matching. A
-    reversed purchase or disposal instead has to undo an acquisition, so
-    stripping the prefix would import it as a fresh trade in the wrong
-    direction. Leave it prefixed and let it stop as an unknown action.
+    reversed purchase or disposal instead has to be reconciled with the trade
+    it refers to, so stripping the prefix would import it as a fresh trade in
+    the wrong direction. Leave it prefixed: `action_from_str` recognises the
+    prefix and reports what the row is missing.
     """
     if details.startswith(REVERSAL_STR):
         reversed_details = details[len(REVERSAL_STR) :]

--- a/docs/brokers/vanguard.md
+++ b/docs/brokers/vanguard.md
@@ -97,8 +97,8 @@ Deposit and withdrawal wording is recognised through phrases such as `Regular De
 matter. Most other text stops the import with `Unknown action`. `Reversal of` is stripped only when
 what follows is a dividend, interest or a cash movement, which the exported signed amount alone
 reverses: a reversed dividend is exported as a debit and a reversed fee as a credit. A reversed
-purchase or disposal stops with `Unknown action` rather than being read as a fresh trade in the
-wrong direction.
+purchase or disposal stops the import rather than being read as a fresh trade in the wrong
+direction.
 
 By contrast, a separate account-fee or ETF-dealing-fee row only changes the tracked cash balance.
 cgt-calc does not assign that row to a purchase or disposal as an allowable cost.
@@ -161,7 +161,7 @@ taxed as interest rather than dividends; see
   `Unknown action`.
 - The dividend reader expects Vanguard's `DIV: ... @ ...` text layout. Changed dividend wording or
   another income type is not mapped merely because it appears in the workbook.
-- A reversed purchase or disposal stops the import. Undoing one needs the acquisition it cancels,
+- A reversed purchase or disposal stops the import. It has to be reconciled with the original trade,
   which the row does not identify, so cgt-calc refuses it instead of guessing.
 - The importer treats every transaction amount as GBP. Foreign-currency dividend text has not been
   validated and is not converted.
@@ -206,12 +206,28 @@ install it. If it still fails, open a
 [GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new) with your cgt-calc
 version, the complete error and a sanitised copy of the row.
 
-A row beginning `Reversal of` reaches this error when it reverses anything other than a dividend,
-interest or a cash movement. Report the row rather than deleting it: undoing a purchase or disposal
-has to be recorded against the acquisition it cancels, which the export does not name.
-
 A row with the wrong number of fields stops the import too, with a different message naming its
-physical file line; check the source workbook as described below.
+physical file line; check the source workbook as described below. A reversed purchase or disposal
+has its own message, described next.
+
+### A reversed purchase or disposal
+
+`Reversal of Bought ...` and `Reversal of Sold ...` stop the import. Reversing a dividend, interest
+or a cash movement only negates one exported amount, so cgt-calc reads those. Reversing a trade
+instead has to be reconciled with the original trade, and the row does not say which purchase or
+disposal that is, so the share matching cannot be worked out from it.
+
+Keep the export unchanged, and please report the row with your cgt-calc version and a sanitised copy
+in a [GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new). No export
+containing a reversed trade has been examined, so what the row means is not established: it may
+cancel a trade that never stood, or record something that is itself a disposal. A real example is
+what would let cgt-calc handle it for you instead of stopping.
+
+Do not simply delete the rows to get the import to run. Deleting the reversal alone leaves a trade
+in the pool that may have been cancelled; deleting it together with the original removes activity
+that may be chargeable, and the original may not even be in the export if your period starts after
+it. Establish the correct treatment for the event first, then record it through the
+[RAW format](raw.md) or calculate it separately, and retain the original workbook as evidence.
 
 ### Automatic sales to pay fees
 
@@ -233,9 +249,10 @@ summary now stop the import naming the physical file line, rather than being ski
 inside a table stops the import for the same reason: a transaction that lost its separators arrives
 as a single cell and must not pass as a footer.
 
-A reversed purchase or disposal no longer imports silently either; it stops with `Unknown action`.
-Keep the original export unchanged and report an unchanged Vanguard row that behaves unexpectedly in
-a [GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new).
+A reversed purchase or disposal no longer imports silently either; see
+[A reversed purchase or disposal](#a-reversed-purchase-or-disposal). Keep the original export
+unchanged and report an unchanged Vanguard row that behaves unexpectedly in a
+[GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new).
 
 ### `Reached a negative balance` or `Tried to sell not owned symbol`
 

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -394,11 +394,7 @@ def test_dual_table_reversal_handling() -> None:
 
 @pytest.mark.parametrize(
     "details",
-    [
-        "Bought 10 Foo Fund (FOO)",
-        "Sold 10 Foo Fund (FOO)",
-        "Frobnicated 10 Foo Fund (FOO)",
-    ],
+    ["Bought 10 Foo Fund (FOO)", "Sold 10 Foo Fund (FOO)"],
 )
 def test_read_vanguard_reversal_of_a_trade_is_rejected(
     tmp_path: Path, details: str
@@ -410,9 +406,22 @@ def test_read_vanguard_reversal_of_a_trade_is_rejected(
         encoding="utf-8",
     )
 
-    expected = re.escape(f"Unknown action: Reversal of {details}")
-    with pytest.raises(ParsingError, match=expected):
+    expected = re.escape(f"Cannot import a reversed trade: Reversal of {details}")
+    with pytest.raises(ParsingError, match=expected) as exc:
         VanguardParser().load_from_file(vanguard_file)
+
+    message = str(exc.value)
+    # The row is understood; it is the trade it cancels that is missing. Ask
+    # for it to be reported, so the format can eventually be read, and do not
+    # prescribe an edit: what the row means has not been established, so any
+    # deletion could drop activity that turns out to be chargeable.
+    assert "Keep the export unchanged" in message
+    assert "please report this row" in message
+    assert "remove" not in message.lower()
+    assert "delete" not in message.lower()
+    assert "https://cgt-calc.uk/brokers/vanguard/#a-reversed-purchase-or-disposal" in (
+        message
+    )
 
 
 @pytest.mark.parametrize(
@@ -441,6 +450,23 @@ def test_read_vanguard_reversal_of_income_is_still_read(
     assert isinstance(transaction, VanguardTransaction)
     assert transaction.action is action
     assert transaction.is_reversal is True
+
+
+def test_read_vanguard_reversal_of_unknown_activity_stays_generic(
+    tmp_path: Path,
+) -> None:
+    """Do not call a reversal a trade when the activity itself is unrecognised."""
+    vanguard_file = tmp_path / "reversed_unknown.csv"
+    vanguard_file.write_text(
+        "Date,Details,Amount,Balance\n"
+        "09/03/2022,Reversal of Corporate Action,100.00,0\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ParsingError, match="Unknown action: Reversal of Corporate Action"
+    ):
+        VanguardParser().load_from_file(vanguard_file)
 
 
 def test_read_vanguard_reversed_fee_sale_is_enriched(tmp_path: Path) -> None:


### PR DESCRIPTION
`Reversal of Bought ...` and `Reversal of Sold ...` stopped with a bare `Unknown action`, which is misleading: the row itself is understood, it is the original trade it has to be reconciled with that the row does not identify.

The message now says what is missing and asks for the row to be reported, so that the format can eventually be supported. It deliberately prescribes no edit. #1029 records that no export containing a reversed trade has been examined, so what the row means is not established: deleting the reversal could leave a trade in the pool that was cancelled, deleting it with its original could remove activity that turns out to be chargeable, and the original may not be in the export at all if the period starts after it. The guide says that explicitly and points at the RAW format for recording the event once its treatment is established.

Only reversals whose activity is recognised as a trade get the new message. `Reversal of Corporate Action` keeps `Unknown action`, because the underlying activity is unrecognised too.

Groundwork for #1029, which needs a real export before the two rows can be paired automatically.