### PR TITLE
Record where every transaction was read from

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -21,6 +21,7 @@ BrokerTransaction
 BSF
 BST
 calc
+CalculationEntry
 Center
 CG12920
 CG14530
@@ -38,13 +39,13 @@ CG52742
 CG59562
 cgt
 CMF5
-CRLF
 codepage
 codespell
 Colima
 colorama
 colorama's
 ConsoleUI
+CRLF
 csv
 CSVs
 CurrencyConverter
@@ -89,13 +90,14 @@ IsinConverter
 ISINs
 json
 Lansdown
-LF
 len
+LF
 LSE
 Luhn
 lychee
 markdown
 matchable
+matchings
 md
 MiKTeX
 MMM
@@ -129,6 +131,7 @@ python3
 rata
 regularMarketPrice
 reportable
+repr
 restkey
 restval
 roundings
@@ -137,6 +140,7 @@ RuntimeError
 RuntimeMode
 s105
 s106A
+s122
 s127
 s17
 s18
@@ -164,6 +168,7 @@ SpinOff
 SpinOffs
 SplitHistory
 sqrt
+ss126
 stderr
 stdin
 stdout
@@ -173,6 +178,7 @@ subrow
 tablefinder
 TCGA
 toml
+Trading212Column
 tranche's
 TransactionDetails
 transferor

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -25,6 +25,7 @@ from .util import (
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+    from pathlib import Path
 
 
 _ISIN_REGEX: Final = re.compile(r"^[A-Z]{2}[A-Z0-9]{9}[0-9]$")
@@ -275,6 +276,36 @@ class CalculationType(Enum):
     DISPOSAL = 2
 
 
+@dataclass(frozen=True)
+class TransactionSource:
+    """Where a transaction was read from.
+
+    ``index`` is the position the parser read this row at within one source
+    file, and it is what says which of two rows on one day came first. It is
+    not ``row``: a parser is free to emit rows in an order the file does not
+    use, and Freetrade does exactly that because its export is newest first.
+    ``row`` is the line the row came from, for pointing an error at it.
+
+    ``account`` is an opaque token for the boundary the user declared by
+    passing one file or one directory. It is calculation-local: it says that
+    two transactions were configured as one account, never which account, and
+    nothing about it may be read as a broker account identifier.
+    """
+
+    parser: str | None = None
+    account: str | None = None
+    file: Path | None = None
+    row: int | None = None
+    index: int | None = None
+    # The instant the export stated, where it states one at all.
+    timestamp: datetime.datetime | None = None
+    # Whether this source documents that rows sharing a date are in the order
+    # they happened. A hand-written RAW history says so; a broker export does
+    # not, and several parsers reorder their rows for the calculation's sake,
+    # so `index` says which row was read first and nothing more.
+    rows_in_time_order: bool = False
+
+
 @dataclass
 class BrokerTransaction:
     """Broker transaction data."""
@@ -298,6 +329,13 @@ class BrokerTransaction:
     # when the two cannot be told apart, so that whichever the user confirms
     # can settle it.
     ambiguous_quantity: Decimal | None = None
+    # Where this row was read from. Excluded from equality and from any
+    # __hash__: parsers deduplicate overlapping exports by comparing
+    # transactions, and a field that varies with the file would keep both
+    # copies of every row two exports share. Out of the repr too, which is
+    # printed whole in several errors and is about the transaction, not about
+    # which file on this machine it was read from.
+    source: TransactionSource | None = field(default=None, compare=False, repr=False)
 
     def __post_init__(self) -> None:
         """Validate BrokerTransaction data."""

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -205,15 +205,20 @@ class StandardCSVParser[T: BrokerTransaction](BaseSingleFileParser[T]):
         """Read a single transaction from a row in the CSV."""
 
     @classmethod
-    def pre_reading(cls, file: TextIO, file_path: Path) -> Iterable[str]:  # noqa: ARG003
-        """Do any preprocessing of the file before parsing the csv."""
-        return file
+    def pre_reading(
+        cls,
+        file: TextIO,
+        file_path: Path,  # noqa: ARG003
+    ) -> tuple[Iterable[str], int]:
+        """Return preprocessed lines and the physical line of their header."""
+        return file, 1
 
     @classmethod
     @override
     def read_transactions(cls, file: TextIO, file_path: Path) -> list[T]:
         """Read transactions from a CSV file."""
-        reader = csv.DictReader(cls.pre_reading(file, file_path))
+        lines, header_row = cls.pre_reading(file, file_path)
+        reader = csv.DictReader(lines)
         if reader.fieldnames is None:
             raise ParsingError(
                 file_path, f"{cls.pretty_name} {cls.format_name} doesn't have a header"
@@ -223,8 +228,7 @@ class StandardCSVParser[T: BrokerTransaction](BaseSingleFileParser[T]):
 
         transactions: list[T] = []
         saw_row = False
-        # Row numbers are 1-based file lines; the header is line 1.
-        for index, row in enumerate(reader, start=2):
+        for index, row in enumerate(reader, start=header_row + 1):
             saw_row = True
             try:
                 # A row with MORE fields than the header collects the extras

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 import argparse
 from collections.abc import Iterable, Sequence
 import csv
+import dataclasses
+import itertools
 import logging
 from pathlib import Path
 import sys
@@ -20,9 +22,22 @@ from cgt_calc.args_validators import (
 )
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
 from cgt_calc.logging import parsing_msg
-from cgt_calc.model import BrokerTransaction
+from cgt_calc.model import BrokerTransaction, TransactionSource
 
 LOGGER = logging.getLogger(__name__)
+
+_ACCOUNT_COUNTER = itertools.count(1)
+
+
+def next_account_token(name: str) -> str:
+    """Return a fresh opaque token for one declared account boundary.
+
+    Every separately configured input is a boundary of its own: one file
+    passed on its own, or one directory of exports. The token only says which
+    transactions were configured together, so it is deliberately not derived
+    from the path, which is a location on this machine rather than an account.
+    """
+    return f"{name} #{next(_ACCOUNT_COUNTER)}"
 
 
 class BaseParser(ABC):
@@ -49,6 +64,10 @@ class BaseSingleFileParser[T: BrokerTransaction](BaseParser):
     full_arg: str
     deprecated_flags: ClassVar[list[str]] = []
     encoding: str = "utf-8"
+    # Set only where the format documents that rows sharing a date are in the
+    # order they happened. It decides whether a row can be placed either side
+    # of a same-day share reorganisation without an exported time.
+    rows_in_time_order: ClassVar[bool] = False
 
     @override
     def __init_subclass__(cls, **kwargs: object) -> None:
@@ -100,8 +119,17 @@ class BaseSingleFileParser[T: BrokerTransaction](BaseParser):
         *,
         warn_on_empty: bool = True,
         show_parsing_msg: bool = True,
+        account: str | None = None,
     ) -> list[T]:
-        """Load broker data from file path."""
+        """Load broker data from file path.
+
+        ``account`` is the boundary this file was loaded under. A directory
+        load passes its own token so every file in it shares one boundary; a
+        file loaded on its own is a boundary of its own.
+        """
+        boundary = (
+            account if account is not None else next_account_token(cls.pretty_name)
+        )
         if file_path == STDIN_PATH:
             if show_parsing_msg:
                 parsing_msg("stdin")
@@ -113,7 +141,33 @@ class BaseSingleFileParser[T: BrokerTransaction](BaseParser):
                 transactions = cls.read_transactions(file, file_path)
         if not transactions and warn_on_empty:
             LOGGER.warning("No transactions detected in file %s", file_path)
+        cls.stamp_source(transactions, file_path, boundary)
         return cls.post_process_transactions(transactions)
+
+    @classmethod
+    def stamp_source(
+        cls,
+        transactions: list[T],
+        file_path: Path,
+        account: str,
+    ) -> None:
+        """Record where each transaction was read from.
+
+        Whatever the parser already put on the transaction is kept: it knows
+        the line a row came from and the instant the export stated, and this
+        only adds what it cannot know. ``index`` is the order the parser read
+        the rows in, which is what says which of two rows on one day came
+        first.
+        """
+        for index, transaction in enumerate(transactions):
+            transaction.source = dataclasses.replace(
+                transaction.source or TransactionSource(),
+                parser=cls.pretty_name,
+                account=account,
+                file=file_path,
+                index=index,
+                rows_in_time_order=cls.rows_in_time_order,
+            )
 
     @classmethod
     @abstractmethod
@@ -191,6 +245,7 @@ class StandardCSVParser[T: BrokerTransaction](BaseSingleFileParser[T]):
                     )
                 transaction = cls.read_row(row, file_path)
                 if transaction:
+                    transaction.source = TransactionSource(row=index)
                     transactions.append(transaction)
             except ParsingError as err:
                 err.add_row_context(index)
@@ -253,11 +308,18 @@ class BaseDirParser[T: BrokerTransaction](BaseSingleFileParser[T]):
 
     @classmethod
     def load_from_dir(cls, dir_path: Path) -> list[T]:
-        """Load broker data from dir path."""
+        """Load broker data from dir path.
+
+        One directory is one declared account boundary, so every file in it
+        is loaded under the same token.
+        """
+        account = next_account_token(cls.pretty_name)
         transactions: list[T] = []
         for file_path in sorted(dir_path.glob(cls.glob_dir, case_sensitive=False)):
             if cls.file_path_filter(file_path):
-                transactions += cls.load_from_file(file_path, warn_on_empty=False)
+                transactions += cls.load_from_file(
+                    file_path, warn_on_empty=False, account=account
+                )
         if not transactions:
             LOGGER.warning(
                 "No transactions detected in directory %s for broker %s",

--- a/cgt_calc/parsers/eri/raw.py
+++ b/cgt_calc/parsers/eri/raw.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 from cgt_calc.const import ERI_RESOURCE_FOLDER
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
-from cgt_calc.model import CurrencyCode, Isin
+from cgt_calc.model import CurrencyCode, Isin, TransactionSource
 from cgt_calc.parsers.base_parsers import BaseSingleFileParser
 from cgt_calc.resources import RESOURCES_PACKAGE
 
@@ -122,8 +122,10 @@ class ERIRawParser(BaseSingleFileParser[ERIRaw]):
         transactions: list[ERIRaw] = []
         for index, row in enumerate(lines[1:], start=2):
             try:
-                transactions.append(ERIRaw(header, row, file_path))
+                transaction = ERIRaw(header, row, file_path)
             except ParsingError as err:
                 err.add_row_context(index)
                 raise
+            transaction.source = TransactionSource(row=index)
+            transactions.append(transaction)
         return transactions

--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -206,6 +206,7 @@ class FreetradeTransaction(BrokerTransaction):
             # The export states its times in UTC, so a value without a zone
             # is read as UTC too rather than as the machine's local time.
             timestamp = timestamp.replace(tzinfo=UTC)
+        self.datetime = timestamp
 
         super().__init__(
             date=timestamp.astimezone(UK_TIMEZONE).date(),
@@ -291,11 +292,15 @@ class FreetradeParser(BaseSingleFileParser[BrokerTransaction]):
                 continue
             try:
                 transaction = FreetradeTransaction(row, file_path)
-                transaction.source = TransactionSource(row=index)
+                transaction.source = TransactionSource(
+                    row=index, timestamp=transaction.datetime
+                )
                 transactions.append(transaction)
                 dividend_tax = _dividend_tax_transaction(transaction, row)
                 if dividend_tax is not None:
-                    dividend_tax.source = TransactionSource(row=index)
+                    dividend_tax.source = TransactionSource(
+                        row=index, timestamp=transaction.datetime
+                    )
                     transactions.append(dividend_tax)
             except ParsingError as err:
                 err.add_row_context(index)

--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -15,7 +15,13 @@ from cgt_calc.exceptions import (
     UnsupportedBrokerActionError,
     UnsupportedBrokerCurrencyError,
 )
-from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode, Isin
+from cgt_calc.model import (
+    ActionType,
+    BrokerTransaction,
+    CurrencyCode,
+    Isin,
+    TransactionSource,
+)
 
 from .base_parsers import BaseSingleFileParser
 
@@ -285,9 +291,11 @@ class FreetradeParser(BaseSingleFileParser[BrokerTransaction]):
                 continue
             try:
                 transaction = FreetradeTransaction(row, file_path)
+                transaction.source = TransactionSource(row=index)
                 transactions.append(transaction)
                 dividend_tax = _dividend_tax_transaction(transaction, row)
                 if dividend_tax is not None:
+                    dividend_tax.source = TransactionSource(row=index)
                     transactions.append(dividend_tax)
             except ParsingError as err:
                 err.add_row_context(index)

--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
+from itertools import chain
 from pathlib import Path
 import re
 from typing import ClassVar, TextIO, override
@@ -138,14 +139,12 @@ class HargreavesLansdownParser(
 
     @classmethod
     @override
-    def pre_reading(cls, file: TextIO, file_path: Path) -> Iterable[str]:
-        """Skip preamble lines until the 'Trade date' header is found."""
+    def pre_reading(cls, file: TextIO, file_path: Path) -> tuple[Iterable[str], int]:
+        """Skip the preamble and retain the header's physical line."""
         lines = iter(file)
-        for line in lines:
+        for row, line in enumerate(lines, start=1):
             if line.strip().startswith("Trade date"):
-                yield line
-                yield from lines
-                return
+                return chain([line], lines), row
 
         raise ParsingError(file_path, "Could not find the 'Trade date' header.")
 

--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -213,9 +213,11 @@ class InteractiveBrokersParser(StandardCSVParser[InteractiveBrokersTransaction])
 
     @classmethod
     @override
-    def pre_reading(cls, file: Iterable[str], file_path: Path) -> Iterable[str]:
+    def pre_reading(
+        cls, file: Iterable[str], file_path: Path
+    ) -> tuple[Iterable[str], int]:
         """Skip Statement and Summary sections. Transaction History is the important one."""
-        for line in file:
+        for row, line in enumerate(file, start=1):
             # Validate we're dealing with a GBP account
             if line.startswith("Summary,Data,Base Currency,"):
                 rows = line.split(",")
@@ -228,7 +230,7 @@ class InteractiveBrokersParser(StandardCSVParser[InteractiveBrokersTransaction])
                         f"Unexpected base currency: '{rows[3]}', only GBP is supported",
                     )
             if line.startswith("Transaction History"):
-                return chain([line], file)
+                return chain([line], file), row
         raise ParsingError(
             file_path,
             "Couldn't find Transaction History header, is this the right file?",

--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -128,13 +128,13 @@ class MSSBParser(
 
     @classmethod
     @override
-    def pre_reading(cls, file: TextIO, file_path: Path) -> Iterable[str]:
+    def pre_reading(cls, file: TextIO, file_path: Path) -> tuple[Iterable[str], int]:
         """Select the expected column set based on the report filename."""
         if cls._is_withdrawals_report(file_path):
             cls.columns = set(COLUMNS_WITHDRAWAL)
         else:
             cls.columns = set(COLUMNS_RELEASE)
-        return file
+        return file, 1
 
     @classmethod
     @override

--- a/cgt_calc/parsers/raw.py
+++ b/cgt_calc/parsers/raw.py
@@ -11,7 +11,12 @@ from typing import TYPE_CHECKING, ClassVar, Final, Literal, TextIO, overload, ov
 
 from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
-from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
+from cgt_calc.model import (
+    ActionType,
+    BrokerTransaction,
+    CurrencyCode,
+    TransactionSource,
+)
 
 from .base_parsers import BaseSingleFileParser
 
@@ -173,6 +178,9 @@ class RawParser(BaseSingleFileParser[RawTransaction]):
 
     arg_name = "raw"
     pretty_name = "RAW format"
+    # The format documents that rows for one date are written in the order
+    # they happened, each in the units in force at that point.
+    rows_in_time_order: ClassVar[bool] = True
     format_name = "CSV"
     deprecated_flags: ClassVar[list[str]] = ["--raw"]
 
@@ -228,10 +236,12 @@ class RawParser(BaseSingleFileParser[RawTransaction]):
         transactions: list[RawTransaction] = []
         for index, row in enumerate(data_rows, start=start_index):
             try:
-                transactions.append(RawTransaction(row, file_path))
+                transaction = RawTransaction(row, file_path)
             except ParsingError as err:
                 err.add_row_context(index)
                 raise
             except ValueError as err:
                 raise ParsingError(file_path, str(err), row_index=index) from err
+            transaction.source = TransactionSource(row=index)
+            transactions.append(transaction)
         return transactions

--- a/cgt_calc/parsers/raw.py
+++ b/cgt_calc/parsers/raw.py
@@ -179,7 +179,9 @@ class RawParser(BaseSingleFileParser[RawTransaction]):
     arg_name = "raw"
     pretty_name = "RAW format"
     # The format documents that rows for one date are written in the order
-    # they happened, each in the units in force at that point.
+    # they happened, each in the units in force at that point: see "The order
+    # of rows on one date" in docs/brokers/raw.md, which is what a user writing
+    # the file by hand is told to do. No broker export makes that promise.
     rows_in_time_order: ClassVar[bool] = True
     format_name = "CSV"
     deprecated_flags: ClassVar[list[str]] = ["--raw"]

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -23,7 +23,12 @@ from cgt_calc.exceptions import (
     UnexpectedRowCountError,
 )
 from cgt_calc.logging import parsing_msg
-from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
+from cgt_calc.model import (
+    ActionType,
+    BrokerTransaction,
+    CurrencyCode,
+    TransactionSource,
+)
 from cgt_calc.parsers.schwab_cusip_bonds import adjust_cusip_bond_price
 
 from .base_parsers import BaseSingleFileParser
@@ -844,6 +849,7 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
             except ValueError as err:
                 raise ParsingError(file_path, str(err), row_index=index) from err
 
+            transaction.source = TransactionSource(row=index)
             transactions.append(transaction)
         transactions = _unify_schwab_paired_transactions(transactions, file_path)
         transactions = _filter_cancelled_buy_transactions(transactions, file_path)

--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -17,7 +17,12 @@ from cgt_calc.exceptions import (
     ParsingError,
     UnexpectedColumnCountError,
 )
-from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
+from cgt_calc.model import (
+    ActionType,
+    BrokerTransaction,
+    CurrencyCode,
+    TransactionSource,
+)
 
 from .base_parsers import BaseDirParser
 
@@ -279,7 +284,7 @@ class SharesightParser(BaseDirParser[SharesightTransaction]):
     def _parse_dividend_payments(
         cls,
         schema: DividendSectionSchema,
-        rows: Iterator[list[str]],
+        rows: RowIterator,
         file: Path,
     ) -> Iterable[SharesightTransaction]:
         """Parse dividend payments from Sharesight data."""
@@ -350,6 +355,7 @@ class SharesightParser(BaseDirParser[SharesightTransaction]):
                 quantity=None,
                 price=None,
                 fees=Decimal(0),
+                source=TransactionSource(row=rows.line),
             )
 
             # Generate the tax as a separate transaction
@@ -365,11 +371,12 @@ class SharesightParser(BaseDirParser[SharesightTransaction]):
                     quantity=None,
                     price=None,
                     fees=Decimal(0),
+                    source=TransactionSource(row=rows.line),
                 )
 
     @classmethod
     def _parse_local_income(
-        cls, rows: Iterator[list[str]], file: Path
+        cls, rows: RowIterator, file: Path
     ) -> Iterable[SharesightTransaction]:
         """Parse Local Income section from Sharesight data."""
         for row in rows:
@@ -406,7 +413,7 @@ class SharesightParser(BaseDirParser[SharesightTransaction]):
 
     @classmethod
     def _parse_trades(
-        cls, header: list[str], rows: Iterator[list[str]], file: Path
+        cls, header: list[str], rows: RowIterator, file: Path
     ) -> Iterable[SharesightTransaction]:
         """Parse content in All Trades Report from Sharesight."""
         header_columns = cls._trade_header_columns(header)
@@ -501,6 +508,7 @@ class SharesightParser(BaseDirParser[SharesightTransaction]):
                 amount=amount,
                 currency=currency,
                 broker=broker,
+                source=TransactionSource(row=rows.line),
             )
 
             # Sharesight has no native support for stock activity, so use a string

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -12,7 +12,13 @@ from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
 
 from cgt_calc.const import TICKER_RENAMES, UK_TIMEZONE
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
-from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode, Isin
+from cgt_calc.model import (
+    ActionType,
+    BrokerTransaction,
+    CurrencyCode,
+    Isin,
+    TransactionSource,
+)
 
 from .base_parsers import BaseDirParser
 
@@ -451,12 +457,16 @@ class Trading212Parser(BaseDirParser[Trading212Transaction]):
         transactions: list[Trading212Transaction] = []
         for index, row in enumerate(lines, start=2):
             try:
-                transactions.append(Trading212Transaction(header, row, file_path))
+                transaction = Trading212Transaction(header, row, file_path)
             except ParsingError as err:
                 err.add_row_context(index)
                 raise
             except ValueError as err:
                 raise ParsingError(file_path, str(err), row_index=index) from err
+            transaction.source = TransactionSource(
+                row=index, timestamp=transaction.datetime
+            )
+            transactions.append(transaction)
         return transactions
 
     @staticmethod

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -12,7 +12,12 @@ from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
 
 from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
-from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
+from cgt_calc.model import (
+    ActionType,
+    BrokerTransaction,
+    CurrencyCode,
+    TransactionSource,
+)
 
 from .base_parsers import BaseSingleFileParser
 
@@ -673,6 +678,7 @@ class VanguardParser(BaseSingleFileParser[VanguardTransaction]):
         *,
         warn_on_empty: bool = True,
         show_parsing_msg: bool = True,
+        account: str | None = None,
     ) -> list[VanguardTransaction]:
         """Load a text CSV and report Excel or encoding mistakes clearly."""
         if file_path.suffix.casefold() in {".xls", ".xlsx", ".xlsm", ".xlsb"}:
