### PR TITLE
Add argument for excluding some tickers from CGT

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -135,6 +135,7 @@ py
 pyproject
 pytest
 python3
+QCB
 QCBs
 rata
 regularMarketPrice
@@ -197,6 +198,7 @@ txn
 ty
 UCITS
 un
+unvalidated
 US9220427424
 usr
 UTF

--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -135,6 +135,7 @@ py
 pyproject
 pytest
 python3
+QCBs
 rata
 regularMarketPrice
 reportable
@@ -147,6 +148,7 @@ RuntimeError
 RuntimeMode
 s105
 s106A
+s115
 s122
 s127
 s17

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -160,7 +160,12 @@ Environment variables:
         type=ticker_list_type,
         metavar="TICKER[,TICKER...]",
         default=[],
-        help="tickers of assets exempt from CGT (e.g. UK gilts, qualifying corporate bonds)",
+        help="advanced manual CGT-exempt instrument classification (TCGA 1992 "
+        "s115): your own unverified assertion, since QCB status cannot be "
+        "inferred from a ticker or name; disregards both gains and losses on "
+        "disposals and changes nothing else, so coupon and accrued interest "
+        "stay taxable in whichever box the broker's rows put them and the "
+        "Accrued Income Scheme is not implemented",
     )
 
     # Output Options

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -155,6 +155,13 @@ Environment variables:
         default=[],
         help="tickers of bond funds/ETFs whose dividends are taxed as interest in the UK",
     )
+    calc_group.add_argument(
+        "--cgt-exempt-tickers",
+        type=ticker_list_type,
+        metavar="TICKER[,TICKER...]",
+        default=[],
+        help="tickers of assets exempt from CGT (e.g. UK gilts, qualifying corporate bonds)",
+    )
 
     # Output Options
     output_group = parser.add_argument_group("Output")

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -165,7 +165,8 @@ Environment variables:
         "inferred from a ticker or name; disregards both gains and losses on "
         "disposals and changes nothing else, so coupon and accrued interest "
         "stay taxable in whichever box the broker's rows put them and the "
-        "Accrued Income Scheme is not implemented",
+        "Accrued Income Scheme is not implemented; not for a QCB carrying a "
+        "deferred gain or for a deeply discounted security",
     )
 
     # Output Options

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -223,10 +223,9 @@ class CapitalGainsCalculator:
         self.balance_check = balance_check
         self.calc_unrealized_gains = calc_unrealized_gains
         self.interest_fund_tickers = interest_fund_tickers
-        self.cgt_exempt_tickers = [
-            ticker.upper() for ticker in (cgt_exempt_tickers or [])
-        ]
-        self.cgt_exempt_tickers_set = set(self.cgt_exempt_tickers)
+        self.cgt_exempt_tickers = frozenset(
+            ticker.upper() for ticker in cgt_exempt_tickers or []
+        )
         self.total_uk_interest = Decimal(0)
         self.total_foreign_interest = Decimal(0)
         self.total_interest_tax = Decimal(0)
@@ -312,7 +311,7 @@ class CapitalGainsCalculator:
 
     def is_cgt_exempt(self, symbol: str) -> bool:
         """Check if symbol is exempt from Capital Gains Tax."""
-        return symbol.upper() in self.cgt_exempt_tickers_set
+        return symbol.upper() in self.cgt_exempt_tickers
 
     def get_eri(self, symbol: str, date: datetime.date) -> ExcessReportedIncome | None:
         """Return Excess Reported Income at specific date for the input symbol."""
@@ -716,6 +715,10 @@ class CapitalGainsCalculator:
 
         A sale with a gift to someone unconnected is one ordinary disposal,
         reported as a sale.
+
+        A disposal of an instrument the user has classified as CGT-exempt is
+        named "exempt" whichever kind it is, so a gift of one is reported as an
+        exempt disposal rather than as a gift.
         """
         if self.is_cgt_exempt(symbol):
             return "exempt"
@@ -2439,7 +2442,7 @@ class CapitalGainsCalculator:
             for day in log.values()
             for sym in day
         }
-        for ticker in dict.fromkeys(self.cgt_exempt_tickers):
+        for ticker in sorted(self.cgt_exempt_tickers):
             if ticker not in logged_symbols:
                 LOGGER.warning(
                     "CGT-exempt ticker '%s' was not found in acquisitions or disposals",
@@ -2545,7 +2548,7 @@ class CapitalGainsCalculator:
                         calculation_log[date_index][f"{prefix}${symbol}"] = (
                             calculation_entries
                         )
-                        if self.is_cgt_exempt(symbol):
+                        if prefix == "exempt":
                             exempt_disposal_count += 1
                             exempt_disposal_proceeds += transaction_disposal_proceeds
                             LOGGER.debug(

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -197,6 +197,7 @@ class CapitalGainsCalculator:
         initial_prices: InitialPrices,
         interest_fund_tickers: list[str],
         *,
+        cgt_exempt_tickers: list[str] | None = None,
         balance_check: bool = True,
         calc_unrealized_gains: bool = False,
         period_start: datetime.date | None = None,
@@ -222,6 +223,10 @@ class CapitalGainsCalculator:
         self.balance_check = balance_check
         self.calc_unrealized_gains = calc_unrealized_gains
         self.interest_fund_tickers = interest_fund_tickers
+        self.cgt_exempt_tickers = [
+            ticker.upper() for ticker in (cgt_exempt_tickers or [])
+        ]
+        self.cgt_exempt_tickers_set = set(self.cgt_exempt_tickers)
         self.total_uk_interest = Decimal(0)
         self.total_foreign_interest = Decimal(0)
         self.total_interest_tax = Decimal(0)
@@ -304,6 +309,10 @@ class CapitalGainsCalculator:
         """Check if date is within current tax year."""
         assert is_date(date)
         return self.tax_year_start_date <= date <= self.tax_year_end_date
+
+    def is_cgt_exempt(self, symbol: str) -> bool:
+        """Check if symbol is exempt from Capital Gains Tax."""
+        return symbol.upper() in self.cgt_exempt_tickers_set
 
     def get_eri(self, symbol: str, date: datetime.date) -> ExcessReportedIncome | None:
         """Return Excess Reported Income at specific date for the input symbol."""
@@ -708,6 +717,8 @@ class CapitalGainsCalculator:
         A sale with a gift to someone unconnected is one ordinary disposal,
         reported as a sale.
         """
+        if self.is_cgt_exempt(symbol):
+            return "exempt"
         key = (date_index, symbol)
         connected = self.gift_disposals.get(key)
         if connected:
@@ -2420,6 +2431,21 @@ class CapitalGainsCalculator:
             if is_interest_fund:
                 self.total_foreign_interest += amount
 
+    def _warn_unmatched_cgt_exempt_tickers(self) -> None:
+        """Warn for any exempt ticker with no transactions."""
+        logged_symbols = {
+            sym.upper()
+            for log in (self.acquisition_list, self.disposal_list)
+            for day in log.values()
+            for sym in day
+        }
+        for ticker in dict.fromkeys(self.cgt_exempt_tickers):
+            if ticker not in logged_symbols:
+                LOGGER.warning(
+                    "CGT-exempt ticker '%s' was not found in acquisitions or disposals",
+                    ticker,
+                )
+
     def calculate_capital_gain(
         self,
     ) -> CapitalGainsReport:
