### PR TITLE
List the Vanguard ISIN warning symbols as CSV fields

### DIFF
--- a/cgt_calc/parsers/broker_registry.py
+++ b/cgt_calc/parsers/broker_registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import csv
+import io
 import logging
 import sys
 from typing import TYPE_CHECKING, ClassVar
@@ -121,6 +123,20 @@ def _transaction_sort_key(
     return (transaction.date, order)
 
 
+def _as_csv_fields(symbols: list[str]) -> str:
+    """Render symbols the way the cache file has to spell them.
+
+    A Vanguard symbol falls back to the fund name, which can contain a comma
+    or a quote. The listed text is meant to be copied into the translation
+    CSV, so write it with the same module that reads the cache: each field
+    then survives the round trip verbatim, and a comma inside a name is
+    quoted rather than read as a separator.
+    """
+    buffer = io.StringIO()
+    csv.writer(buffer).writerow(symbols)
+    return buffer.getvalue().rstrip("\r\n")
+
+
 class BrokerRegistry:
     """Registry for all broker parsers."""
 
@@ -191,7 +207,7 @@ class BrokerRegistry:
                 "row listing every symbol it is known by: a row that leaves one "
                 "out replaces the existing mapping and can stop a later run. "
                 "See https://cgt-calc.uk/configuration/",
-                ", ".join(unmapped_vanguard_symbols),
+                _as_csv_fields(unmapped_vanguard_symbols),
                 location,
             )
         all_transactions += [

--- a/tests/general/test_broker_registry.py
+++ b/tests/general/test_broker_registry.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import csv
 import datetime
 from decimal import Decimal
+import io
 import logging
 from typing import TYPE_CHECKING
+
+import pytest
 
 from cgt_calc.args_parser import create_parser
 from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
@@ -16,8 +20,6 @@ from cgt_calc.parsers.vanguard import VanguardTransaction
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 
 def _vanguard_warning(caplog: pytest.LogCaptureFixture) -> str:
@@ -31,13 +33,14 @@ def _vanguard_warning(caplog: pytest.LogCaptureFixture) -> str:
     return warnings[0]
 
 
-def _write_vanguard_csv(tmp_path: Path) -> Path:
+def _write_vanguard_csv(tmp_path: Path, fund_name: str = "Foo Fund") -> Path:
     """Write a one-row Vanguard cash table whose symbol is a fund name."""
     vanguard_file = tmp_path / "vanguard.csv"
-    vanguard_file.write_text(
-        "Date,Details,Amount,Balance\n09/03/2022,Bought 10 Foo Fund,-100.00,0\n",
-        encoding="utf-8",
-    )
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(["Date", "Details", "Amount", "Balance"])
+    writer.writerow(["09/03/2022", f"Bought 10 {fund_name}", "-100.00", "0"])
+    vanguard_file.write_text(buffer.getvalue(), encoding="utf-8")
     return vanguard_file
 
 
@@ -76,6 +79,32 @@ def test_load_all_transactions_from_raw_file(
         "2022-11-14",
         "2023-02-09",
     ]
+
+
+@pytest.mark.parametrize(
+    "fund_name",
+    ["Foo Fund", "World ex-U.K. Equity Index Fund, Acc", 'Fund "A" Shares'],
+)
+def test_vanguard_warning_lists_symbols_as_usable_csv_fields(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, fund_name: str
+) -> None:
+    """List each symbol as text that can be pasted into the cache verbatim."""
+    vanguard_file = _write_vanguard_csv(tmp_path, fund_name)
+    args = create_parser().parse_args(
+        ["--year", "2023", "--vanguard-file", str(vanguard_file)]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        BrokerRegistry.load_all_transactions(
+            args, IsinConverter(isin_translation_file=tmp_path / "isin.csv")
+        )
+
+    warning = _vanguard_warning(caplog)
+    listed = warning.split("was found for: ")[1].split(". cgt-calc")[0]
+    # The user copies this into the cache, so reading it back as CSV has to
+    # return the symbol unchanged: a bare name that a comma would split, or
+    # a quote kept as part of the symbol, would never match.
+    assert next(csv.reader([f"IE00B50MZ724,{listed}"])) == ["IE00B50MZ724", fund_name]
 
 
 def test_vanguard_symbol_without_isin_mapping_warns(


### PR DESCRIPTION
The unmapped-symbol warning joined the symbols with `, `, and a Vanguard symbol falls back to the fund name whenever the details text has no parenthesised ticker. Those names contain commas, so the separator could occur inside a symbol.

The first attempt quoted each symbol with `repr`. That was wrong for this destination. The listed text is meant to be copied into the `--isin-translation-file` cache, which is a CSV, where a single quote has no quoting meaning. `'World ex-U.K. Equity Index Fund, Acc'` pasted into a row parses as three fields, and even `'Foo Fund'` keeps its apostrophes as part of the symbol and never matches — worse than the bare name it replaced.

The list is now written with `csv.writer`, the same module that reads the cache, so a field is quoted exactly when the format requires it and survives the round trip verbatim:

    Foo Fund,"World ex-U.K. Equity Index Fund, Acc",VWRP

The test asserts the round trip rather than the spelling: it parses `ISIN,<listed>` back with `csv.reader` and requires the symbol to come out unchanged, over a plain name, one containing a comma, and one containing double quotes. It fails on both the previous joins.