### PR TITLE
Parameterise the base parsers over their transaction type

### DIFF
--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -41,7 +41,7 @@ class BaseParser(ABC):
         """Load broker data from parsed arguments."""
 
 
-class BaseSingleFileParser(BaseParser):
+class BaseSingleFileParser[T: BrokerTransaction](BaseParser):
     """Parser for single transaction file."""
 
     arg_name: str
@@ -88,7 +88,9 @@ class BaseSingleFileParser(BaseParser):
         """Load broker data from parsed arguments."""
         file_path = getattr(args, cls.full_arg.replace("-", "_"))
         if file_path:
-            return cls.load_from_file(file_path)
+            # list is invariant, so widen explicitly rather than return list[T].
+            transactions: list[BrokerTransaction] = list(cls.load_from_file(file_path))
+            return transactions
         return []
 
     @classmethod
@@ -98,7 +100,7 @@ class BaseSingleFileParser(BaseParser):
         *,
         warn_on_empty: bool = True,
         show_parsing_msg: bool = True,
-    ) -> list[BrokerTransaction]:
+    ) -> list[T]:
         """Load broker data from file path."""
         if file_path == STDIN_PATH:
             if show_parsing_msg:
@@ -115,20 +117,16 @@ class BaseSingleFileParser(BaseParser):
 
     @classmethod
     @abstractmethod
-    def read_transactions(
-        cls, file: TextIO, file_path: Path
-    ) -> list[BrokerTransaction]:
+    def read_transactions(cls, file: TextIO, file_path: Path) -> list[T]:
         """Parse broker transactions from open file."""
 
     @classmethod
-    def post_process_transactions(
-        cls, transactions: list[BrokerTransaction]
-    ) -> list[BrokerTransaction]:
+    def post_process_transactions(cls, transactions: list[T]) -> list[T]:
         """Do any required post processing after loading the transactions."""
         return transactions
 
 
-class StandardCSVParser(BaseSingleFileParser):
+class StandardCSVParser[T: BrokerTransaction](BaseSingleFileParser[T]):
     """Base parser for CSV files with a fixed set of expected columns."""
 
     columns: ClassVar[set[str]]
@@ -149,7 +147,7 @@ class StandardCSVParser(BaseSingleFileParser):
 
     @classmethod
     @abstractmethod
-    def read_row(cls, row: dict[str, str], file_path: Path) -> BrokerTransaction | None:
+    def read_row(cls, row: dict[str, str], file_path: Path) -> T | None:
         """Read a single transaction from a row in the CSV."""
 
     @classmethod
@@ -159,9 +157,7 @@ class StandardCSVParser(BaseSingleFileParser):
 
     @classmethod
     @override
-    def read_transactions(
-        cls, file: TextIO, file_path: Path
-    ) -> list[BrokerTransaction]:
+    def read_transactions(cls, file: TextIO, file_path: Path) -> list[T]:
         """Read transactions from a CSV file."""
         reader = csv.DictReader(cls.pre_reading(file, file_path))
         if reader.fieldnames is None:
@@ -171,7 +167,7 @@ class StandardCSVParser(BaseSingleFileParser):
         cls._validate_header(reader.fieldnames, file_path)
         expected_col_count = len(reader.fieldnames)
 
-        transactions: list[BrokerTransaction] = []
+        transactions: list[T] = []
         saw_row = False
         # Row numbers are 1-based file lines; the header is line 1.
         for index, row in enumerate(reader, start=2):
@@ -209,7 +205,7 @@ class StandardCSVParser(BaseSingleFileParser):
         return transactions
 
 
-class BaseDirParser(BaseSingleFileParser):
+class BaseDirParser[T: BrokerTransaction](BaseSingleFileParser[T]):
     """Parser for loading all files within a directory."""
 
     glob_dir: str
@@ -252,13 +248,15 @@ class BaseDirParser(BaseSingleFileParser):
         """Load broker data from parsed arguments."""
         dir_path = getattr(args, cls.full_arg.replace("-", "_"))
         if dir_path:
-            return cls.load_from_dir(dir_path)
+            # list is invariant, so widen explicitly rather than return list[T].
+            transactions: list[BrokerTransaction] = list(cls.load_from_dir(dir_path))
+            return transactions
         return []
 
     @classmethod
-    def load_from_dir(cls, dir_path: Path) -> list[BrokerTransaction]:
+    def load_from_dir(cls, dir_path: Path) -> list[T]:
         """Load broker data from dir path."""