@@ -2435,6 +2461,7 @@ class CapitalGainsCalculator:
                 "new one to calculate again"
             )
         self.calculated = True
+        self._warn_unmatched_cgt_exempt_tickers()
         begin_index = INTERNAL_START_DATE
         tax_year_start_index = self.tax_year_start_date
         end_index = self.tax_year_end_date
@@ -2444,6 +2471,8 @@ class CapitalGainsCalculator:
         capital_gain = Decimal(0)
         capital_loss = Decimal(0)
         gift_loss = Decimal(0)
+        exempt_disposal_count = 0
+        exempt_disposal_proceeds = Decimal(0)
 
         # The first pass left its estimates in the portfolio; the walk rebuilds
         # it from nothing.
@@ -2486,7 +2515,6 @@ class CapitalGainsCalculator:
                         self.process_disposal(symbol, date_index)
                     )
                     if date_index >= tax_year_start_index:
-                        disposal_count += 1
                         transaction_amount = self.disposal_list[date_index][
                             symbol
                         ].amount
@@ -2494,20 +2522,9 @@ class CapitalGainsCalculator:
                         transaction_disposal_proceeds = (
                             transaction_amount + transaction_fees
                         )
-                        disposal_proceeds += transaction_disposal_proceeds
-                        allowable_costs += (
-                            transaction_disposal_proceeds - transaction_capital_gain
-                        )
                         transaction_quantity = self.disposal_list[date_index][
                             symbol
                         ].quantity
-                        LOGGER.debug(
-                            "DISPOSAL on %s of %s, quantity %s, capital gain $%s",
-                            date_index,
-                            symbol,
-                            transaction_quantity,
-                            round_decimal(transaction_capital_gain, 2),
-                        )
                         calculated_quantity = Decimal(0)
                         calculated_proceeds = Decimal(0)
                         calculated_gain = Decimal(0)
@@ -2528,16 +2545,39 @@ class CapitalGainsCalculator:
                         calculation_log[date_index][f"{prefix}${symbol}"] = (
                             calculation_entries
                         )
-                        if transaction_capital_gain > 0:
-                            capital_gain += transaction_capital_gain
-                        elif prefix == "gift":
-                            # A clogged loss: usable only against gains on
-                            # disposals to the same connected person while
-                            # still connected (TCGA 1992 s18(3)). Kept out of
-                            # the loss total and reported as its own.
-                            gift_loss += transaction_capital_gain
+                        if self.is_cgt_exempt(symbol):
+                            exempt_disposal_count += 1
+                            exempt_disposal_proceeds += transaction_disposal_proceeds
+                            LOGGER.debug(
+                                "EXEMPT DISPOSAL on %s of %s, quantity %s, proceeds £%s",
+                                date_index,
+                                symbol,
+                                transaction_quantity,
+                                round_decimal(transaction_disposal_proceeds, 2),
+                            )
                         else:
-                            capital_loss += transaction_capital_gain
+                            disposal_count += 1
+                            disposal_proceeds += transaction_disposal_proceeds
+                            allowable_costs += (
+                                transaction_disposal_proceeds - transaction_capital_gain
+                            )
+                            LOGGER.debug(
+                                "DISPOSAL on %s of %s, quantity %s, capital gain $%s",
+                                date_index,
+                                symbol,
+                                transaction_quantity,
+                                round_decimal(transaction_capital_gain, 2),
+                            )
+                            if transaction_capital_gain > 0:
+                                capital_gain += transaction_capital_gain
+                            elif prefix == "gift":
+                                # A clogged loss: usable only against gains on
+                                # disposals to the same connected person while
+                                # still connected (TCGA 1992 s18(3)). Kept out of
+                                # the loss total and reported as its own.
+                                gift_loss += transaction_capital_gain
+                            else:
+                                capital_loss += transaction_capital_gain
 
             if date_index in self.rename_list:
                 for old, new in self.rename_list[date_index].items():
@@ -2631,6 +2671,8 @@ class CapitalGainsCalculator:
             gift_loss=round_decimal(gift_loss, 2),
             period_start=self.period_start,
             period_end=self.period_end,
+            exempt_disposal_count=exempt_disposal_count,
+            exempt_disposal_proceeds=round_decimal(exempt_disposal_proceeds, 2),
         )
 
     def make_portfolio_entry(
@@ -2675,6 +2717,7 @@ def calculate_cgt(args: argparse.Namespace) -> None:
         spin_off_handler,
         initial_prices,
         args.interest_fund_tickers,
+        cgt_exempt_tickers=args.cgt_exempt_tickers,
         balance_check=args.balance_check,
         calc_unrealized_gains=args.calc_unrealized_gains,
         period_start=args.period_from,

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -559,18 +559,11 @@ class CapitalGainsReport:
     # Losses on gifts, kept out of capital_loss: a loss on a disposal to a
     # connected person is a clogged loss (TCGA 1992 s18(3)). Negative or zero.
     gift_loss: Decimal = Decimal(0)
+    # Disposals of instruments the user classified as CGT-exempt, kept out of
+    # disposal_count and disposal_proceeds: an exempt asset is not a chargeable
+    # asset, so neither its gain nor its loss reaches the calculation.
     exempt_disposal_count: int = 0
     exempt_disposal_proceeds: Decimal = Decimal(0)
-
-    @property
-    def exempt_disposals(self) -> int:
-        """Alias for exempt_disposal_count."""
-        return self.exempt_disposal_count
-
-    @property
-    def exempt_proceeds(self) -> Decimal:
-        """Alias for exempt_disposal_proceeds."""
-        return self.exempt_disposal_proceeds
 
     def period_label(self) -> str | None:
         """Label for a custom reporting period, None for a full tax year."""
@@ -720,8 +713,14 @@ class CapitalGainsReport:
             ("Loss", f"£{-self.capital_loss:,}"),
             *([("Losses on gifts", f"£{-self.gift_loss:,}")] if self.gift_loss else []),
             *(
-                [("Exempt disposals", f"£{self.exempt_disposal_proceeds:,}")]
-                if self.exempt_disposal_proceeds
+                [
+                    ("Exempt disposals", str(self.exempt_disposal_count)),
+                    (
+                        "Exempt disposal proceeds",
+                        f"£{self.exempt_disposal_proceeds:,}",
+                    ),
+                ]
+                if self.exempt_disposal_count
                 else []
             ),
             ("Total gain", f"£{self.total_gain():,}"),

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -559,6 +559,18 @@ class CapitalGainsReport:
     # Losses on gifts, kept out of capital_loss: a loss on a disposal to a
     # connected person is a clogged loss (TCGA 1992 s18(3)). Negative or zero.
     gift_loss: Decimal = Decimal(0)
+    exempt_disposal_count: int = 0
+    exempt_disposal_proceeds: Decimal = Decimal(0)
+
+    @property
+    def exempt_disposals(self) -> int:
+        """Alias for exempt_disposal_count."""
+        return self.exempt_disposal_count
+
+    @property
+    def exempt_proceeds(self) -> Decimal:
+        """Alias for exempt_disposal_proceeds."""
+        return self.exempt_disposal_proceeds
 
     def period_label(self) -> str | None:
         """Label for a custom reporting period, None for a full tax year."""
@@ -707,6 +719,11 @@ class CapitalGainsReport:
             ("Gain", f"£{self.capital_gain:,}"),
             ("Loss", f"£{-self.capital_loss:,}"),
             *([("Losses on gifts", f"£{-self.gift_loss:,}")] if self.gift_loss else []),
+            *(
+                [("Exempt disposals", f"£{self.exempt_disposal_proceeds:,}")]
+                if self.exempt_disposal_proceeds
+                else []
+            ),
             ("Total gain", f"£{self.total_gain():,}"),
         ]
         capital_notes: list[str] = []

