### PR TITLE
Drop the unread Vanguard source_file field

### DIFF
--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -216,7 +216,6 @@ class VanguardTransaction(BrokerTransaction):
 
     is_reversal: bool
     details_text: str
-    source_file: Path | None
 
     def __init__(
         self,
@@ -232,7 +231,6 @@ class VanguardTransaction(BrokerTransaction):
 
         date = datetime.datetime.strptime(row[CashColumn.DATE], "%d/%m/%Y").date()
         self.details_text, self.is_reversal = _strip_reversal(row[CashColumn.DETAILS])
-        self.source_file = file
         self.action = action_from_str(self.details_text, file)
         self.amount = _parse_decimal(row[CashColumn.AMOUNT], CashColumn.AMOUNT.value)
         self.symbol, self.quantity, self.price, self.currency = _parse_details(
@@ -284,7 +282,6 @@ class VanguardTransaction(BrokerTransaction):
         txn = object.__new__(cls)
         txn.is_reversal = is_reversal
         txn.details_text = ""
-        txn.source_file = None
         BrokerTransaction.__init__(
             txn,
             date,


### PR DESCRIPTION
`VanguardTransaction.source_file` was written in two places and read nowhere.

It was added in #773, which did read it: it was passed to `_parse_details(..., self.source_file)` to give parse errors provenance. That parameter was never used in the function body, so the field never did anything. #874 enabled ruff's `flake8-unused-arguments` rule, which removed the unused argument but could not see that the attribute feeding it had lost its only consumer, and #987 then had to widen the field to `Path | None` to drop a `type: ignore[assignment]`.

Nothing reads it indirectly either: no code uses `vars()`, `__dict__` or `asdict` on transactions, and although `BrokerTransaction` is a dataclass, the field is a bare annotation on the undecorated subclass, so `dataclasses.fields()` excludes it and it never reaches the generated `repr`.

The provenance it was meant to provide is already carried by `ParsingError`, which takes the file and row and is raised with both throughout this parser.