-        transactions: list[BrokerTransaction] = []
+        transactions: list[T] = []
         for file_path in sorted(dir_path.glob(cls.glob_dir, case_sensitive=False)):
             if cls.file_path_filter(file_path):
                 transactions += cls.load_from_file(file_path, warn_on_empty=False)
@@ -277,8 +275,6 @@ class BaseDirParser(BaseSingleFileParser):
 
     @classmethod
     @override
-    def post_process_transactions(
-        cls, transactions: list[BrokerTransaction]
-    ) -> list[BrokerTransaction]:
+    def post_process_transactions(cls, transactions: list[T]) -> list[T]:
         """Do any required post processing after loading all the transactions in the dir."""
         return transactions

--- a/cgt_calc/parsers/eri/raw.py
+++ b/cgt_calc/parsers/eri/raw.py
@@ -75,7 +75,7 @@ class ERIRaw(ERITransaction):
         )
 
 
-class ERIRawParser(BaseSingleFileParser):
+class ERIRawParser(BaseSingleFileParser[ERIRaw]):
     """Parser for ERI (Excess Reported Income) CSV data files."""
 
     arg_name = "eri-raw"
@@ -109,9 +109,7 @@ class ERIRawParser(BaseSingleFileParser):
 
     @classmethod
     @override
-    def read_transactions(
-        cls, file: TextIO, file_path: Path
-    ) -> list[BrokerTransaction]:
+    def read_transactions(cls, file: TextIO, file_path: Path) -> list[ERIRaw]:
         """Read ERI raw transactions from file."""
 
         lines = list(csv.reader(file))
@@ -123,7 +121,7 @@ class ERIRawParser(BaseSingleFileParser):
 
         ERIRawParser._validate_header(header, file_path, COLUMNS)
 
-        transactions: list[BrokerTransaction] = []
+        transactions: list[ERIRaw] = []
         for index, row in enumerate(lines[1:], start=2):
             try:
                 transactions.append(ERIRaw(header, row, file_path))

--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -244,7 +244,7 @@ def _dividend_tax_transaction(
     )
 
 
-class FreetradeParser(BaseSingleFileParser):
+class FreetradeParser(BaseSingleFileParser[BrokerTransaction]):
     """Parser for Freetrade transaction files."""
 
     arg_name = "freetrade"

--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -41,7 +41,9 @@ class HLPdfData:
     fees: Decimal
 
 
-class HargreavesLansdownParser(StandardCSVParser, BaseDirParser):
+class HargreavesLansdownParser(
+    StandardCSVParser[BrokerTransaction], BaseDirParser[BrokerTransaction]
+):
     """Parser for Hargreaves Lansdown transaction exports and contract note PDFs."""
 
     arg_name = "hl"

--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -195,7 +195,7 @@ class InteractiveBrokersTransaction(BrokerTransaction):
         )
 
 
-class InteractiveBrokersParser(StandardCSVParser):
+class InteractiveBrokersParser(StandardCSVParser[InteractiveBrokersTransaction]):
     """Parser for Interactive Brokers format transaction files."""
 
     arg_name = "interactive-brokers"
@@ -210,7 +210,9 @@ class InteractiveBrokersParser(StandardCSVParser):
 
     @classmethod
     @override
-    def read_row(cls, row: dict[str, str], file_path: Path) -> BrokerTransaction | None:
+    def read_row(
+        cls, row: dict[str, str], file_path: Path
+    ) -> InteractiveBrokersTransaction | None:
         """Read a single transaction from a row in the CSV."""
         return InteractiveBrokersTransaction(row, file_path)
 
@@ -256,8 +258,8 @@ class InteractiveBrokersParser(StandardCSVParser):
     @classmethod
     @override
     def post_process_transactions(
-        cls, transactions: list[BrokerTransaction]
-    ) -> list[BrokerTransaction]:
+        cls, transactions: list[InteractiveBrokersTransaction]
+    ) -> list[InteractiveBrokersTransaction]:
         """Sort transactions by date, buys and withheld tax last."""
         transactions.sort(key=cls._by_date_and_action)
         return transactions

--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -101,7 +101,9 @@ def _parse_decimal(row: dict[str, str], column: StrEnum) -> Decimal:
         ) from err
 
 
-class MSSBParser(StandardCSVParser, BaseDirParser):
+class MSSBParser(
+    StandardCSVParser[BrokerTransaction], BaseDirParser[BrokerTransaction]
+):
     """Morgan Stanley parser."""
 
     arg_name = "mssb"

--- a/cgt_calc/parsers/raw.py
+++ b/cgt_calc/parsers/raw.py
@@ -168,7 +168,7 @@ class RawTransaction(BrokerTransaction):
         )
 
 
