### PR TITLE
Give the Schwab equity award transaction a distinct name

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -148,6 +148,7 @@ SA106
 SalePrice
 Schwab
 Schwab's
+SchwabAwardTransaction
 SchwabTransaction
 Sharesight
 Sharesight's

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -592,11 +592,11 @@ def _check_disposal_units(
             )
 
 
-class SchwabTransaction(BrokerTransaction):
-    """Represent single Schwab transaction."""
+class SchwabAwardTransaction(BrokerTransaction):
+    """Represent a single Schwab equity award transaction."""
 
     def __init__(self, row: JsonRowType, file: Path, field_names: FieldNames) -> None:
-        """Create a new SchwabTransaction from a JSON row."""
+        """Create a new SchwabAwardTransaction from a JSON row."""
         names = field_names
         description = row[names.description]
         self.raw_action = row[names.action]
@@ -877,7 +877,7 @@ class SchwabTransaction(BrokerTransaction):
             self.price = round_decimal(self.price / multiplier, ROUND_DIGITS)
 
 
-class SchwabEquityAwardsJSONParser(BaseSingleFileParser[SchwabTransaction]):
+class SchwabEquityAwardsJSONParser(BaseSingleFileParser[SchwabAwardTransaction]):
     """Parser for Charles Schwab Equity Awards JSON files."""
 
     arg_name = "schwab-equity-award"
@@ -889,7 +889,7 @@ class SchwabEquityAwardsJSONParser(BaseSingleFileParser[SchwabTransaction]):
     @override
     def read_transactions(
         cls, file: TextIO, file_path: Path
-    ) -> list[SchwabTransaction]:
+    ) -> list[SchwabAwardTransaction]:
         """Read Schwab Equity Awards transactions from JSON."""
         try:
             data = json.load(file, parse_float=Decimal, parse_int=Decimal)
@@ -923,7 +923,7 @@ class SchwabEquityAwardsJSONParser(BaseSingleFileParser[SchwabTransaction]):
         _check_lapse_units(data[fields.transactions], file_path, fields)
 
         transactions = [
-            SchwabTransaction(transac, file_path, fields)
+            SchwabAwardTransaction(transac, file_path, fields)
             for transac in data[fields.transactions]
             # Journal and Wire Transfer move cash between accounts.
             #

--- a/tests/schwab/test_schwab_equity_award_json.py
+++ b/tests/schwab/test_schwab_equity_award_json.py
@@ -7,12 +7,16 @@ from decimal import Decimal
 import io
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType
 from cgt_calc.parsers import schwab_equity_award_json
+
+if TYPE_CHECKING:
+    from cgt_calc.parsers.schwab_equity_award_json import SchwabAwardTransaction
 
 # ruff: noqa: SLF001 "Private member accessed"
 
@@ -306,7 +310,7 @@ def test_action_from_str_unknown() -> None:
 
 def _read_json(
     content: str,
-) -> list[schwab_equity_award_json.SchwabTransaction]:
+) -> list[SchwabAwardTransaction]:
     """Parse Schwab equity award JSON from a string."""
     parser = schwab_equity_award_json.SchwabEquityAwardsJSONParser
     return parser.read_transactions(io.StringIO(content), Path("awards.json"))

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -23,7 +23,11 @@ import pytest
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType, BrokerTransaction
 from cgt_calc.parsers import schwab_equity_award_json
-from cgt_calc.parsers.schwab_equity_award_json import JsonRowType, split_multiplier
+from cgt_calc.parsers.schwab_equity_award_json import (
+    JsonRowType,
+    SchwabAwardTransaction,
+    split_multiplier,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -32,7 +36,7 @@ FIXTURE = Path("tests/schwab/data/equity_award/nvda_synthetic.json")
 
 
 @pytest.fixture(name="transactions")
-def transactions_fixture() -> list[schwab_equity_award_json.SchwabTransaction]:
+def transactions_fixture() -> list[SchwabAwardTransaction]:
     """Parse the synthetic NVDA portfolio."""
     return schwab_equity_award_json.SchwabEquityAwardsJSONParser().load_from_file(
         FIXTURE
@@ -247,7 +251,7 @@ def mutated(tmp_path: Path, change: Callable[[list[JsonRowType]], None]) -> Path
     return path
 
 
-def parse(path: Path) -> list[schwab_equity_award_json.SchwabTransaction]:
+def parse(path: Path) -> list[SchwabAwardTransaction]:
     """Parse an export, whatever it contains."""
     return schwab_equity_award_json.SchwabEquityAwardsJSONParser().load_from_file(path)
 


### PR DESCRIPTION
Two unrelated classes were both called `SchwabTransaction`: one in `schwab.py` for the CSV export, one in `schwab_equity_award_json.py` for the JSON awards file. They are not interchangeable — both carry `raw_action`, but only the awards transaction adds `acquired_nothing` and can populate `ambiguous_quantity`.

#1034 made the collision easier to hit by putting the name in a type parameter, so `BaseSingleFileParser[SchwabTransaction]` appeared in two files meaning different types. Nothing imported both, and the tests disambiguated by qualifying one and importing the other bare, but that was convention rather than anything enforced.

The awards class is now `SchwabAwardTransaction`. The CSV one keeps its name, since it is the one referenced from the most places. With the names distinct, the tests import the class directly instead of qualifying it through the module, and its docstring names what it actually represents.