@@ -686,6 +692,7 @@ class VanguardParser(BaseSingleFileParser[VanguardTransaction]):
                 file_path,
                 warn_on_empty=warn_on_empty,
                 show_parsing_msg=show_parsing_msg,
+                account=account,
             )
         except UnicodeDecodeError as err:
             raise ParsingError(
@@ -768,6 +775,7 @@ class VanguardParser(BaseSingleFileParser[VanguardTransaction]):
                     ) from err
                 if txn is None:
                     continue  # zero-out half of a NameChange pair
+                txn.source = TransactionSource(row=row_index)
                 if txn.action is ActionType.RENAME:
                     transactions.append(txn)
                     continue
@@ -790,12 +798,14 @@ class VanguardParser(BaseSingleFileParser[VanguardTransaction]):
                     row_index=row_index,
                 )
             try:
-                transactions.append(VanguardTransaction(cash_header, row, file_path))
+                cash_txn = VanguardTransaction(cash_header, row, file_path)
             except ParsingError as err:
                 err.add_row_context(row_index)
                 raise
             except ValueError as err:
                 raise ParsingError(file_path, str(err), row_index=row_index) from err
+            cash_txn.source = TransactionSource(row=row_index)
+            transactions.append(cash_txn)
 
         # Resolve missing quantity/price with values from the investment table, see
         # https://github.com/cgt-calc/capital-gains-calculator/issues/758