-class RawParser(BaseSingleFileParser):
+class RawParser(BaseSingleFileParser[RawTransaction]):
     """Parser for RAW format transaction files."""
 
     arg_name = "raw"
@@ -206,9 +206,7 @@ class RawParser(BaseSingleFileParser):
 
     @classmethod
     @override
-    def read_transactions(
-        cls, file: TextIO, file_path: Path
-    ) -> list[BrokerTransaction]:
+    def read_transactions(cls, file: TextIO, file_path: Path) -> list[RawTransaction]:
         """Read Raw transactions from file."""
         lines = list(csv.reader(file))
 
@@ -227,7 +225,7 @@ class RawParser(BaseSingleFileParser):
                 file_path,
             )
 
-        transactions: list[BrokerTransaction] = []
+        transactions: list[RawTransaction] = []
         for index, row in enumerate(data_rows, start=start_index):
             try:
                 transactions.append(RawTransaction(row, file_path))

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -759,7 +759,7 @@ def _read_schwab_awards(
     return AwardPrices(award_prices=dict(initial_prices))
 
 
-class SchwabParser(BaseSingleFileParser):
+class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
     """Parser for Charles Schwab transaction files."""
 
     arg_name = "schwab"
@@ -804,7 +804,7 @@ class SchwabParser(BaseSingleFileParser):
     @override
     def read_transactions(
         cls, file: TextIO, file_path: Path
-    ) -> list[BrokerTransaction]:
+    ) -> list[SchwabTransaction]:
         """Read Schwab transactions from file."""
 
         lines = list(csv.reader(file))

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -877,7 +877,7 @@ class SchwabTransaction(BrokerTransaction):
             self.price = round_decimal(self.price / multiplier, ROUND_DIGITS)
 
 
-class SchwabEquityAwardsJSONParser(BaseSingleFileParser):
+class SchwabEquityAwardsJSONParser(BaseSingleFileParser[SchwabTransaction]):
     """Parser for Charles Schwab Equity Awards JSON files."""
 
     arg_name = "schwab-equity-award"
@@ -889,7 +889,7 @@ class SchwabEquityAwardsJSONParser(BaseSingleFileParser):
     @override
     def read_transactions(
         cls, file: TextIO, file_path: Path
-    ) -> list[BrokerTransaction]:
+    ) -> list[SchwabTransaction]:
         """Read Schwab Equity Awards transactions from JSON."""
         try:
             data = json.load(file, parse_float=Decimal, parse_int=Decimal)

--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -179,7 +179,7 @@ class RowIterator(Iterator[list[str]]):
         return self
 
 
-class SharesightParser(BaseDirParser):
+class SharesightParser(BaseDirParser[SharesightTransaction]):
     """Sharesight parser."""
 
     arg_name = "sharesight"
@@ -194,7 +194,7 @@ class SharesightParser(BaseDirParser):
     @override
     def read_transactions(
         cls, file: TextIO, file_path: Path
-    ) -> list[BrokerTransaction]:
+    ) -> list[SharesightTransaction]:
         """Parse Sharesight transactions from reports."""
         if file_path.match("Taxable Income Report*.csv", case_sensitive=False):
             return list(cls._parse_income_report(file, file_path))
@@ -206,8 +206,8 @@ class SharesightParser(BaseDirParser):
     @classmethod
     @override
     def post_process_transactions(
-        cls, transactions: list[BrokerTransaction]
-    ) -> list[BrokerTransaction]:
+        cls, transactions: list[SharesightTransaction]
+    ) -> list[SharesightTransaction]:
         """Sort transactions by date."""
         transactions.sort(key=lambda t: t.date)
         return transactions

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -428,7 +428,7 @@ class Trading212Transaction(BrokerTransaction):
         return hash(self.transaction_id)
 
 
-class Trading212Parser(BaseDirParser):
+class Trading212Parser(BaseDirParser[Trading212Transaction]):
     """Trading 212 parser."""
 
     arg_name = "trading212"
@@ -441,7 +441,7 @@ class Trading212Parser(BaseDirParser):
     @override
     def read_transactions(
         cls, file: TextIO, file_path: Path
-    ) -> list[BrokerTransaction]:
+    ) -> list[Trading212Transaction]:
         """Parse Trading 212 transactions from CSV file."""
         lines = list(csv.reader(file))
         if not lines:
@@ -449,7 +449,7 @@ class Trading212Parser(BaseDirParser):
         header = lines[0]
         cls._validate_header(header, file_path)
         lines = lines[1:]
