### PR TITLE
Trim dead code and needless wrappers from recent changes

### DIFF
--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import datetime
-import logging
 
 import shtab
 
@@ -29,8 +28,6 @@ from .const import (
 )
 from .dates import get_tax_year_end, get_tax_year_for_date, get_tax_year_start
 from .parsers.broker_registry import BrokerRegistry
-
-LOGGER = logging.getLogger(__name__)
 
 
 def get_last_elapsed_tax_year() -> int:

--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -89,8 +89,7 @@ def _ensure_readable_file(path: Path, value: str) -> None:
 def _ensure_readable_directory(path: Path, value: str) -> None:
     """Raise ArgumentTypeError when directory contents cannot be listed."""
     try:
-        iterator = path.iterdir()
-        next(iterator, None)
+        next(path.iterdir(), None)
     except OSError as err:
         raise argparse.ArgumentTypeError(
             f"unable to read directory path: '{value}': {err}"

--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -109,7 +109,7 @@ class IsinConverter:
                     f"ISIN {transaction.isin} is linked to {', '.join(sorted(current_symbols))}",
                 )
 
-            if transaction.symbol not in self.data.get(transaction.isin, set()):
+            if transaction.symbol not in (current_symbols or set()):
                 self.data.setdefault(transaction.isin, set()).add(transaction.symbol)
                 self.write_data.setdefault(transaction.isin, set()).add(
                     transaction.symbol
@@ -213,11 +213,7 @@ class IsinConverter:
             msg += f"manually to {self.isin_translation_file}. Error: {err}"
             raise ExternalApiError(url, msg) from err
 
-        if (
-            not json_response
-            or len(json_response) == 0
-            or "data" not in json_response[0]
-        ):
+        if not json_response or "data" not in json_response[0]:
             LOGGER.warning(
                 "Couldn't translate ISIN %s: Invalid Response: %s", isin, json_response
             )

--- a/cgt_calc/logging.py
+++ b/cgt_calc/logging.py
@@ -29,29 +29,6 @@ class ConsoleUI:
 
     def supports_colour(self, stream: TextIO) -> bool:
         """Return True if colour output should be used for the given stream."""
-        return self._should_use_colour(stream)
-
-    def supports_emoji(self, stream: TextIO) -> bool:
-        """Return True if emoji output should be used for the given stream."""
-        return self._should_use_emoji(stream)
-
-    def painted(
-        self,
-        stream: TextIO,
-        msg: str,
-        colour: str | None = None,
-        emoji: str | None = None,
-    ) -> str:
-        """Return msg wrapped in colour with emoji prefix if enabled."""
-        if colour is not None and self.supports_colour(stream):
-            msg = f"{colour}{msg}{colorama.Style.RESET_ALL}"
-        if emoji is not None and self.supports_emoji(stream):
-            msg = f"{emoji}  {msg}"
-        return msg
-
-    def _should_use_colour(self, stream: TextIO) -> bool:
-        """Return True if colour output should be enabled for the given stream."""
-
         # Respect NO_COLOR (https://no-color.org/): any non-empty value disables.
         if os.environ.get("NO_COLOR"):
             return False
@@ -64,9 +41,8 @@ class ConsoleUI:
         except (AttributeError, OSError):
             return False
 
-    def _should_use_emoji(self, stream: TextIO) -> bool:
-        """Return True if emoji output should be enabled for the given stream."""
-
+    def supports_emoji(self, stream: TextIO) -> bool:
+        """Return True if emoji output should be used for the given stream."""
         # Emoji output requires colour support
         if not self.supports_colour(stream):
             return False
@@ -84,6 +60,20 @@ class ConsoleUI:
             return bool(os.environ.get("WT_SESSION") or "utf-8" in encoding)
 
         return True
+
+    def painted(
+        self,
+        stream: TextIO,
+        msg: str,
+        colour: str | None = None,
+        emoji: str | None = None,
+    ) -> str:
+        """Return msg wrapped in colour with emoji prefix if enabled."""
+        if colour is not None and self.supports_colour(stream):
+            msg = f"{colour}{msg}{colorama.Style.RESET_ALL}"
+        if emoji is not None and self.supports_emoji(stream):
+            msg = f"{emoji}  {msg}"
+        return msg
 
 
 class ColourMessageFormatter(logging.Formatter):

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -302,9 +302,7 @@ class CapitalGainsCalculator:
 
     def get_eri(self, symbol: str, date: datetime.date) -> ExcessReportedIncome | None:
         """Return Excess Reported Income at specific date for the input symbol."""
-        if date in self.eris and symbol in self.eris[date]:
-            return self.eris[date][symbol]
-        return None
+        return self.eris.get(date, {}).get(symbol)
 
     def add_acquisition(
         self,
@@ -713,17 +711,6 @@ class CapitalGainsCalculator:
             return "sell"
         return "gift-unconnected"
 
-    def add_shares_given_away(self, transaction: BrokerTransaction) -> None:
-        """Record shares handed to someone for nothing.
-
-        To a spouse that is no gain/no loss; to anyone else it is a disposal
-        at market value.
-        """
-        if transaction.action is ActionType.TRANSFER_TO_SPOUSE:
-            self.add_transfer_to_spouse(transaction)
-        else:
-            self.add_gift(transaction)
-
     @staticmethod
     def _gift_values_differ_message(symbol: str, date_index: datetime.date) -> str:
         return (
@@ -1131,7 +1118,10 @@ class CapitalGainsCalculator:
                 # charging the fee there only ever drives that balance negative.
                 # The fee still counts as a cost; it is the cash check it cannot
                 # take part in.
-                self.add_shares_given_away(transaction)
+                if transaction.action is ActionType.TRANSFER_TO_SPOUSE:
+                    self.add_transfer_to_spouse(transaction)
+                else:
+                    self.add_gift(transaction)
             elif transaction.action is ActionType.REINVEST_DIVIDENDS:
                 LOGGER.warning("Ignoring unsupported action: %s", transaction.action)
             else:

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -209,14 +209,12 @@ class BaseDirParser[T: BrokerTransaction](BaseSingleFileParser[T]):
     """Parser for loading all files within a directory."""
 
     glob_dir: str
-    deprecated_flags: ClassVar[list[str]] = []
 
     @override
     def __init_subclass__(cls, **kwargs: object) -> None:
         """Compute full arg."""
         super().__init_subclass__(**kwargs)
-        suffix = "dir"
-        cls.full_arg = f"{getattr(cls, 'arg_name', None)}-{suffix}"
+        cls.full_arg = f"{getattr(cls, 'arg_name', None)}-dir"
 
     @classmethod
     @override
@@ -272,9 +270,3 @@ class BaseDirParser[T: BrokerTransaction](BaseSingleFileParser[T]):
     def file_path_filter(cls, file_path: Path) -> bool:  # noqa: ARG003
         """Choose which files to parse."""
         return True
-
-    @classmethod
-    @override
-    def post_process_transactions(cls, transactions: list[T]) -> list[T]:
-        """Do any required post processing after loading all the transactions in the dir."""
-        return transactions

--- a/cgt_calc/parsers/eri/importer/invesco.py
+++ b/cgt_calc/parsers/eri/importer/invesco.py
@@ -28,7 +28,6 @@ from .model import ERIImporter, ERIImporterOutput
 LOGGER = logging.getLogger(__name__)
 
 REPORT_FILE_REGEX = re.compile(r"^invesco-.*reportable-income.*(\d+)\.pdf$")
-CURRENCY_REGEX = re.compile(r"^[A-Z]{3}$")
 AMOUNT_REGEX = re.compile(r"^\d+\.\d+$")
 
 ISIN_COLUMN = 0

--- a/cgt_calc/parsers/eri/importer/xtrackers.py
+++ b/cgt_calc/parsers/eri/importer/xtrackers.py
@@ -35,7 +35,6 @@ REPORT_FILE_REGEX = re.compile(
 
 XTRACKERS_ERI_FILENAME = "xtrackers_eri.csv"
 
-CURRENCY_REGEX = re.compile(r"^[A-Z]{3}$")
 AMOUNT_REGEX = re.compile(r"^\d+\.\d+$")
 
 # Column indices configuration for Xtrackers tables

--- a/cgt_calc/parsers/eri/raw.py
+++ b/cgt_calc/parsers/eri/raw.py
@@ -6,7 +6,6 @@ import csv
 import datetime
 from decimal import Decimal, InvalidOperation
 from importlib import resources
-import logging
 from typing import TYPE_CHECKING, Final, TextIO, override
 
 if TYPE_CHECKING:
@@ -29,7 +28,6 @@ COLUMNS: Final[list[str]] = [
     "Currency",
     "Excess of reporting income over distribution",
 ]
-LOGGER = logging.getLogger(__name__)
 
 RAW_DATE_FORMAT = "%d/%m/%Y"
 
@@ -83,9 +81,9 @@ class ERIRawParser(BaseSingleFileParser[ERIRaw]):
     format_name = "CSV"
 
     @staticmethod
-    def _validate_header(header: list[str], file: Path, columns: list[str]) -> None:
+    def _validate_header(header: list[str], file: Path) -> None:
         """Check if header is valid."""
-        unknown_columns = sorted(set(header) - set(columns))
+        unknown_columns = sorted(set(header) - set(COLUMNS))
         if unknown_columns:
             raise ParsingError(
                 file,
@@ -119,7 +117,7 @@ class ERIRawParser(BaseSingleFileParser[ERIRaw]):
 
         header = lines[0]
 
-        ERIRawParser._validate_header(header, file_path, COLUMNS)
+        cls._validate_header(header, file_path)
 
         transactions: list[ERIRaw] = []
         for index, row in enumerate(lines[1:], start=2):

--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -51,7 +51,6 @@ class HargreavesLansdownParser(
     format_name = "CSV and PDF"
     glob_dir = "*.csv"
     encoding = "windows-1252"
-    deprecated_flags: ClassVar[list[str]] = []
 
     columns: ClassVar[set[str]] = {
         "Trade date",

--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -6,7 +6,6 @@ import datetime
 from decimal import Decimal, InvalidOperation
 from enum import StrEnum
 from itertools import chain
-import logging
 import re
 from typing import TYPE_CHECKING, ClassVar, Final, override
 
@@ -20,8 +19,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
 
-
-LOGGER = logging.getLogger(__name__)
 
 EXPECTED_COLS_IN_SUMMARY_SECTION: Final[int] = 4
 
@@ -57,12 +54,10 @@ class InteractiveBrokersColumn(StrEnum):
     EXCHANGE_RATE = "Exchange Rate"
 
 
-_IBKR_OPTIONAL_COLUMNS: Final[set[str]] = set(
-    {
-        InteractiveBrokersColumn.PRICE_CURRENCY,
-        InteractiveBrokersColumn.EXCHANGE_RATE,
-    }
-)
+_IBKR_OPTIONAL_COLUMNS: Final[set[str]] = {
+    InteractiveBrokersColumn.PRICE_CURRENCY,
+    InteractiveBrokersColumn.EXCHANGE_RATE,
+}
 
 
 def _action_from_str(action_type: str, file_path: Path) -> ActionType:

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -654,13 +654,12 @@ def _filter_cancelled_buy_transactions(
                 "other cancellation reverses it.",
             )
 
-    if len(indices_to_remove) > 0:
+    if indices_to_remove:
         LOGGER.info(
             "Removed %d cancelled transaction(s) and their originals",
             len(indices_to_remove),
         )
 
-    # Return filtered list
     return [txn for i, txn in enumerate(transactions) if i not in indices_to_remove]
 
 
@@ -681,7 +680,7 @@ def _read_schwab_awards(
             schwab_award_transactions_file, "Charles Schwab Award CSV file is empty"
         )
     header = lines[0]
-    required_columns = set({column.value for column in RequiredAwardColumn})
+    required_columns = {column.value for column in RequiredAwardColumn}
     if not required_columns.issubset(header):
         raise ParsingError(
             schwab_award_transactions_file,
@@ -814,7 +813,7 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
             )
         header = lines[0]
 
-        required_headers = set({column.value for column in RequiredTransactionsColumn})
+        required_headers = {column.value for column in RequiredTransactionsColumn}
         if not required_headers.issubset(header):
             raise ParsingError(
                 file_path,
@@ -849,4 +848,4 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
         transactions = _unify_schwab_paired_transactions(transactions, file_path)
         transactions = _filter_cancelled_buy_transactions(transactions, file_path)
         transactions.reverse()
-        return list(transactions)
+        return transactions

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -953,4 +953,4 @@ class SchwabEquityAwardsJSONParser(BaseSingleFileParser[SchwabAwardTransaction])
         _check_disposal_units(transactions, file_path)
 
         transactions.reverse()
-        return list(transactions)
+        return transactions

--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -382,13 +382,6 @@ class SharesightParser(BaseDirParser[SharesightTransaction]):
                 )
 
     @classmethod
-    def _parse_foreign_income(
-        cls, rows: Iterator[list[str]], file: Path
-    ) -> Iterable[SharesightTransaction]:
-        """Parse Foreign Income section from Sharesight data."""
-        yield from cls._parse_dividend_payments(FOREIGN_DIVIDEND_SCHEMA, rows, file)
-
-    @classmethod
     def _parse_income_report(
         cls, file: TextIO, file_path: Path
     ) -> Iterable[SharesightTransaction]:
@@ -402,7 +395,9 @@ class SharesightParser(BaseDirParser[SharesightTransaction]):
                 if row[0] == "Local Income":
                     yield from cls._parse_local_income(rows_iter, file_path)
                 elif row[0] == "Foreign Income":
-                    yield from cls._parse_foreign_income(rows_iter, file_path)
+                    yield from cls._parse_dividend_payments(
+                        FOREIGN_DIVIDEND_SCHEMA, rows_iter, file_path
+                    )
         except ParsingError as err:
             err.add_row_context(rows_iter.line)
             raise

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -74,7 +74,6 @@ class Trading212Column(StrEnum):
     MERCHANT_NAME = "Merchant name"
 
 
-COLUMNS: Final[list[str]] = [column.value for column in Trading212Column]
 COLUMN_SET: Final[set[str]] = {column.value for column in Trading212Column}
 LOGGER = logging.getLogger(__name__)
 

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -7,7 +7,6 @@ import datetime
 from decimal import Decimal, InvalidOperation
 from enum import StrEnum
 import io
-import logging
 import re
 from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
 
@@ -87,7 +86,6 @@ _PAGE_LABEL_RE = re.compile(r"^page\s+\d+(?:\s*(?:of|/)\s*\d+)?$", re.IGNORECASE
 
 INTEREST_STR = "Cash Account Interest"
 REVERSAL_STR = "Reversal of "
-LOGGER = logging.getLogger(__name__)
 
 
 def action_from_str(label: str, file: Path) -> ActionType:
@@ -629,17 +627,6 @@ class _TableSplitter:
         )
 
 
-def _split_tables(
-    lines: list[tuple[int, list[str]]],
-    file_path: Path,
-) -> tuple[
-    list[tuple[int, list[str]]] | None,
-    list[tuple[int, list[str]]] | None,
-]:
-    """Split tables while rejecting structures that could discard transactions."""
-    return _TableSplitter(lines, file_path).split()
-
-
 def _find_investment_match(
     txn: VanguardTransaction,
     investment_lookup: dict[tuple[str, bool], list[dict[str, str]]],
@@ -734,7 +721,7 @@ class VanguardParser(BaseSingleFileParser[VanguardTransaction]):
         if not lines:
             raise ParsingError(file_path, "Vanguard CSV file is empty")
 
-        cash_lines, investment_lines = _split_tables(lines, file_path)
+        cash_lines, investment_lines = _TableSplitter(lines, file_path).split()
 
         if cash_lines is None:
             if investment_lines is None:


### PR DESCRIPTION
Remove complexity that accumulated across the ~30 PRs merged since
c2406be, with no behaviour change.

- Delete four unused module loggers, two unused CURRENCY_REGEX
  constants, and trading212's unreferenced COLUMNS
- Drop a BaseDirParser.post_process_transactions override identical to
  the method it inherits, and two deprecated_flags redeclarations of
  the base default
- Inline one-caller wrappers: _split_tables, _parse_foreign_income,
  add_shares_given_away, and eri/raw's never-varying columns parameter
- Fold ConsoleUI._should_use_colour/_emoji into their public twins
- Replace redundant set()/list() copies, len(x) > 0, and a duplicated
  dict lookup with the direct form

Nothing removed was referenced anywhere: every deleted name has zero
hits across cgt_calc/ and tests/. Tax-rule comments, error-message
guidance, and the get_ui() lru_cache API are untouched.