--- a/cgt_calc/resources/template.tex.j2
+++ b/cgt_calc/resources/template.tex.j2
@@ -139,12 +139,15 @@
     \BLOCK{ set overall_disposed = round_decimal(entries|sum(attribute="amount") + entries|sum(attribute="fees"), 2) }
     \BLOCK{ set overall_gain = round_decimal(entries|sum(attribute="gain"), 2) }
     \subsubsection*{
-        Exempt disposal: \VAR{ strip_zeros(overall_quantity) } units of \VAR{ symbol } for £\VAR{ "{:,}".format(overall_disposed) }
+        Exempt disposal: \VAR{ strip_zeros(overall_quantity) } units of \VAR{ symbol } valued at £\VAR{ "{:,}".format(overall_disposed) }
         (£\VAR{ "{:,}".format(round_decimal(overall_disposed/overall_quantity, 2)) }/unit)%
         \BLOCK{ if overall_fees > 0 }
-            , £\VAR{ "{:,}".format(overall_fees) } fees allowed as cost
+            , £\VAR{ "{:,}".format(overall_fees) } disposal expenses included in the illustrative calculation
         \BLOCK{ endif }
     }
+    The cost and disposal expenses shown below are used for this illustrative calculation only;
+    they are not allowable deductions against other gains.
+
     \BLOCK{ if overall_gain > 0 -}
         Gain is £\VAR{ "{:,}".format(overall_gain) }; the gain or loss is disregarded (exempt asset).
     \BLOCK{ elif overall_gain == 0 }
@@ -178,11 +181,11 @@
     \BLOCK{ if entry.quantity < overall_quantity }
         disposal proceeds: £\VAR{ "{:,}".format(round_decimal(entry.amount + entry.fees, 2)) },
     \BLOCK{ endif }
-    allowable
+    cost used for this illustrative
     \BLOCK{ if entry.rule_type.name == "BED_AND_BREAKFAST" }
-        cost on \mbox{\VAR{ entry.bed_and_breakfast_date_index.strftime("%d %b %Y") }:}
+        calculation on \mbox{\VAR{ entry.bed_and_breakfast_date_index.strftime("%d %b %Y") }:}
     \BLOCK{ else }
-        cost:
+        calculation:
     \BLOCK{ endif }
     £\VAR{ "{:,}".format(round_decimal(entry.allowable_cost, 2)) },
     \BLOCK{ if entry.gain > 0}
@@ -308,8 +311,9 @@
 \BLOCK{ if gift_loss.value > 0 }
 \subsection*{Losses on gifts, kept separate: £\VAR{ "{:,}".format(gift_loss.value) }}
 \BLOCK{ endif }
-\BLOCK{ if report.exempt_disposal_proceeds > 0 }
-\subsection*{Exempt disposals: £\VAR{ "{:,}".format(report.exempt_disposal_proceeds) }}
+\BLOCK{ if report.exempt_disposal_count > 0 }
+\subsection*{Number of exempt disposals: \VAR{ report.exempt_disposal_count }}
+\subsection*{Total exempt disposal proceeds: £\VAR{ "{:,}".format(report.exempt_disposal_proceeds) }}
 \BLOCK{ endif }
 \subsection*{Total capital gain after loss: £\VAR{ "{:,}".format(total_gain.value - total_loss.value) }}
 \vspace{1em}

--- a/cgt_calc/resources/template.tex.j2
+++ b/cgt_calc/resources/template.tex.j2
@@ -48,6 +48,9 @@
     \BLOCK{ set symbol = symbol[17:] }
     \BLOCK{ set is_disposal = True }
     \BLOCK{ set is_gift = True }
+\BLOCK{ elif symbol.startswith("exempt$") }
+    \BLOCK{ set symbol = symbol[7:] }
+    \BLOCK{ set is_exempt = True }
 \BLOCK{ endif }
 \BLOCK{ set overall_quantity = entries|sum(attribute="quantity") }
 \BLOCK{ set overall_fees = round_decimal(entries|sum(attribute="fees"), 2) }
@@ -132,6 +135,23 @@
         new pool cost: £\VAR{ "{:,}".format(round_decimal(pool.new_pool_cost, 2)) }
         (£\VAR{ "{:,}".format(round_decimal(pool.new_pool_cost/pool.new_quantity, 2)) }/unit)%
     \BLOCK{ endif }.
+\BLOCK{ elif is_exempt } % if is_exempt
+    \BLOCK{ set overall_disposed = round_decimal(entries|sum(attribute="amount") + entries|sum(attribute="fees"), 2) }
+    \BLOCK{ set overall_gain = round_decimal(entries|sum(attribute="gain"), 2) }
+    \subsubsection*{
+        Exempt disposal: \VAR{ strip_zeros(overall_quantity) } units of \VAR{ symbol } for £\VAR{ "{:,}".format(overall_disposed) }
+        (£\VAR{ "{:,}".format(round_decimal(overall_disposed/overall_quantity, 2)) }/unit)%
+        \BLOCK{ if overall_fees > 0 }
+            , £\VAR{ "{:,}".format(overall_fees) } fees allowed as cost
+        \BLOCK{ endif }
+    }
+    \BLOCK{ if overall_gain > 0 -}
+        Gain is £\VAR{ "{:,}".format(overall_gain) }; the gain or loss is disregarded (exempt asset).
+    \BLOCK{ elif overall_gain == 0 }
+        Neither a gain nor a loss; the gain or loss is disregarded (exempt asset).
+    \BLOCK{ else }
+        Loss is £\VAR{ "{:,}".format(-overall_gain) }; the gain or loss is disregarded (exempt asset).
+    \BLOCK{ endif }
 \BLOCK{ endif }
 
 \BLOCK{ if not is_rename and not is_transfer_to_spouse }
@@ -154,6 +174,22 @@
     \BLOCK{ else }
         \mbox{loss: £\VAR{ "{:,}".format(round_decimal(-entry.gain, 2)) }.}
     \BLOCK{ endif }