-        transactions: list[BrokerTransaction] = []
+        transactions: list[Trading212Transaction] = []
         for index, row in enumerate(lines, start=2):
             try:
                 transactions.append(Trading212Transaction(header, row, file_path))
@@ -471,11 +471,9 @@ class Trading212Parser(BaseDirParser):
 
     @staticmethod
     def _by_date_and_action(
-        transaction: BrokerTransaction,
+        transaction: Trading212Transaction,
     ) -> tuple[datetime, bool]:
         """Sort by date and action type."""
-
-        assert isinstance(transaction, Trading212Transaction)
 
         # If there's a deposit in the same second as a buy
         # (happens with the referral award at least)
@@ -485,8 +483,8 @@ class Trading212Parser(BaseDirParser):
     @classmethod
     @override
     def post_process_transactions(
-        cls, transactions: list[BrokerTransaction]
-    ) -> list[BrokerTransaction]:
+        cls, transactions: list[Trading212Transaction]
+    ) -> list[Trading212Transaction]:
         """Remove duplicates and sort."""
         transactions = list(set(transactions))
         transactions.sort(key=cls._by_date_and_action)

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 import io
 import logging
 import re
-from typing import TYPE_CHECKING, ClassVar, Final, TextIO, cast, override
+from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
 
 from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
@@ -670,7 +670,7 @@ def _find_investment_match(
     return max(before, key=_investment_date) if before else None
 
 
-class VanguardParser(BaseSingleFileParser):
+class VanguardParser(BaseSingleFileParser[VanguardTransaction]):
     """Parser for Vanguard transaction files."""
 
     arg_name = "vanguard"
@@ -686,7 +686,7 @@ class VanguardParser(BaseSingleFileParser):
         *,
         warn_on_empty: bool = True,
         show_parsing_msg: bool = True,
-    ) -> list[BrokerTransaction]:
+    ) -> list[VanguardTransaction]:
         """Load a text CSV and report Excel or encoding mistakes clearly."""
         if file_path.suffix.casefold() in {".xls", ".xlsx", ".xlsm", ".xlsb"}:
             raise ParsingError(
@@ -724,7 +724,7 @@ class VanguardParser(BaseSingleFileParser):
     @override
     def read_transactions(
         cls, file: TextIO, file_path: Path
-    ) -> list[BrokerTransaction]:
+    ) -> list[VanguardTransaction]:
         """Read Vanguard transactions from exported transaction report file."""
         raw_text = file.read().removeprefix("\ufeff")
         delimiter = _detect_delimiter(raw_text)
@@ -817,4 +817,4 @@ class VanguardParser(BaseSingleFileParser):
             txn.enrich_details(matched_inv)
 
         transactions.sort(key=by_date_and_action)
-        return cast("list[BrokerTransaction]", transactions)
+        return transactions

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -9,10 +9,11 @@ import subprocess
 import pytest
 
 from cgt_calc.exceptions import ParsingError, SymbolMissingError
-from cgt_calc.model import ActionType, BrokerTransaction
+from cgt_calc.model import ActionType
 from cgt_calc.parsers.schwab import (
     AwardPrices,
     SchwabParser,
+    SchwabTransaction,
     _read_schwab_awards,
     action_from_str,
 )
@@ -237,7 +238,7 @@ def test_run_with_schwab_interest_tax_files(request: pytest.FixtureRequest) -> N
 SCHWAB_HEADER = "Date,Action,Symbol,Description,Price,Quantity,Fees & Comm,Amount\n"
 
 