--- a/docs/brokers/raw.md
+++ b/docs/brokers/raw.md
@@ -24,6 +24,43 @@ Example usage for the tax year 2024/25:
 cgt-calc --year 2024 --raw-file raw_data.csv
 ```
 
+## The order of rows on one date
+
+The `date` column carries no time, so within a single day the order you write the rows in is the
+only record of what happened first. Write each day's rows in the order the transactions actually
+happened, and give every `quantity` and `price` in the units that were in force at that moment.
+
+This matters most on the day of a share split. A `STOCK_SPLIT` row states the number of **new**
+shares the split created, not the total you held afterwards, and that number depends on how many
+shares you held when it ran. Say you held 11 shares and sold 5 that morning. Six shares went into a
+20-for-1 split and became 120, so the split created 114, and the sale above it is written in
+pre-split shares at the pre-split price:
+
+```csv
+2022-06-06,SELL,AMZN,5,2400.00,0.00,USD
+2022-06-06,STOCK_SPLIT,AMZN,114,0.00,0.00,USD
+```
+
+Had you sold after the split instead, all 11 shares went into it and became 220, so the split
+created 209, and the sale below it is written in post-split shares at the post-split price:
+
+```csv
+2022-06-06,STOCK_SPLIT,AMZN,209,0.00,0.00,USD
+2022-06-06,SELL,AMZN,100,120.00,0.00,USD
+```
+
+!!! warning "Selling on the day of a split"
+
+    A disposal written above a `STOCK_SPLIT` row for the same date is not worked out reliably yet.
+    The cost cgt-calc allows against that disposal can come out far too low, which overstates the
+    gain and so the tax. Selling on any other day is fine, including the day before or the day
+    after the split. If you sold on the day of a split, work that one disposal out by hand and
+    check it against the report before you use the figure.
+
+This is about the RAW file you write yourself. cgt-calc assumes nothing about the order of the rows
+inside a broker's own export, so if you keep a small RAW file alongside a broker export, it is the
+RAW rows that need to be in the order things happened.
+
 ## Transfers to a spouse or civil partner
 
 Shares given to a spouse or civil partner usually move at **no gain / no loss**: nothing is taxable

--- a/tests/freetrade/test_freetrade.py
+++ b/tests/freetrade/test_freetrade.py
@@ -1,7 +1,7 @@
 """Test Freetrade support."""
 
 import csv
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import Decimal
 import logging
 from pathlib import Path
@@ -169,6 +169,22 @@ def test_run_with_freetrade_file(request: pytest.FixtureRequest) -> None:
         "Run with example files generated unexpected outputs, "
         "if you added new features update the test with:\n"
         f"{cmd_str} > {expected_file}"
+    )
+
+
+def test_real_export_preserves_transaction_timestamp() -> None:
+    """Keep the exact instant stated by the Freetrade export."""
+    transactions = FreetradeParser.load_from_file(
+        Path("tests/freetrade/data/transactions.csv"), show_parsing_msg=False
+    )
+
+    transaction = next(
+        txn for txn in transactions if txn.source and txn.source.row == 2
+    )
+
+    assert transaction.source is not None
+    assert transaction.source.timestamp == datetime(
+        2024, 1, 16, 10, 1, 2, 811000, tzinfo=UTC
     )
 
 

--- a/tests/general/test_broker_registry.py
+++ b/tests/general/test_broker_registry.py
@@ -15,7 +15,10 @@ from cgt_calc.args_parser import create_parser
 from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode, Isin
+from cgt_calc.parsers.base_parsers import BaseParser, BaseSingleFileParser
 from cgt_calc.parsers.broker_registry import BrokerRegistry, _resolve_isins
+from cgt_calc.parsers.eri.raw import ERIRawParser
+from cgt_calc.parsers.raw import RawParser
 from cgt_calc.parsers.vanguard import VanguardTransaction
 
 if TYPE_CHECKING:
@@ -321,3 +324,27 @@ def test_resolve_isins_matches_the_eri_filter() -> None:
 
     assert isins == {Isin("IE00BK5BQT80")}
     assert unmapped == []
+
+
+@pytest.mark.parametrize(
+    "parser",
+    [*BrokerRegistry._BROKERS, ERIRawParser],  # noqa: SLF001
+    ids=lambda parser: parser.pretty_name,
+)
+def test_only_the_raw_format_promises_rows_in_time_order(
+    parser: type[BaseParser],
+) -> None:
+    """Only a hand-written RAW file states that a day's rows are in order.
+
+    ``rows_in_time_order`` is what lets a row be placed either side of a
+    same-day share reorganisation with no exported time to go on, so a parser
+    that claims it without its format saying so would settle a tax question
+    from the order a broker happened to export in. RAW earns it because
+    docs/brokers/raw.md tells the user writing the file to keep that order.
+
+    Every registered parser is pinned, not just RAW: the flag is inherited, so
+    a parser added later by copying ``RawParser`` would otherwise claim the
+    guarantee in silence.
+    """
+    assert issubclass(parser, BaseSingleFileParser)
+    assert parser.rows_in_time_order is (parser is RawParser)

--- a/tests/general/test_model.py
+++ b/tests/general/test_model.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import replace
 import datetime
 from decimal import Decimal
+from pathlib import Path
+from typing import override
 
 import pytest
 
@@ -15,6 +17,7 @@ from cgt_calc.model import (
     CurrencyCode,
     ForeignCurrencyAmount,
     Isin,
+    TransactionSource,
 )
 
 # Apple, a real ISIN with a valid check digit.
@@ -251,3 +254,60 @@ def test_broker_transaction_keeps_typed_foreign_fees_as_is() -> None:
     """An already-typed fee table passes through untouched."""
     fees = {CurrencyCode("USD"): Decimal(1)}
     assert _transaction_with_fees(fees).foreign_fees is fees
+
+
+class _HashedTransaction(BrokerTransaction):
+    """A transaction hashed by identity fields, as broker parsers hash theirs."""
+
+    @override
+    def __hash__(self) -> int:
+        """Hash on what identifies the row, never on where it was read from."""
+        return hash((self.date, self.symbol, self.quantity))
+
+
+def _hashed(source: TransactionSource) -> _HashedTransaction:
+    return _HashedTransaction(
+        date=datetime.date(2023, 1, 1),
+        action=ActionType.BUY,
+        symbol="FOO",
+        description="test",
+        quantity=Decimal(1),
+        price=Decimal(1),
+        fees=Decimal(0),
+        amount=Decimal(-1),
+        currency=USD,
+        broker="Test",
+        source=source,
+    )
+
+
+def test_source_is_not_part_of_transaction_equality() -> None:
+    """One row two overlapping exports both state stays one row.
+
+    Parsers deduplicate by comparing transactions, so the file a row came
+    from, the line it sat on and the boundary it was loaded under have to
+    stay out of the comparison and out of the hash. Left in, every row two
+    exports share would survive twice and double the holding.
+    """
+    first = _hashed(
+        TransactionSource(
+            parser="Trading 212",
+            account="Trading 212 #1",
+            file=Path("2026-01.csv"),
+            row=7,
+            index=5,
+            timestamp=datetime.datetime(2026, 1, 5, 9, 30, tzinfo=datetime.UTC),
+        )
+    )
+    second = _hashed(
+        TransactionSource(
+            parser="Trading 212",
+            account="Trading 212 #2",
+            file=Path("2026-02.csv"),
+            row=2,
+            index=0,
+        )
+    )
+
+    assert first == second
+    assert len({first, second}) == 1

--- a/tests/hl/test_hl.py
+++ b/tests/hl/test_hl.py
@@ -210,6 +210,27 @@ def test_load_from_dir_accepts_uppercase_csv_extension(tmp_path: Path) -> None:
     assert transactions[0].amount == Decimal("12.34")
 
 
+def test_real_preamble_preserves_physical_row_numbers(tmp_path: Path) -> None:
+    """Count HL's preamble when recording transaction source lines."""
+    csv_file = tmp_path / "hl-transaction-summary.csv"
+    shutil.copy2(
+        Path("tests/hl/data/inputs/hl-transaction-summary.csv"),
+        csv_file,
+    )
+    _create_buy_pdf(str(tmp_path / "B302087054_BOUGHT_Vanguard.pdf"))
+    _create_sell_pdf(str(tmp_path / "S302087055_SOLD_Vanguard.pdf"))
+
+    transactions = HargreavesLansdownParser.load_from_file(csv_file)
+
+    rows = {
+        transaction.date.isoformat(): transaction.source.row
+        for transaction in transactions
+        if transaction.source
+    }
+    assert rows["2026-04-04"] == 7
+    assert rows["2026-03-09"] == 8
+
+
 # The tests below call the parser directly: the end-to-end tests above
 # run in a subprocess, which is invisible to coverage.
 

--- a/tests/raw/test_raw.py
+++ b/tests/raw/test_raw.py
@@ -187,6 +187,34 @@ def test_read_raw_transactions_with_header(tmp_path: Path) -> None:
     assert transaction.fees == Decimal("0.10")
 
 
+def test_read_raw_transactions_keep_their_row_and_order(tmp_path: Path) -> None:
+    """RAW rows keep the line they came from and the order they were read in.
+
+    A RAW file has dates and no times, so the order of its rows is the only
+    statement it makes about what happened first on a day. It is preserved
+    here rather than re-derived later from the merged, re-sorted stream.
+    """
+
+    raw_file = tmp_path / "raw_ordered.csv"
+    rows = [
+        COLUMNS,
+        ["2024-01-02", "BUY", "XYZ", "10", "2.50", "0.00", "USD"],
+        ["2024-01-02", "BUY", "XYZ", "5", "3.00", "0.00", "USD"],
+    ]
+    _write_csv(raw_file, rows)
+
+    transactions = RawParser().load_from_file(raw_file)
+
+    sources = [transaction.source for transaction in transactions]
+    assert all(source is not None for source in sources)
+    assert [source.row for source in sources if source] == [2, 3]
+    assert [source.index for source in sources if source] == [0, 1]
+    assert [source.file for source in sources if source] == [raw_file, raw_file]
+    assert [source.parser for source in sources if source] == ["RAW format"] * 2
+    # A RAW export states no times, so nothing may later read one from it.
+    assert [source.timestamp for source in sources if source] == [None, None]
+
+
 def test_read_raw_transactions_transfer_to_spouse(tmp_path: Path) -> None:
     """Parse a RAW TRANSFER_TO_SPOUSE row (no gain/no loss share transfer)."""
 

--- a/tests/raw/test_raw.py
+++ b/tests/raw/test_raw.py
@@ -213,6 +213,9 @@ def test_read_raw_transactions_keep_their_row_and_order(tmp_path: Path) -> None:
     assert [source.parser for source in sources if source] == ["RAW format"] * 2
     # A RAW export states no times, so nothing may later read one from it.
     assert [source.timestamp for source in sources if source] == [None, None]
+    # The order above is a statement about what happened first, because the
+    # format asks the user to write a day's rows in the order they happened.
+    assert [source.rows_in_time_order for source in sources if source] == [True] * 2
 
 
 def test_read_raw_transactions_transfer_to_spouse(tmp_path: Path) -> None:

--- a/tests/sharesight/test_sharesight.py
+++ b/tests/sharesight/test_sharesight.py
@@ -62,6 +62,21 @@ def test_run_with_sharesight_files_no_balance_check(
     )
 
 
+def test_real_exports_preserve_physical_row_numbers() -> None:
+    """Keep the physical CSV line for trades and income transactions."""
+    transactions = SharesightParser.load_from_dir(Path("tests/sharesight/data/inputs"))
+
+    rows = {
+        (transaction.date.isoformat(), transaction.symbol, transaction.action): (
+            transaction.source.row if transaction.source else None
+        )
+        for transaction in transactions
+    }
+    assert rows["2019-08-01", "FX:ETH", ActionType.BUY] == 4
+    assert rows["2020-11-10", "FUND1.UKF", ActionType.DIVIDEND] == 7
+    assert rows["2020-10-10", "FOO.NASDAQ", ActionType.DIVIDEND_TAX] == 14
+
+
 def test_parse_income_report_missing_local_column(tmp_path: Path) -> None:
     """Error when Sharesight local dividend header omits required column."""
     file_path = tmp_path / "Taxable Income Report.csv"

--- a/tests/trading212/test_trading212.py
+++ b/tests/trading212/test_trading212.py
@@ -1118,6 +1118,158 @@ def test_read_trading212_transactions_mixes_time_column_spellings(
     ]
 
 
+def test_load_from_dir_deduplicates_overlapping_exports(tmp_path: Path) -> None:
+    """Collapse a transaction that two overlapping exports both report.
+
+    Exports are requested by date range, so consecutive downloads routinely
+    cover the same days. Deduplication rests on `Trading212Transaction.__hash__`
+    together with the field-by-field `__eq__` that `BrokerTransaction` gets as a
+    dataclass, so any field that varies with the source file would keep both
+    copies and double the holding.
+    """
+
+    folder = tmp_path / "inputs"
+    folder.mkdir()
+
+    def buy(transaction_id: str, day: str, shares: str, total: str) -> list[str]:
+        return _make_row(
+            HEADER_2026,
+            {
+                Trading212Column.ACTION: "Market buy",
+                Trading212Column.TIME: f"{day} 09:30:00",
+                Trading212Column.ISIN: "US0000000002",
+                Trading212Column.TICKER: "FOO",
+                Trading212Column.NAME: "Foo Inc",
+                Trading212Column.NO_OF_SHARES: shares,
+                Trading212Column.PRICE_PER_SHARE: "100.00",
+                Trading212Column.CURRENCY_PRICE_PER_SHARE: "GBP",
+                Trading212Column.TOTAL: total,
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.TRANSACTION_ID: transaction_id,
+            },
+        )
+
+    overlapping = buy("buy-overlapping", "2026-02-10", "2", "200.00")
+    _write_csv(
+        folder / "2026-01.csv",
+        [HEADER_2026, buy("buy-january", "2026-01-05", "1", "100.00"), overlapping],
+    )
+    _write_csv(
+        folder / "2026-02.csv",
+        [HEADER_2026, overlapping, buy("buy-february", "2026-02-20", "3", "300.00")],
+    )
+
+    transactions = Trading212Parser().load_from_dir(folder)
+
+    assert [transaction.date for transaction in transactions] == [
+        date(2026, 1, 5),
+        date(2026, 2, 10),
+        date(2026, 2, 20),
+    ]
+    assert sum(
+        transaction.quantity or Decimal(0) for transaction in transactions
+    ) == Decimal(6)
+
+
+def test_load_from_dir_records_where_each_row_came_from(tmp_path: Path) -> None:
+    """Every row keeps its file, line, read order and exported instant.
+
+    The line is what an error points at; the read order is what says which
+    of two rows on one day came first, and the export's own instant settles
+    it here without needing either.
+    """
+    folder = tmp_path / "inputs"
+    folder.mkdir()
+
+    def buy(transaction_id: str, day: str) -> list[str]:
+        return _make_row(
+            HEADER_2026,
+            {
+                Trading212Column.ACTION: "Market buy",
+                Trading212Column.TIME: f"{day} 09:30:00",
+                Trading212Column.ISIN: "US0000000002",
+                Trading212Column.TICKER: "FOO",
+                Trading212Column.NAME: "Foo Inc",
+                Trading212Column.NO_OF_SHARES: "1",
+                Trading212Column.PRICE_PER_SHARE: "100.00",
+                Trading212Column.CURRENCY_PRICE_PER_SHARE: "GBP",
+                Trading212Column.TOTAL: "100.00",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.TRANSACTION_ID: transaction_id,
+            },
+        )
+
+    _write_csv(
+        folder / "2026-01.csv",
+        [HEADER_2026, buy("buy-a", "2026-01-05"), buy("buy-b", "2026-01-06")],
+    )
+    _write_csv(folder / "2026-02.csv", [HEADER_2026, buy("buy-c", "2026-02-10")])
+
+    transactions = Trading212Parser().load_from_dir(folder)
+
+    sources = [transaction.source for transaction in transactions]
+    assert [source.file.name for source in sources if source and source.file] == [
+        "2026-01.csv",
+        "2026-01.csv",
+        "2026-02.csv",
+    ]
+    assert [source.row for source in sources if source] == [2, 3, 2]
+    assert [source.index for source in sources if source] == [0, 1, 0]
+    assert [source.parser for source in sources if source] == ["Trading 212"] * 3
+    assert [source.timestamp for source in sources if source] == [
+        datetime(2026, 1, 5, 9, 30, tzinfo=UTC),
+        datetime(2026, 1, 6, 9, 30, tzinfo=UTC),
+        datetime(2026, 2, 10, 9, 30, tzinfo=UTC),
+    ]
+
+
+def test_one_directory_is_one_account_boundary(tmp_path: Path) -> None:
+    """Files in one directory share a boundary; two loads never do.
+
+    Passing a directory is the user's declaration that its exports are one
+    account. Two separately configured inputs are two accounts, whatever the
+    export says, because nothing in the CSV identifies the account.
+    """
+    rows = [
+        HEADER_2026,
+        _make_row(
+            HEADER_2026,
+            {
+                Trading212Column.ACTION: "Market buy",
+                Trading212Column.TIME: "2026-01-05 09:30:00",
+                Trading212Column.ISIN: "US0000000002",
+                Trading212Column.TICKER: "FOO",
+                Trading212Column.NAME: "Foo Inc",
+                Trading212Column.NO_OF_SHARES: "1",
+                Trading212Column.PRICE_PER_SHARE: "100.00",
+                Trading212Column.CURRENCY_PRICE_PER_SHARE: "GBP",
+                Trading212Column.TOTAL: "100.00",
+                Trading212Column.CURRENCY_TOTAL: "GBP",
+                Trading212Column.TRANSACTION_ID: "buy-a",
+            },
+        ),
+    ]
+    first = tmp_path / "first"
+    first.mkdir()
+    _write_csv(first / "a.csv", rows)
+    _write_csv(first / "b.csv", rows)
+    second = tmp_path / "second"
+    second.mkdir()
+    _write_csv(second / "a.csv", rows)
+
+    together = Trading212Parser().load_from_dir(first)
+    apart = Trading212Parser().load_from_dir(second)
+
+    accounts = {
+        transaction.source.account
+        for transaction in together
+        if transaction.source is not None
+    }
+    assert len(accounts) == 1
+    assert apart[0].source is not None
+    assert apart[0].source.account not in accounts
+
+
 def test_read_trading212_transactions_missing_time_column(tmp_path: Path) -> None:
     """Raise ParsingError when neither Time column is present."""
 


### PR DESCRIPTION
Every parser now stamps each transaction with where it was read from: the parser, an opaque token for the account boundary the user declared, the file, the row, the order the rows were read in, and the exported instant where there is one.

Nothing consumes it yet. Same-day share reorganisations need it — a trade on the day of one can only be placed either side from an exported time or from a source documented as writing same-date rows in the order they happened, which only RAW does.

No calculation or report output changes. `source` is `compare=False` and out of the repr: Trading 212 deduplicates overlapping exports by comparing transactions, and the repr is printed whole in several errors where a local file path has no business appearing.

Groundwork for the next PR in the stack.