+\BLOCK{ elif is_exempt }
+    \BLOCK{ if entry.quantity < overall_quantity }
+        disposal proceeds: £\VAR{ "{:,}".format(round_decimal(entry.amount + entry.fees, 2)) },
+    \BLOCK{ endif }
+    allowable
+    \BLOCK{ if entry.rule_type.name == "BED_AND_BREAKFAST" }
+        cost on \mbox{\VAR{ entry.bed_and_breakfast_date_index.strftime("%d %b %Y") }:}
+    \BLOCK{ else }
+        cost:
+    \BLOCK{ endif }
+    £\VAR{ "{:,}".format(round_decimal(entry.allowable_cost, 2)) },
+    \BLOCK{ if entry.gain > 0}
+        \mbox{disregarded gain: £\VAR{ "{:,}".format(round_decimal(entry.gain, 2)) }.}
+    \BLOCK{ else }
+        \mbox{disregarded loss: £\VAR{ "{:,}".format(round_decimal(-entry.gain, 2)) }.}
+    \BLOCK{ endif }
 \BLOCK{ elif is_spin_off }
     original cost of \VAR{ entry.spin_off.source }: £\VAR{ "{:,}".format(round_decimal(-entry.amount, 2))}, after spin-off: £\VAR{ "{:,}".format(round_decimal(entry.new_pool_cost, 2))}
 \BLOCK{ elif is_eri }
@@ -162,7 +198,7 @@
     actual cost: £\VAR{ "{:,}".format(round_decimal(-entry.amount, 2)) }.
 \BLOCK{ endif}
 
-\BLOCK{ if is_disposal }
+\BLOCK{ if is_disposal or is_exempt }
     Number of units left in the pool:
 \BLOCK{ else }
     Number of units in the pool:
@@ -271,6 +307,9 @@
 \subsection*{Total capital loss: £\VAR{ "{:,}".format(total_loss.value) }}
 \BLOCK{ if gift_loss.value > 0 }
 \subsection*{Losses on gifts, kept separate: £\VAR{ "{:,}".format(gift_loss.value) }}
+\BLOCK{ endif }
+\BLOCK{ if report.exempt_disposal_proceeds > 0 }
+\subsection*{Exempt disposals: £\VAR{ "{:,}".format(report.exempt_disposal_proceeds) }}
 \BLOCK{ endif }
 \subsection*{Total capital gain after loss: £\VAR{ "{:,}".format(total_gain.value - total_loss.value) }}
 \vspace{1em}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,17 @@ The following configuration files and options allow you to customize the calcula
     - This is your own unverified assertion. The calculator does not identify or validate gilts or
       [qualifying corporate bonds (QCBs)](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg53702),
       and QCB status cannot be inferred from a ticker or name.