-def _read(content: str) -> list[BrokerTransaction]:
+def _read(content: str) -> list[SchwabTransaction]:
     """Parse a Schwab CSV from a string."""
     return SchwabParser.read_transactions(
         io.StringIO(content), Path("transactions.csv")

--- a/tests/schwab/test_schwab_equity_award_json.py
+++ b/tests/schwab/test_schwab_equity_award_json.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from cgt_calc.exceptions import ParsingError
-from cgt_calc.model import ActionType, BrokerTransaction
+from cgt_calc.model import ActionType
 from cgt_calc.parsers import schwab_equity_award_json
 
 # ruff: noqa: SLF001 "Private member accessed"
@@ -304,7 +304,9 @@ def test_action_from_str_unknown() -> None:
         schwab_equity_award_json.action_from_str("Dance", Path("awards.json"))
 
 
-def _read_json(content: str) -> list[BrokerTransaction]:
+def _read_json(
+    content: str,
+) -> list[schwab_equity_award_json.SchwabTransaction]:
     """Parse Schwab equity award JSON from a string."""
     parser = schwab_equity_award_json.SchwabEquityAwardsJSONParser
     return parser.read_transactions(io.StringIO(content), Path("awards.json"))

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -26,13 +26,13 @@ from cgt_calc.parsers import schwab_equity_award_json
 from cgt_calc.parsers.schwab_equity_award_json import JsonRowType, split_multiplier
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
 FIXTURE = Path("tests/schwab/data/equity_award/nvda_synthetic.json")
 
 
 @pytest.fixture(name="transactions")
-def transactions_fixture() -> list[BrokerTransaction]:
+def transactions_fixture() -> list[schwab_equity_award_json.SchwabTransaction]:
     """Parse the synthetic NVDA portfolio."""
     return schwab_equity_award_json.SchwabEquityAwardsJSONParser().load_from_file(
         FIXTURE
@@ -40,7 +40,9 @@ def transactions_fixture() -> list[BrokerTransaction]:
 
 
 def on(
-    transactions: list[BrokerTransaction], date: datetime.date, action: ActionType
+    transactions: Sequence[BrokerTransaction],
+    date: datetime.date,
+    action: ActionType,
 ) -> BrokerTransaction:
     """Return the single transaction of that kind on that date."""
     found = [t for t in transactions if t.date == date and t.action == action]
@@ -245,7 +247,7 @@ def mutated(tmp_path: Path, change: Callable[[list[JsonRowType]], None]) -> Path
     return path
 
 
-def parse(path: Path) -> list[BrokerTransaction]:
+def parse(path: Path) -> list[schwab_equity_award_json.SchwabTransaction]:
     """Parse an export, whatever it contains."""
     return schwab_equity_award_json.SchwabEquityAwardsJSONParser().load_from_file(path)
 

--- a/tests/schwab/test_schwab_interest_tax.py
+++ b/tests/schwab/test_schwab_interest_tax.py
@@ -38,7 +38,7 @@ def test_schwab_interest_tax_without_symbol_is_account_level() -> None:
         interest_fund_tickers=[],
         balance_check=False,
     )
-    calculator.convert_to_hmrc_transactions(transactions)
+    calculator.convert_to_hmrc_transactions(list(transactions))
     report = calculator.calculate_capital_gain()
 
     assert report.total_foreign_interest == Decimal("2.94")

--- a/tests/vanguard/test_vanguard.py
+++ b/tests/vanguard/test_vanguard.py
@@ -487,12 +487,7 @@ def test_read_vanguard_reversed_fee_sale_is_enriched(tmp_path: Path) -> None:
 
     transactions = VanguardParser().load_from_file(vanguard_file)
 
-    assert all(isinstance(t, VanguardTransaction) for t in transactions)
-    by_reversal = {
-        transaction.is_reversal: transaction
-        for transaction in transactions
-        if isinstance(transaction, VanguardTransaction)
-    }
+    by_reversal = {transaction.is_reversal: transaction for transaction in transactions}
     # Each row takes its own quantity, so neither is enriched from the other.
     assert by_reversal[False].quantity == Decimal("1.391")
     assert by_reversal[True].quantity == Decimal("2.5")


### PR DESCRIPTION
`BaseSingleFileParser`, `StandardCSVParser` and `BaseDirParser` are now generic over the transaction type they produce, so each parser declares what it actually returns. `Trading212Parser._by_date_and_action` no longer needs `assert isinstance(transaction, Trading212Transaction)` — permanently unreachable, since `post_process_transactions` is only called with the parser's own rows — nor the `type: ignore[arg-type]` the assert replaced. Neither remains anywhere in `cgt_calc/parsers`.

Eight of the eleven parsers gain precise types: Raw, Sharesight, Schwab, Schwab equity awards, Vanguard, Interactive Brokers, ERI raw and Trading 212. Three cannot and are parameterised at `BrokerTransaction` for uniformity: Freetrade genuinely returns a mixed list (`FreetradeTransaction` rows plus bare `BrokerTransaction` rows for dividend withholding tax), while Hargreaves Lansdown and Morgan Stanley have no subclass and construct `BrokerTransaction` directly.

`BaseParser` stays non-generic, so the type parameter never escapes into the registry: `broker_registry.py` and `main.py` are unchanged. Because `list` is invariant, `load_from_args` widens explicitly in both bases; that is the only place production crosses the boundary, since the registry consumes `load_from_args`.

Test changes follow from the same invariance, in helpers that reach past `load_from_args` to `load_from_file`/`read_transactions`. `on()` now takes a covariant `Sequence`, one call widens for the calculator, and a Vanguard test drops an `isinstance` narrowing that the parser's own type now makes redundant.