-    - The override disregards both gains and losses on disposals.
+    - The override disregards both gains and losses on disposals. Do not use it where a disposal
+      can still produce a charge: disposing of a QCB acquired on a takeover or reorganisation can
+      bring a
+      [deferred gain](https://www.gov.uk/government/publications/share-reorganisations-company-takeovers-and-capital-gains-tax-hs285-self-assessment-helpsheet)
+      back into charge, and the profit on a
+      [deeply discounted security](https://www.gov.uk/hmrc-internal-manuals/savings-and-investment-manual/saim3010)
+      is taxable as income. Neither is calculated here.
+    - The per-disposal breakdown in the PDF applies the ordinary same-day, 30-day and Section 104
+      share identification rules. Those are not the identification rules HMRC gives for gilts, QCBs
+      and other relevant securities, so read the breakdown as workings for the quantities only. It
+      has no effect on the figures reported, because the gain or loss is disregarded.
     - Coupon and accrued interest remain taxable income. The calculator does not implement the
       [Accrued Income Scheme](https://www.gov.uk/government/publications/accrued-income-scheme-hs343-self-assessment-helpsheet).
     - The importers for [Freetrade](brokers/freetrade.md),
@@ -57,4 +67,7 @@ The following configuration files and options allow you to customize the calcula
       history has to be listed under both names.
     - A gift of a listed instrument is reported as an exempt disposal and does not also appear in the
       **Gifts at market value** section.
+    - Listing an instrument does not lift the restrictions on disposing of it in more than one way
+      on a single day. A sale and a gift to a connected person on the same day are still refused,
+      even though the loss they cannot apportion would be disregarded.
 <!-- dprint-ignore-end -->

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,3 +34,7 @@ The following configuration files and options allow you to customize the calcula
 - **Interest fund tickers.** Some bond funds and ETFs should be taxed as interest rather than
   dividends. Specify these funds via the `--interest-fund-tickers` CLI option, using a
   comma-separated list of ticker symbols.
+
+- **CGT-exempt tickers.** Disposals of UK gilts and qualifying corporate bonds (QCBs) are exempt
+  from Capital Gains Tax (TCGA 1992 s115). Specify these assets via the `--cgt-exempt-tickers` CLI
+  option, using a comma-separated list of ticker symbols.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@ The following configuration files and options allow you to customize the calcula
 
 ## Manual configuration files
 
+<!-- dprint-ignore-start -->
 - **Initial stock prices.** Required for special events like vesting, splits, or spin-offs when
   historical prices aren't available from your broker. Prices should be in USD.
   [`initial_prices.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_prices.csv)
@@ -39,20 +40,21 @@ The following configuration files and options allow you to customize the calcula
   with a comma-separated list only when you have established that each instrument is exempt under
   [TCGA 1992 s115](https://www.legislation.gov.uk/ukpga/1992/12/section/115).
 
-  - This is your own unverified assertion. The calculator does not identify or validate gilts or
-    [qualifying corporate bonds (QCBs)](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg53702),
-    and QCB status cannot be inferred from a ticker or name.
-  - The override disregards both gains and losses on disposals.
-  - Coupon and accrued interest remain taxable income. The calculator does not implement the
-    [Accrued Income Scheme](https://www.gov.uk/government/publications/accrued-income-scheme-hs343-self-assessment-helpsheet).
-  - The importers for [Freetrade](brokers/freetrade.md),
-    [Hargreaves Lansdown](brokers/hargreaves-lansdown.md) and
-    [Interactive Brokers](brokers/interactive-brokers.md) are documented as unvalidated for bonds
-    and gilts. This override does not validate them either.
-  - The override changes the capital gains calculation only. A coupon is reported in whichever box
-    its broker rows put it in. `--interest-fund-tickers` reports as foreign interest, so it is not a
-    fix for a UK gilt coupon. Check the interest and dividend figures against your own records.
-  - Matching uses the ticker at the disposal, so an instrument renamed part-way through the history
-    has to be listed under both names.
-  - A gift of a listed instrument is reported as an exempt disposal and does not also appear in the
-    **Gifts at market value** section.
+    - This is your own unverified assertion. The calculator does not identify or validate gilts or
+      [qualifying corporate bonds (QCBs)](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg53702),
+      and QCB status cannot be inferred from a ticker or name.
+    - The override disregards both gains and losses on disposals.
+    - Coupon and accrued interest remain taxable income. The calculator does not implement the
+      [Accrued Income Scheme](https://www.gov.uk/government/publications/accrued-income-scheme-hs343-self-assessment-helpsheet).
+    - The importers for [Freetrade](brokers/freetrade.md),
+      [Hargreaves Lansdown](brokers/hargreaves-lansdown.md) and
+      [Interactive Brokers](brokers/interactive-brokers.md) are documented as unvalidated for bonds
+      and gilts. This override does not validate them either.
+    - The override changes the capital gains calculation only. A coupon is reported in whichever box
+      its broker rows put it in. `--interest-fund-tickers` reports as foreign interest, so it is not a
+      fix for a UK gilt coupon. Check the interest and dividend figures against your own records.
+    - Matching uses the ticker at the disposal, so an instrument renamed part-way through the
+      history has to be listed under both names.
+    - A gift of a listed instrument is reported as an exempt disposal and does not also appear in the
+      **Gifts at market value** section.
+<!-- dprint-ignore-end -->

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,17 +37,22 @@ The following configuration files and options allow you to customize the calcula
 
 - **CGT-exempt instrument classification (advanced manual override).** Use `--cgt-exempt-tickers`
   with a comma-separated list only when you have established that each instrument is exempt under
-  TCGA 1992 s115. This is your own unverified assertion: the calculator does not identify or
-  validate gilts or qualifying corporate bonds (QCBs), and QCB status cannot be inferred from a
-  ticker or name. The override disregards both gains and losses on disposals. Coupon and accrued
-  interest remain taxable income; the calculator does not implement the Accrued Income Scheme. The
-  importers for [Freetrade](brokers/freetrade.md),
-  [Hargreaves Lansdown](brokers/hargreaves-lansdown.md) and
-  [Interactive Brokers](brokers/interactive-brokers.md) are documented as unvalidated for bonds and
-  gilts, and this override does not validate them either. It changes the capital gains calculation
-  only: a coupon is reported in whichever box its broker rows put it in, and
-  `--interest-fund-tickers` reports as foreign interest, so it is not a fix for a UK gilt coupon.
-  Check the interest and dividend figures against your own records. Matching is by the ticker as it
-  stands at the disposal, so an instrument renamed part-way through the history has to be listed
-  under both names. A gift of a listed instrument is reported as an exempt disposal and does not
-  also appear in the **Gifts at market value** section.
+  [TCGA 1992 s115](https://www.legislation.gov.uk/ukpga/1992/12/section/115).
+
+  - This is your own unverified assertion. The calculator does not identify or validate gilts or
+    [qualifying corporate bonds (QCBs)](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg53702),
+    and QCB status cannot be inferred from a ticker or name.
+  - The override disregards both gains and losses on disposals.
+  - Coupon and accrued interest remain taxable income. The calculator does not implement the
+    [Accrued Income Scheme](https://www.gov.uk/government/publications/accrued-income-scheme-hs343-self-assessment-helpsheet).
+  - The importers for [Freetrade](brokers/freetrade.md),
+    [Hargreaves Lansdown](brokers/hargreaves-lansdown.md) and
+    [Interactive Brokers](brokers/interactive-brokers.md) are documented as unvalidated for bonds
+    and gilts. This override does not validate them either.
+  - The override changes the capital gains calculation only. A coupon is reported in whichever box
+    its broker rows put it in. `--interest-fund-tickers` reports as foreign interest, so it is not a
+    fix for a UK gilt coupon. Check the interest and dividend figures against your own records.
+  - Matching uses the ticker at the disposal, so an instrument renamed part-way through the history
+    has to be listed under both names.
+  - A gift of a listed instrument is reported as an exempt disposal and does not also appear in the
+    **Gifts at market value** section.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,19 @@ The following configuration files and options allow you to customize the calcula
   dividends. Specify these funds via the `--interest-fund-tickers` CLI option, using a
   comma-separated list of ticker symbols.
 
-- **CGT-exempt tickers.** Disposals of UK gilts and qualifying corporate bonds (QCBs) are exempt
-  from Capital Gains Tax (TCGA 1992 s115). Specify these assets via the `--cgt-exempt-tickers` CLI
-  option, using a comma-separated list of ticker symbols.
+- **CGT-exempt instrument classification (advanced manual override).** Use `--cgt-exempt-tickers`
+  with a comma-separated list only when you have established that each instrument is exempt under
+  TCGA 1992 s115. This is your own unverified assertion: the calculator does not identify or
+  validate gilts or qualifying corporate bonds (QCBs), and QCB status cannot be inferred from a
+  ticker or name. The override disregards both gains and losses on disposals. Coupon and accrued
+  interest remain taxable income; the calculator does not implement the Accrued Income Scheme. The
+  importers for [Freetrade](brokers/freetrade.md),
+  [Hargreaves Lansdown](brokers/hargreaves-lansdown.md) and
+  [Interactive Brokers](brokers/interactive-brokers.md) are documented as unvalidated for bonds and
+  gilts, and this override does not validate them either. It changes the capital gains calculation
+  only: a coupon is reported in whichever box its broker rows put it in, and
+  `--interest-fund-tickers` reports as foreign interest, so it is not a fix for a UK gilt coupon.
+  Check the interest and dividend figures against your own records. Matching is by the ticker as it
+  stands at the disposal, so an instrument renamed part-way through the history has to be listed
+  under both names. A gift of a listed instrument is reported as an exempt disposal and does not
+  also appear in the **Gifts at market value** section.

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -719,6 +719,60 @@ def test_interest_fund_tickers_empty_items_filtered() -> None:
     assert args.interest_fund_tickers == ["VGOV", "VBMFX"]
 
 
+def test_cgt_exempt_tickers_single() -> None:
+    """Test that a single exempt ticker is parsed correctly."""
+    parser = create_parser()
+
+    args = parser.parse_args(["--cgt-exempt-tickers", "T26"])
+
+    assert args.cgt_exempt_tickers == ["T26"]
+
+
+def test_cgt_exempt_tickers_multiple() -> None:
+    """Test that multiple exempt tickers are parsed correctly."""
+    parser = create_parser()
+
+    args = parser.parse_args(["--cgt-exempt-tickers", "T26,TN28,TR32"])
+
+    assert args.cgt_exempt_tickers == ["T26", "TN28", "TR32"]
+
+
+def test_cgt_exempt_tickers_with_spaces() -> None:
+    """Test that exempt tickers with spaces are trimmed correctly."""
+    parser = create_parser()
+
+    args = parser.parse_args(["--cgt-exempt-tickers", " T26 , TN28 , TR32 "])
+
+    assert args.cgt_exempt_tickers == ["T26", "TN28", "TR32"]
+
+
+def test_cgt_exempt_tickers_lowercase() -> None:
+    """Test that lowercase exempt tickers are converted to uppercase."""
+    parser = create_parser()
+
+    args = parser.parse_args(["--cgt-exempt-tickers", "t26,tn28"])
+
+    assert args.cgt_exempt_tickers == ["T26", "TN28"]
+
+
+def test_cgt_exempt_tickers_empty_default() -> None:
+    """Test that default is an empty list when not specified."""
+    parser = create_parser()
+
+    args = parser.parse_args([])
+
+    assert args.cgt_exempt_tickers == []
+
+
+def test_cgt_exempt_tickers_empty_items_filtered() -> None:
+    """Test that empty items (e.g., trailing commas) are filtered out."""
+    parser = create_parser()
+
+    args = parser.parse_args(["--cgt-exempt-tickers", "T26,,TN28,"])
+
+    assert args.cgt_exempt_tickers == ["T26", "TN28"]
+
+
 def test_existing_file_or_stdin_type_accepts_stdin() -> None:
     """Ensure existing_file_or_stdin_type returns STDIN_PATH when passed '-'."""
     assert existing_file_or_stdin_type("-") == STDIN_PATH

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -72,7 +72,10 @@ def get_report(
 
 
 def create_calculator(
-    *, tax_year: int, balance_check: bool = True
+    *,
+    tax_year: int,
+    balance_check: bool = True,
+    cgt_exempt_tickers: list[str] | None = None,
 ) -> CapitalGainsCalculator:
     """Create a calculator with standard test configuration.
 
@@ -93,6 +96,7 @@ def create_calculator(
         SpinOffHandler(),
         InitialPrices(),
         interest_fund_tickers=[],
+        cgt_exempt_tickers=cgt_exempt_tickers,
         balance_check=balance_check,
     )
 

--- a/tests/general/test_cgt_exempt.py
+++ b/tests/general/test_cgt_exempt.py
@@ -8,12 +8,11 @@ import logging
 import os
 from pathlib import Path
 import re
-import shutil
 import subprocess
 
 import pytest
 
-from cgt_calc.model import ActionType
+from cgt_calc.model import ActionType, RuleType
 from cgt_calc.render_latex import render_pdf
 from tests.utils import build_cmd, report_path, stderr_alerts
 
@@ -45,16 +44,15 @@ def test_exempt_disposal_at_gain_excluded_from_capital_gain() -> None:
     assert report.taxable_gain() == Decimal(0)
     assert report.exempt_disposal_count == 1
     assert report.exempt_disposal_proceeds == Decimal(12000)
-    assert report.exempt_disposals == 1
-    assert report.exempt_proceeds == Decimal(12000)
 
     assert "exempt$T26" in report.calculation_log[SELL_DATE]
     assert "sell$T26" not in report.calculation_log[SELL_DATE]
 
     report_str = str(report)
-    assert "Exempt disposals:   £12,000.00" in report_str
-    assert "Gain:                    £0.00" in report_str
-    assert "Total gain:              £0.00" in report_str
+    assert "Exempt disposals:                  1" in report_str
+    assert "Exempt disposal proceeds: £12,000.00" in report_str
+    assert "Gain:                          £0.00" in report_str
+    assert "Total gain:                    £0.00" in report_str
 
 
 def test_exempt_disposal_at_loss_excluded_from_capital_loss() -> None:
@@ -76,8 +74,9 @@ def test_exempt_disposal_at_loss_excluded_from_capital_loss() -> None:
     assert report1.exempt_disposal_proceeds == Decimal(8000)
 
     report_str = str(report1)
-    assert "Loss:                   £0.00" in report_str
-    assert "Exempt disposals:   £8,000.00" in report_str
+    assert "Loss:                         £0.00" in report_str
+    assert "Exempt disposals:                 1" in report_str
+    assert "Exempt disposal proceeds: £8,000.00" in report_str
 
     # In a subsequent tax year with a chargeable gain, verify no allowable loss carried forward
     next_year_buy = datetime.date(2025, 5, 1)
@@ -123,12 +122,12 @@ def test_mixed_portfolio_chargeable_and_exempt() -> None:
     assert report.exempt_disposal_proceeds == Decimal(12000)
 
     report_str = str(report)
-    assert "Disposals:                   1" in report_str
-    assert "Disposal proceeds:   £1,500.00" in report_str
-    assert "Allowable costs:     £1,000.00" in report_str
-    assert "Gain:                  £500.00" in report_str
-    assert "Exempt disposals:   £12,000.00" in report_str
-    assert "Total gain:            £500.00" in report_str
+    assert "Disposals:                         1" in report_str
+    assert "Disposal proceeds:         £1,500.00" in report_str
+    assert "Allowable costs:           £1,000.00" in report_str
+    assert "Gain:                        £500.00" in report_str
+    assert "Exempt disposal proceeds: £12,000.00" in report_str
+    assert "Total gain:                  £500.00" in report_str
 
 
 def test_exempt_holding_still_present_in_year_end_portfolio() -> None:
@@ -152,6 +151,71 @@ def test_exempt_holding_still_present_in_year_end_portfolio() -> None:
 
     report_str = str(report)
     assert "T26: 60.00, £6,000.00" in report_str
+
+
+def test_exempt_disposal_uses_same_day_matching() -> None:
+    """Same-day matching still runs, but its gain is disregarded."""
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "T26", 100, 100, 0, -10000, GBP),
+        transaction(BUY_DATE, ActionType.SELL, "T26", 100, 120, 0, 12000, GBP),
+    ]
+    report = get_report(
+        create_calculator(
+            tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=["T26"]
+        ),
+        transactions,
+    )
+
+    assert [
+        entry.rule_type for entry in report.calculation_log[BUY_DATE]["exempt$T26"]
+    ] == [RuleType.SAME_DAY]
+    assert report.capital_gain == report.capital_loss == Decimal(0)
+    assert report.exempt_disposal_proceeds == Decimal(12000)
+
+
+def test_exempt_disposal_uses_bed_and_breakfast_matching() -> None:
+    """Thirty-day matching still runs, but its gain is disregarded."""
+    repurchase_date = SELL_DATE + datetime.timedelta(days=10)
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "T26", 100, 100, 0, -10000, GBP),
+        transaction(SELL_DATE, ActionType.SELL, "T26", 100, 120, 0, 12000, GBP),
+        transaction(repurchase_date, ActionType.BUY, "T26", 100, 110, 0, -11000, GBP),
+    ]
+    report = get_report(
+        create_calculator(
+            tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=["T26"]
+        ),
+        transactions,
+    )
+
+    assert [
+        entry.rule_type for entry in report.calculation_log[SELL_DATE]["exempt$T26"]
+    ] == [RuleType.BED_AND_BREAKFAST]
+    assert report.capital_gain == report.capital_loss == Decimal(0)
+    assert report.exempt_disposal_proceeds == Decimal(12000)
+
+
+def test_exempt_ticker_income_is_retained() -> None:
+    """The override disregards CGT only, leaving taxable income in the report."""
+    income_date = datetime.date(2024, 7, 1)
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "T26", 100, 100, 0, -10000, GBP),
+        transaction(income_date, ActionType.DIVIDEND, "T26", amount=250, currency=GBP),
+        transaction(income_date, ActionType.INTEREST, "T26", amount=40, currency=GBP),
+        transaction(SELL_DATE, ActionType.SELL, "T26", 100, 120, 0, 12000, GBP),
+    ]
+    report = get_report(
+        create_calculator(
+            tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=["T26"]
+        ),
+        transactions,
+    )
+
+    assert report.capital_gain == report.capital_loss == Decimal(0)
+    assert report.total_dividends_amount() == Decimal(250)
+    assert report.total_uk_interest == Decimal(40)
+    assert "dividend$T26" in report.calculation_log_yields[income_date]
+    assert "interestUK$Testing" in report.calculation_log_yields[income_date]
 
 
 def test_unmatched_ticker_warning(caplog: pytest.LogCaptureFixture) -> None:
@@ -224,18 +288,67 @@ def test_pdf_report_rendering_exempt_disposal(tmp_path: Path) -> None:
     source_flat = re.sub(r"\s+", " ", source)
 
     # Check per-disposal subsection
-    assert "Exempt disposal: 100 units of T26 for £12,000" in source_flat
+    assert "Exempt disposal: 100 units of T26 valued at £12,000" in source_flat
     assert "the gain or loss is disregarded" in source_flat
+    # The cost label carries its colon like the chargeable branch does: no
+    # stray space in front of it, and on a bed-and-breakfast line the date and
+    # its colon stay in one \mbox so they cannot be split across lines.
+    assert "cost used for this illustrative calculation: £10,000" in source_flat
+    assert "not allowable deductions against other gains" in source_flat
 
     # Check Overall section line
-    assert "Exempt disposals: £12,000" in source_flat
+    assert "Number of exempt disposals: 1" in source_flat
+    assert "Total exempt disposal proceeds: £12,000" in source_flat
     assert "Number of disposals: 0" in source_flat
 
-    if shutil.which("pdflatex") is not None:
-        pdf_path = tmp_path / "actual_report.pdf"
-        render_pdf(report, pdf_path, skip_pdflatex=False)
-        assert pdf_path.exists()
-        assert pdf_path.stat().st_size > 0
+
+def test_pdf_report_rendering_exempt_bed_and_breakfast(tmp_path: Path) -> None:
+    """A bed-and-breakfast exempt line keeps its match date and colon together."""
+    repurchase_date = SELL_DATE + datetime.timedelta(days=10)
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "T26", 100, 100, 0, -10000, GBP),
+        transaction(SELL_DATE, ActionType.SELL, "T26", 100, 120, 0, 12000, GBP),
+        transaction(repurchase_date, ActionType.BUY, "T26", 100, 110, 0, -11000, GBP),
+    ]
+    calc = create_calculator(
+        tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=["T26"]
+    )
+    report = get_report(calc, transactions)
+
+    render_pdf(report, tmp_path / "report.pdf", skip_pdflatex=True)
+    source_flat = re.sub(
+        r"\s+", " ", (tmp_path / "report.tex").read_text(encoding="utf-8")
+    )
+
+    assert (
+        "cost used for this illustrative calculation on "
+        "\\mbox{11 Sep 2024:} £11,000" in source_flat
+    )
+
+
+def test_pdf_reports_exempt_gift_with_neutral_valuation_wording(
+    tmp_path: Path,
+) -> None:
+    """An exempt gift is not described as receiving sale proceeds."""
+    gift_date = datetime.date(2024, 9, 1)
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "T26", 100, 100, 0, -10000, GBP),
+        transaction(gift_date, ActionType.GIFT, "T26", 100, 80, 0, None, GBP),
+    ]
+    report = get_report(
+        create_calculator(
+            tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=["T26"]
+        ),
+        transactions,
+    )
+
+    assert "exempt$T26" in report.calculation_log[gift_date]
+    assert "Gifts at market value" not in str(report)
+    render_pdf(report, tmp_path / "report.pdf", skip_pdflatex=True)
+    source_flat = re.sub(
+        r"\s+", " ", (tmp_path / "report.tex").read_text(encoding="utf-8")
+    )
+    assert "Exempt disposal: 100 units of T26 valued at £8,000.00" in source_flat
 
 
 def test_run_with_exempt_tickers(
@@ -267,7 +380,7 @@ def test_run_with_exempt_tickers(
             f"Integration test failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
     assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
-    assert "Exempt disposals:   £12,000.00" in result.stdout
+    assert "Exempt disposal proceeds: £12,000.00" in result.stdout
     if os.getenv("ENABLE_PDFLATEX"):
         pdf_file = Path(out_dir.rstrip("/")).with_suffix(".pdf")
         assert pdf_file.exists()

--- a/tests/general/test_cgt_exempt.py
+++ b/tests/general/test_cgt_exempt.py
@@ -1,0 +1,274 @@
+"""Tests for CGT-exempt assets (UK gilts, QCBs)."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+import logging
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import pytest
+
+from cgt_calc.model import ActionType
+from cgt_calc.render_latex import render_pdf
+from tests.utils import build_cmd, report_path, stderr_alerts
+
+from .calc_test_data import GBP, transaction
+from .test_calc import create_calculator, get_report
+
+TAX_YEAR = 2024
+BUY_DATE = datetime.date(2024, 5, 1)
+SELL_DATE = datetime.date(2024, 9, 1)
+
+
+def test_exempt_disposal_at_gain_excluded_from_capital_gain() -> None:
+    """Exempt disposal with a gain does not increase chargeable gain or proceeds."""
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "T26", 100, 100, 0, -10000, GBP),
+        transaction(SELL_DATE, ActionType.SELL, "T26", 100, 120, 0, 12000, GBP),
+    ]
+    calc = create_calculator(
+        tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=["T26"]
+    )
+    report = get_report(calc, transactions)
+
+    assert report.disposal_count == 0
+    assert report.disposal_proceeds == Decimal(0)
+    assert report.allowable_costs == Decimal(0)
+    assert report.capital_gain == Decimal(0)
+    assert report.capital_loss == Decimal(0)
+    assert report.total_gain() == Decimal(0)
+    assert report.taxable_gain() == Decimal(0)
+    assert report.exempt_disposal_count == 1
+    assert report.exempt_disposal_proceeds == Decimal(12000)
+    assert report.exempt_disposals == 1
+    assert report.exempt_proceeds == Decimal(12000)
+
+    assert "exempt$T26" in report.calculation_log[SELL_DATE]
+    assert "sell$T26" not in report.calculation_log[SELL_DATE]
+
+    report_str = str(report)
+    assert "Exempt disposals:   £12,000.00" in report_str
+    assert "Gain:                    £0.00" in report_str
+    assert "Total gain:              £0.00" in report_str
+
+
+def test_exempt_disposal_at_loss_excluded_from_capital_loss() -> None:
+    """Exempt disposal with a loss is excluded from capital_loss and not carried forward."""
+    transactions_year1 = [
+        transaction(BUY_DATE, ActionType.BUY, "T26", 100, 100, 0, -10000, GBP),
+        transaction(SELL_DATE, ActionType.SELL, "T26", 100, 80, 0, 8000, GBP),
+    ]
+    calc1 = create_calculator(
+        tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=["T26"]
+    )
+    report1 = get_report(calc1, transactions_year1)
+
+    assert report1.capital_gain == Decimal(0)
+    assert report1.capital_loss == Decimal(0)
+    assert report1.total_gain() == Decimal(0)
+    assert report1.taxable_gain() == Decimal(0)
+    assert report1.exempt_disposal_count == 1
+    assert report1.exempt_disposal_proceeds == Decimal(8000)
+
+    report_str = str(report1)
+    assert "Loss:                   £0.00" in report_str
+    assert "Exempt disposals:   £8,000.00" in report_str
+
+    # In a subsequent tax year with a chargeable gain, verify no allowable loss carried forward
+    next_year_buy = datetime.date(2025, 5, 1)
+    next_year_sell = datetime.date(2025, 9, 1)
+    transactions_year2 = [
+        *transactions_year1,
+        transaction(next_year_buy, ActionType.BUY, "FOO", 50, 10, 0, -500, GBP),
+        transaction(next_year_sell, ActionType.SELL, "FOO", 50, 20, 0, 1000, GBP),
+    ]
+    calc2 = create_calculator(
+        tax_year=2025, balance_check=False, cgt_exempt_tickers=["T26"]
+    )
+    report2 = get_report(calc2, transactions_year2)
+
+    assert report2.capital_gain == Decimal(500)
+    assert report2.capital_loss == Decimal(0)
+    assert report2.total_gain() == Decimal(500)
+
+
+def test_mixed_portfolio_chargeable_and_exempt() -> None:
+    """Chargeable disposal alongside an exempt disposal is completely unaffected."""
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "T26", 100, 100, 0, -10000, GBP),
+        transaction(BUY_DATE, ActionType.BUY, "FOO", 50, 20, 0, -1000, GBP),
+        transaction(SELL_DATE, ActionType.SELL, "T26", 100, 120, 0, 12000, GBP),
+        transaction(SELL_DATE, ActionType.SELL, "FOO", 50, 30, 0, 1500, GBP),
+    ]
+    calc = create_calculator(
+        tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=["T26"]
+    )
+    report = get_report(calc, transactions)
+
+    # Only the FOO disposal should be in chargeable totals
+    assert report.disposal_count == 1
+    assert report.disposal_proceeds == Decimal(1500)
+    assert report.allowable_costs == Decimal(1000)
+    assert report.capital_gain == Decimal(500)
+    assert report.capital_loss == Decimal(0)
+    assert report.total_gain() == Decimal(500)
+
+    # T26 disposal should be in exempt totals
+    assert report.exempt_disposal_count == 1
+    assert report.exempt_disposal_proceeds == Decimal(12000)
+
+    report_str = str(report)
+    assert "Disposals:                   1" in report_str
+    assert "Disposal proceeds:   £1,500.00" in report_str
+    assert "Allowable costs:     £1,000.00" in report_str
+    assert "Gain:                  £500.00" in report_str
+    assert "Exempt disposals:   £12,000.00" in report_str
+    assert "Total gain:            £500.00" in report_str
+
+
+def test_exempt_holding_still_present_in_year_end_portfolio() -> None:
+    """Remaining exempt holding is still pooled and present in the year-end portfolio."""
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "T26", 100, 100, 0, -10000, GBP),
+        transaction(SELL_DATE, ActionType.SELL, "T26", 40, 110, 0, 4400, GBP),
+    ]
+    calc = create_calculator(
+        tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=["T26"]
+    )
+    report = get_report(calc, transactions)
+
+    assert report.exempt_disposal_count == 1
+    assert report.exempt_disposal_proceeds == Decimal(4400)
+
+    positions = {entry.symbol: entry for entry in report.portfolio}
+    assert "T26" in positions
+    assert positions["T26"].quantity == Decimal(60)
+    assert positions["T26"].amount == Decimal(6000)
+
+    report_str = str(report)
+    assert "T26: 60.00, £6,000.00" in report_str
+
+
+def test_unmatched_ticker_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A ticker passed to --cgt-exempt-tickers with no transactions produces a warning."""
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "T26", 100, 100, 0, -10000, GBP),
+        transaction(SELL_DATE, ActionType.SELL, "T26", 100, 110, 0, 11000, GBP),
+    ]
+    calc = create_calculator(
+        tax_year=TAX_YEAR,
+        balance_check=False,
+        cgt_exempt_tickers=["MISSING", "T26"],
+    )
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
+        get_report(calc, transactions)
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "MISSING" in msg and "not found in acquisitions or disposals" in msg
+        for msg in warnings
+    )
+    assert not any("T26" in msg for msg in warnings)
+
+
+def test_case_insensitive_matching() -> None:
+    """Matching is case-insensitive for symbols and command-line tickers."""
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "t26", 100, 100, 0, -10000, GBP),
+        transaction(SELL_DATE, ActionType.SELL, "t26", 100, 120, 0, 12000, GBP),
+    ]
+    calc = create_calculator(
+        tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=["T26"]
+    )
+    report = get_report(calc, transactions)
+
+    assert report.disposal_count == 0
+    assert report.capital_gain == Decimal(0)
+    assert report.exempt_disposal_count == 1
+    assert report.exempt_disposal_proceeds == Decimal(12000)
+
+
+def test_zero_exempt_disposals_hidden_in_terminal_summary() -> None:
+    """When there are no exempt disposals, the Exempt disposals line is omitted."""
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "FOO", 50, 20, 0, -1000, GBP),
+        transaction(SELL_DATE, ActionType.SELL, "FOO", 50, 30, 0, 1500, GBP),
+    ]
+    calc_no_exempt = create_calculator(
+        tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=[]
+    )
+    report = get_report(calc_no_exempt, transactions)
+
+    assert report.exempt_disposal_proceeds == Decimal(0)
+    assert "Exempt disposals" not in str(report)
+
+
+def test_pdf_report_rendering_exempt_disposal(tmp_path: Path) -> None:
+    """PDF report contains per-disposal subsection stating amount and that gain/loss is disregarded."""
+    transactions = [
+        transaction(BUY_DATE, ActionType.BUY, "T26", 100, 100, 0, -10000, GBP),
+        transaction(SELL_DATE, ActionType.SELL, "T26", 100, 120, 0, 12000, GBP),
+    ]
+    calc = create_calculator(
+        tax_year=TAX_YEAR, balance_check=False, cgt_exempt_tickers=["T26"]
+    )
+    report = get_report(calc, transactions)
+
+    render_pdf(report, tmp_path / "report.pdf", skip_pdflatex=True)
+    source = (tmp_path / "report.tex").read_text(encoding="utf-8")
+    source_flat = re.sub(r"\s+", " ", source)
+
+    # Check per-disposal subsection
+    assert "Exempt disposal: 100 units of T26 for £12,000" in source_flat
+    assert "the gain or loss is disregarded" in source_flat
+
+    # Check Overall section line
+    assert "Exempt disposals: £12,000" in source_flat
+    assert "Number of disposals: 0" in source_flat
+
+    if shutil.which("pdflatex") is not None:
+        pdf_path = tmp_path / "actual_report.pdf"
+        render_pdf(report, pdf_path, skip_pdflatex=False)
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 0
+
+
+def test_run_with_exempt_tickers(
+    request: pytest.FixtureRequest, tmp_path: Path
+) -> None:
+    """Run with exempt tickers generates expected terminal report and PDF."""
+    raw_file = tmp_path / "raw_transactions.csv"
+    raw_file.write_text(
+        "date,action,symbol,quantity,price,fees,currency\n"
+        "2024-05-01,BUY,T26,100,100,0,GBP\n"
+        "2024-09-01,SELL,T26,100,120,0,GBP\n",
+        encoding="utf-8",
+    )
+    out_dir = report_path(request)
+    cmd = build_cmd(
+        "--year",
+        "2024",
+        "--raw-file",
+        str(raw_file),
+        "--cgt-exempt-tickers",
+        "T26",
+        "--no-balance-check",
+        "--output",
+        out_dir,
+    )
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
+    if result.returncode:
+        pytest.fail(
+            f"Integration test failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    assert stderr_alerts(result.stderr) == [], "Unexpected stderr message"
+    assert "Exempt disposals:   £12,000.00" in result.stdout
+    if os.getenv("ENABLE_PDFLATEX"):
+        pdf_file = Path(out_dir.rstrip("/")).with_suffix(".pdf")
+        assert pdf_file.exists()
+        assert pdf_file.stat().st_size > 0


### PR DESCRIPTION
This adds the argument:

--cgt-exempt-tickers TICKER[,TICKER]

which is then excluded for CGT purposes (but retained for other purposes like interest). This is useful for UK Gilts and other qualifying bonds.