### PR TITLE
Add --schwab-dir to parse a directory of exports

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -162,6 +162,7 @@ Shareworks
 shfmt
 shtab
 SIPP
+classmethod
 SLF001
 SOLV
 SpinOff
@@ -200,3 +201,5 @@ VTI
 worktree
 xtrackers
 yfinance
+schwab
+cls

--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -80,6 +80,7 @@ GOOGL
 GSU
 HL
 Hmrc
+I/O
 IBKR
 IBKR's
 idx
@@ -88,6 +89,7 @@ InvalidTransactionError
 Invesco
 InvestmentName
 iShares
+IsADirectoryError
 ISIN
 IsinConverter
 ISINs
@@ -117,6 +119,7 @@ NVDA
 NVIDIA
 OCI
 OPRA
+OSError
 OTGLY
 ParsingError
 pdf
@@ -124,6 +127,7 @@ pdflatex
 pipx
 Plc
 png
+PermissionError
 Podman
 prek
 presplit

--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -13,6 +13,7 @@ ArgumentParser
 ArgumentTypeError
 arm64
 autosale
+BaseDirParser
 BaseSingleFileParser
 BGF
 BGIF
@@ -38,6 +39,8 @@ CG51976
 CG52742
 CG59562
 cgt
+classmethod
+cls
 CMF5
 codepage
 codespell
@@ -153,6 +156,7 @@ s58
 SA106
 SalePrice
 Schwab
+schwab
 Schwab's
 SchwabAwardTransaction
 SchwabTransaction
@@ -162,7 +166,6 @@ Shareworks
 shfmt
 shtab
 SIPP
-classmethod
 SLF001
 SOLV
 SpinOff
@@ -201,5 +204,3 @@ VTI
 worktree
 xtrackers
 yfinance
-schwab
-cls

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -249,6 +249,24 @@ def reject_duplicate_stdin(
         )
 
 
+def reject_schwab_file_and_dir(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> None:
+    """Reject ``--schwab-file`` and ``--schwab-dir`` given together.
+
+    Schwab is the only broker offering both, because ``--schwab-file`` predates the
+    directory support and has to keep working. Loading both would mean merging
+    two sources whose overlap cannot be detected: a Schwab CSV has no
+    transaction id, so a row present in each is indistinguishable from a
+    genuine repeat of the same trade.
+    """
+    if args.schwab_file and args.schwab_dir:
+        parser.error(
+            "--schwab-file and --schwab-dir cannot be used together. Pass the "
+            "directory holding every export, or the single file."
+        )
+
+
 def resolve_reporting_period(
     parser: argparse.ArgumentParser, args: argparse.Namespace
 ) -> None:

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -14,7 +14,12 @@ from typing import TYPE_CHECKING
 from colorama import Fore, Style
 
 from . import render_latex
-from .args_parser import create_parser, reject_duplicate_stdin, resolve_reporting_period
+from .args_parser import (
+    create_parser,
+    reject_duplicate_stdin,
+    reject_schwab_file_and_dir,
+    resolve_reporting_period,
+)
 from .const import (
     BALANCE_CHECK_CONTEXT_ROWS,
     BED_AND_BREAKFAST_DAYS,
@@ -2719,6 +2724,7 @@ def main() -> int:
 
     args = parser.parse_args()
     reject_duplicate_stdin(parser, args)
+    reject_schwab_file_and_dir(parser, args)
     resolve_reporting_period(parser, args)
 
     if args.verbose:

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -179,6 +179,11 @@ class BaseSingleFileParser[T: BrokerTransaction](BaseParser):
         """Do any required post processing after loading the transactions."""
         return transactions
 
+    @classmethod
+    def file_path_filter(cls, file_path: Path) -> bool:  # noqa: ARG003
+        """Choose which files to parse."""
+        return True
+
 
 class StandardCSVParser[T: BrokerTransaction](BaseSingleFileParser[T]):
     """Base parser for CSV files with a fixed set of expected columns."""
@@ -331,8 +336,3 @@ class BaseDirParser[T: BrokerTransaction](BaseSingleFileParser[T]):
                 cls.pretty_name,
             )
         return cls.post_process_transactions(transactions)
-
-    @classmethod
-    def file_path_filter(cls, file_path: Path) -> bool:  # noqa: ARG003
-        """Choose which files to parse."""
-        return True

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 from collections import OrderedDict, defaultdict
 import csv
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import datetime
 from decimal import Decimal, InvalidOperation
 from enum import StrEnum
@@ -23,6 +23,7 @@ from cgt_calc.args_validators import (
 )
 from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import (
+    CgtError,
     ParsingError,
     SymbolMissingError,
     UnexpectedColumnCountError,
@@ -653,8 +654,11 @@ def _filter_cancelled_buy_transactions(
             # which refuses any action it does not handle but can only report
             # an unprocessed action type, naming neither the cancellation nor
             # what to do about it.
+            # A directory load passes the directory, so name the file and line
+            # the row records: "remove this row" needs to say which row.
+            source = transaction.source
             raise ParsingError(
-                file,
+                source.file if source and source.file else file,
                 f"Found a {transaction.raw_action} for {transaction.symbol} on "
                 f"{transaction.date} with no Buy to match it in the "
                 f"{CANCEL_BUY_SEARCH_DAYS} days before. The purchase may be "
@@ -663,6 +667,7 @@ def _filter_cancelled_buy_transactions(
                 "another cancellation. Remove this row; remove the purchase "
                 "with it only if the purchase is still in the export and no "
                 "other cancellation reverses it.",
+                row_index=source.row if source else None,
             )
 
     if indices_to_remove:
@@ -825,6 +830,10 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
     pretty_name = "Charles Schwab"
     format_name = "CSV"
     deprecated_flags: ClassVar[list[str]] = ["--schwab"]
+    # Schwab cannot inherit BaseDirParser, which would rename --schwab-file to
+    # --schwab-dir, so it declares the same directory conventions by hand and
+    # reads them through cls in load_from_dir.
+    glob_dir: ClassVar[str] = "*.csv"
 
     awards_prices: AwardPrices = _read_schwab_awards(None)
 
@@ -870,6 +879,15 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
         """Load broker data from parsed arguments."""
         award_path = args.schwab_award_file
         cls.awards_prices = _read_schwab_awards(award_path)
+        if args.schwab_dir and args.schwab_file:
+            # main() rejects this through argparse, for the usage message and
+            # exit code 2. Repeated here because this is the layer that knows
+            # both flags: taking the directory branch silently would drop
+            # every transaction in the file.
+            raise CgtError(
+                "--schwab-file and --schwab-dir cannot be used together. Pass "
+                "the directory holding every export, or the single file."
+            )
         if args.schwab_dir:
             # list is invariant, so widen explicitly rather than return list[T].
             transactions: list[BrokerTransaction] = list(
@@ -899,29 +917,51 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
         then treated as a single export.
 
         Corporate-action pairing stays per file: both shapes it recognises are
-        same-date by construction, and refusing overlapping exports guarantees
-        one date lives in exactly one file, so a pair can never be split.
-        Cancellation matching is the opposite: the Buy a Cancel Buy reverses is
-        up to CANCEL_BUY_SEARCH_DAYS away, so it routinely sits in the
-        neighbouring file and can only be found once everything is merged.
+        same-date by construction, and refusing overlapping exports first
+        guarantees one date lives in exactly one file, so a pair can never be
+        split. Cancellation matching is the opposite: the Buy a Cancel Buy
+        reverses is up to CANCEL_BUY_SEARCH_DAYS away, so it routinely sits in
+        the neighbouring file and can only be found once everything is merged.
         """
         # One directory is one declared account boundary, as it is for the
         # other directory brokers, so every file in it shares a token.
         account = next_account_token(cls.pretty_name)
         exports: list[_Export] = []
-        for file_path in sorted(dir_path.glob("*.csv", case_sensitive=False)):
+        for file_path in sorted(dir_path.glob(cls.glob_dir, case_sensitive=False)):
+            if not cls.file_path_filter(file_path):
+                continue
+            if not file_path.is_file():
+                raise ParsingError(
+                    file_path,
+                    "is not a regular file. Remove or move it out of the Schwab "
+                    "directory.",
+                )
             with file_path.open(encoding=cls.encoding) as file:
                 parsing_msg(file_path)
-                rows = cls._read_rows(file, file_path)
-            rows = _unify_schwab_paired_transactions(rows, file_path)
-            # Rows are still newest-first here, so stamp a reversed view: index
-            # has to rise with time, as it does on the single-file path where
-            # stamping happens after the reverse.
-            cls.stamp_source(list(reversed(rows)), file_path, account)
+                rows = cls._read_rows(file, file_path, from_directory=True)
             if rows:
                 exports.append(_Export(rows=rows, file_path=file_path))
 
+        # Before pairing, not after: an overlap is exactly what can put the two
+        # halves of a corporate action in different files, and pairing would
+        # then report a missing half rather than the overlap behind it. Pairing
+        # only ever merges rows sharing a date, so it cannot change the span a
+        # file covers and the answer here is the same either way.
         _reject_overlapping_exports(exports)
+
+        exports = [
+            replace(
+                export,
+                rows=_unify_schwab_paired_transactions(export.rows, export.file_path),
+            )
+            for export in exports
+        ]
+        for export in exports:
+            # Rows are still newest-first here, so stamp a reversed view: index
+            # has to rise with time, as it does on the single-file path where
+            # stamping happens after the reverse.
+            cls.stamp_source(list(reversed(export.rows)), export.file_path, account)
+
         # Every export is newest-first and no date spans two of them, so
         # ordering whole exports by their newest date makes the concatenation
         # newest-first without disturbing row order inside a file. Sorting the
@@ -945,7 +985,9 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
         return cls.post_process_transactions(transactions)
 
     @classmethod
-    def _read_rows(cls, file: TextIO, file_path: Path) -> list[SchwabTransaction]:
+    def _read_rows(
+        cls, file: TextIO, file_path: Path, *, from_directory: bool = False
+    ) -> list[SchwabTransaction]:
         """Parse the rows of one Schwab CSV, without any cross-row pass.
 
         A ``classmethod`` because pricing a vest needs ``cls.awards_prices``,
@@ -960,10 +1002,20 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
 
         required_headers = {column.value for column in RequiredTransactionsColumn}
         if not required_headers.issubset(header):
+            directory_help = ""
+            if from_directory:
+                directory_help = (
+                    f" Every *.csv in the directory is parsed as Schwab transaction "
+                    f"history; remove or move this file ({file_path.name}) out of the "
+                    "directory."
+                )
+                award_headers = {column.value for column in RequiredAwardColumn}
+                if award_headers.issubset(header):
+                    directory_help += " Pass it with --schwab-award-file instead."
             raise ParsingError(
                 file_path,
                 "Missing columns in Schwab transaction file: "
-                f"{required_headers.difference(header)}",
+                f"{required_headers.difference(header)}.{directory_help}",
                 row_index=1,
             )
 

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -9,12 +9,18 @@ from dataclasses import dataclass
 import datetime
 from decimal import Decimal, InvalidOperation
 from enum import StrEnum
+import itertools
 import logging
 from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
 
 import shtab
 
-from cgt_calc.args_validators import DeprecatedAction, existing_file_type, set_completer
+from cgt_calc.args_validators import (
+    DeprecatedAction,
+    existing_directory_type,
+    existing_file_type,
+    set_completer,
+)
 from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import (
     ParsingError,
@@ -31,7 +37,7 @@ from cgt_calc.model import (
 )
 from cgt_calc.parsers.schwab_cusip_bonds import adjust_cusip_bond_price
 
-from .base_parsers import BaseSingleFileParser
+from .base_parsers import BaseSingleFileParser, next_account_token
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -668,6 +674,55 @@ def _filter_cancelled_buy_transactions(
     return [txn for i, txn in enumerate(transactions) if i not in indices_to_remove]
 
 
+@dataclass(frozen=True)
+class _Export:
+    """One Schwab CSV from a directory, with the dates it actually covers."""
+
+    rows: list[SchwabTransaction]
+    file_path: Path
+
+    @property
+    def oldest(self) -> datetime.date:
+        """Earliest transaction date in the file."""
+        return min(row.date for row in self.rows)
+
+    @property
+    def newest(self) -> datetime.date:
+        """Latest transaction date in the file."""
+        return max(row.date for row in self.rows)
+
+
+def _reject_overlapping_exports(exports: list[_Export]) -> None:
+    """Refuse two exports whose transaction dates overlap.
+
+    A Schwab CSV carries no transaction id, so a row repeated by an overlap is
+    indistinguishable from a genuine repeat of the same trade: two identical
+    buys of the same size and price on one day are a real thing. Continuing
+    would report a disposal or acquisition that never happened, and would leave
+    the order of a shared date decided by the filename.
+
+    The comparison is over the dates present in each file rather than the range
+    the user asked Schwab for. That is the stricter reading of what matters: if
+    two requested ranges overlap but no transaction falls in the shared window,
+    nothing is duplicated and there is nothing to refuse.
+    """
+    ordered = sorted(exports, key=lambda export: (export.oldest, export.newest))
+    for earlier, later in itertools.pairwise(ordered):
+        if later.oldest <= earlier.newest:
+            raise ParsingError(
+                later.file_path,
+                f"has transactions from {later.oldest} to {later.newest}, "
+                f"overlapping {earlier.file_path.name} ({earlier.oldest} to "
+                f"{earlier.newest}). A Schwab CSV has no transaction id, so "
+                "cgt-calc cannot tell a row repeated by the overlap from a "
+                "genuine repeat of the same trade, and would count both. "
+                "Re-export the ranges so they do not overlap, or remove the "
+                "redundant file. If these are exports from two different "
+                "Schwab accounts, cgt-calc cannot combine them: the CSV does "
+                "not say which account a row belongs to.",
+            )
+
+
 def _read_schwab_awards(
     schwab_award_transactions_file: Path | None,
 ) -> AwardPrices:
@@ -794,6 +849,19 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
             type=existing_file_type,
             help=argparse.SUPPRESS,
         )
+        # Schwab keeps both forms: `--schwab-file` predates the directory
+        # support, so removing it would break every existing command. The
+        # other directory brokers replaced their file flag instead.
+        set_completer(
+            arg_group.add_argument(
+                "--schwab-dir",
+                type=existing_directory_type,
+                default=None,
+                metavar="DIR",
+                help="directory with Charles Schwab transaction history in CSV format",
+            ),
+            shtab.DIRECTORY,
+        )
         super().register_arguments(arg_group)
 
     @classmethod
@@ -802,6 +870,12 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
         """Load broker data from parsed arguments."""
         award_path = args.schwab_award_file
         cls.awards_prices = _read_schwab_awards(award_path)
+        if args.schwab_dir:
+            # list is invariant, so widen explicitly rather than return list[T].
+            transactions: list[BrokerTransaction] = list(
+                cls.load_from_dir(args.schwab_dir)
+            )
+            return transactions
         return super().load_from_args(args)
 
     @classmethod
@@ -810,7 +884,73 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
         cls, file: TextIO, file_path: Path
     ) -> list[SchwabTransaction]:
         """Read Schwab transactions from file."""
+        transactions = cls._read_rows(file, file_path)
+        transactions = _unify_schwab_paired_transactions(transactions, file_path)
+        transactions = _filter_cancelled_buy_transactions(transactions, file_path)
+        transactions.reverse()
+        return transactions
 
+    @classmethod
+    def load_from_dir(cls, dir_path: Path) -> list[SchwabTransaction]:
+        """Read every CSV in the directory as one export.
+
+        Schwab limits how much history one export can cover, so a long history
+        arrives as several date-range files. They are parsed separately and
+        then treated as a single export.
+
+        Corporate-action pairing stays per file: both shapes it recognises are
+        same-date by construction, and refusing overlapping exports guarantees
+        one date lives in exactly one file, so a pair can never be split.
+        Cancellation matching is the opposite: the Buy a Cancel Buy reverses is
+        up to CANCEL_BUY_SEARCH_DAYS away, so it routinely sits in the
+        neighbouring file and can only be found once everything is merged.
+        """
+        # One directory is one declared account boundary, as it is for the
+        # other directory brokers, so every file in it shares a token.
+        account = next_account_token(cls.pretty_name)
+        exports: list[_Export] = []
+        for file_path in sorted(dir_path.glob("*.csv", case_sensitive=False)):
+            with file_path.open(encoding=cls.encoding) as file:
+                parsing_msg(file_path)
+                rows = cls._read_rows(file, file_path)
+            rows = _unify_schwab_paired_transactions(rows, file_path)
+            # Rows are still newest-first here, so stamp a reversed view: index
+            # has to rise with time, as it does on the single-file path where
+            # stamping happens after the reverse.
+            cls.stamp_source(list(reversed(rows)), file_path, account)
+            if rows:
+                exports.append(_Export(rows=rows, file_path=file_path))
+
+        _reject_overlapping_exports(exports)
+        # Every export is newest-first and no date spans two of them, so
+        # ordering whole exports by their newest date makes the concatenation
+        # newest-first without disturbing row order inside a file. Sorting the
+        # rows themselves would have to break ties between files, and the only
+        # tiebreak available is the filename.
+        exports.sort(key=lambda export: export.newest, reverse=True)
+
+        transactions = [row for export in exports for row in export.rows]
+        transactions = _filter_cancelled_buy_transactions(transactions, dir_path)
+        transactions.reverse()
+
+        # Checked after filtering, not before: a directory whose only rows are
+        # a Buy and the Cancel Buy that reverses it ends up empty, and has to
+        # warn like any other empty result.
+        if not transactions:
+            LOGGER.warning(
+                "No transactions detected in directory %s for broker %s",
+                dir_path,
+                cls.pretty_name,
+            )
+        return cls.post_process_transactions(transactions)
+
+    @classmethod
+    def _read_rows(cls, file: TextIO, file_path: Path) -> list[SchwabTransaction]:
+        """Parse the rows of one Schwab CSV, without any cross-row pass.
+
+        A ``classmethod`` because pricing a vest needs ``cls.awards_prices``,
+        which ``load_from_args`` fills in from ``--schwab-award-file``.
+        """
         lines = list(csv.reader(file))
         if not lines:
             raise ParsingError(
@@ -851,7 +991,4 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
 
             transaction.source = TransactionSource(row=index)
             transactions.append(transaction)
-        transactions = _unify_schwab_paired_transactions(transactions, file_path)
-        transactions = _filter_cancelled_buy_transactions(transactions, file_path)
-        transactions.reverse()
         return transactions

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -877,17 +877,18 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
     @override
     def load_from_args(cls, args: argparse.Namespace) -> list[BrokerTransaction]:
         """Load broker data from parsed arguments."""
-        award_path = args.schwab_award_file
-        cls.awards_prices = _read_schwab_awards(award_path)
         if args.schwab_dir and args.schwab_file:
             # main() rejects this through argparse, for the usage message and
             # exit code 2. Repeated here because this is the layer that knows
             # both flags: taking the directory branch silently would drop
-            # every transaction in the file.
+            # every transaction in the file. Checked before any I/O so a bad
+            # award file can't mask the real problem.
             raise CgtError(
                 "--schwab-file and --schwab-dir cannot be used together. Pass "
                 "the directory holding every export, or the single file."
             )
+        award_path = args.schwab_award_file
+        cls.awards_prices = _read_schwab_awards(award_path)
         if args.schwab_dir:
             # list is invariant, so widen explicitly rather than return list[T].
             transactions: list[BrokerTransaction] = list(
@@ -930,15 +931,25 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
         for file_path in sorted(dir_path.glob(cls.glob_dir, case_sensitive=False)):
             if not cls.file_path_filter(file_path):
                 continue
-            if not file_path.is_file():
+            try:
+                with file_path.open(encoding=cls.encoding) as file:
+                    parsing_msg(file_path)
+                    rows = cls._read_rows(file, file_path, from_directory=True)
+            except OSError as exc:
+                # Branch on what the path is, not on the exception type:
+                # opening a directory raises IsADirectoryError on POSIX but
+                # PermissionError on Windows.
+                if file_path.is_dir():
+                    raise ParsingError(
+                        file_path,
+                        "is not a regular file. Remove or move it out of the "
+                        "Schwab directory.",
+                    ) from exc
                 raise ParsingError(
                     file_path,
-                    "is not a regular file. Remove or move it out of the Schwab "
-                    "directory.",
-                )
-            with file_path.open(encoding=cls.encoding) as file:
-                parsing_msg(file_path)
-                rows = cls._read_rows(file, file_path, from_directory=True)
+                    f"could not be read ({exc.strerror or exc}). Remove or move "
+                    "it out of the Schwab directory.",
+                ) from exc
             if rows:
                 exports.append(_Export(rows=rows, file_path=file_path))
 
@@ -985,6 +996,14 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
         return cls.post_process_transactions(transactions)
 
     @classmethod
+    def _directory_help(cls, file_path: Path) -> str:
+        return (
+            f" Every {cls.glob_dir} in the directory is parsed as Schwab "
+            f"transaction history; remove or move this file ({file_path.name}) "
+            "out of the directory."
+        )
+
+    @classmethod
     def _read_rows(
         cls, file: TextIO, file_path: Path, *, from_directory: bool = False
     ) -> list[SchwabTransaction]:
@@ -995,20 +1014,17 @@ class SchwabParser(BaseSingleFileParser[SchwabTransaction]):
         """
         lines = list(csv.reader(file))
         if not lines:
-            raise ParsingError(
-                file_path, "Charles Schwab transactions CSV file is empty"
-            )
+            message = "Charles Schwab transactions CSV file is empty."
+            if from_directory:
+                message += cls._directory_help(file_path)
+            raise ParsingError(file_path, message)
         header = lines[0]
 
         required_headers = {column.value for column in RequiredTransactionsColumn}
         if not required_headers.issubset(header):
             directory_help = ""
             if from_directory:
-                directory_help = (
-                    f" Every *.csv in the directory is parsed as Schwab transaction "
-                    f"history; remove or move this file ({file_path.name}) out of the "
-                    "directory."
-                )
+                directory_help = cls._directory_help(file_path)
                 award_headers = {column.value for column in RequiredAwardColumn}
                 if award_headers.issubset(header):
                     directory_help += " Pass it with --schwab-award-file instead."

--- a/docs/brokers/index.md
+++ b/docs/brokers/index.md
@@ -4,17 +4,17 @@ You need to provide the transaction history for each of your accounts, covering 
 since you first acquired any shares owned during the relevant tax years. Pick your broker below for
 export instructions.
 
-| Broker                                        | CLI option                             | Notes                               |
-| --------------------------------------------- | -------------------------------------- | ----------------------------------- |
-| [Charles Schwab](schwab.md)                   | `--schwab-file`, `--schwab-award-file` | Equity awards supported             |
-| [Freetrade](freetrade.md)                     | `--freetrade-file`                     | Activity CSV export                 |
-| [Hargreaves Lansdown](hargreaves-lansdown.md) | `--hl-dir`                             | Tax Centre CSVs plus contract notes |
-| [Interactive Brokers](interactive-brokers.md) | `--interactive-brokers-file`           | Transaction history CSV             |
-| [Morgan Stanley](morgan-stanley.md)           | `--mssb-dir`                           | Alphabet equity-award report folder |
-| [Sharesight](sharesight.md)                   | `--sharesight-dir`                     | Multi-broker portfolio tracker      |
-| [Trading 212](trading212.md)                  | `--trading212-dir`                     | Folder of yearly exports            |
-| [Vanguard](vanguard.md)                       | `--vanguard-file`                      | Client Transactions Listing CSV     |
-| [RAW format](raw.md)                          | `--raw-file`                           | Generic fallback for other brokers  |
+| Broker                                        | CLI option                                                                             | Notes                               |
+| --------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------- |
+| [Charles Schwab](schwab.md)                   | `--schwab-file` or `--schwab-dir`, `--schwab-award-file`, `--schwab-equity-award-json` | Equity awards supported             |
+| [Freetrade](freetrade.md)                     | `--freetrade-file`                                                                     | Activity CSV export                 |
+| [Hargreaves Lansdown](hargreaves-lansdown.md) | `--hl-dir`                                                                             | Tax Centre CSVs plus contract notes |
+| [Interactive Brokers](interactive-brokers.md) | `--interactive-brokers-file`                                                           | Transaction history CSV             |
+| [Morgan Stanley](morgan-stanley.md)           | `--mssb-dir`                                                                           | Alphabet equity-award report folder |
+| [Sharesight](sharesight.md)                   | `--sharesight-dir`                                                                     | Multi-broker portfolio tracker      |
+| [Trading 212](trading212.md)                  | `--trading212-dir`                                                                     | Folder of yearly exports            |
+| [Vanguard](vanguard.md)                       | `--vanguard-file`                                                                      | Client Transactions Listing CSV     |
+| [RAW format](raw.md)                          | `--raw-file`                                                                           | Generic fallback for other brokers  |
 
 ## Dates and time zones
 

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -285,8 +285,16 @@ Make sure `--schwab-file` points to the main transaction-history CSV and `--schw
 points to the supported award-price CSV. A positions export, realised gain/loss report, statement,
 JSON file or spreadsheet converted from PDF has a different layout.
 
+With `--schwab-dir`, this error names the offending file: take it out of the directory (or, if it is
+the Equity Awards CSV, pass it with `--schwab-award-file` instead).
+
 If you combined several history ranges, confirm that there is one header, every data row has the
 same number of fields, and none of the source files used a different export format.
+
+### `is not a regular file` or `could not be read`
+
+With `--schwab-dir`, every entry matching `*.csv` must be a plain, readable file. Remove or move out
+a subdirectory, broken symlink, or file the current user lacks permission to read.
 
 ### `Unknown action`
 

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -27,11 +27,37 @@ CSV whose columns include `Date`, `Action`, `Symbol`, `Description`, `Price`, `Q
 `Fees & Comm` and `Amount`. You can compare it with the
 [sanitised example](https://github.com/cgt-calc/capital-gains-calculator/blob/main/tests/schwab/data/schwab_transactions.csv).
 
-Schwab may limit how much history can be exported at once. If you need several non-overlapping date
-ranges, keep the original files and make a separate combined CSV for cgt-calc. Combine only files
-with the same headings, keep the heading once, and place the newest date range first. Preserve the
-row order within each export, because some corporate actions use adjacent rows. Check carefully for
-gaps or duplicated dates. `--schwab-file` accepts one main transaction CSV.
+Schwab may limit how much history can be exported at once. If your history needs several exports,
+repeat the process with consecutive date ranges, making sure there are no gaps.
+
+## Prepare the directory
+
+One export goes to `--schwab-file`. Several go in a directory passed to `--schwab-dir`, so you do
+not have to combine them yourself:
+
+```text
+schwab/
+├── 2022-04-06_to_2023-04-05.csv
+├── 2023-04-06_to_2024-04-05.csv
+└── 2024-04-06_to_2025-04-05.csv
+```
+
+The base filenames do not matter. cgt-calc reads every CSV file directly inside the directory, but
+it does not search subdirectories.
+
+Two rules to get right:
+
+- **Do not put the Equity Awards CSV in this directory.** It is also a `.csv`, so cgt-calc would
+  read it as transaction history and stop with `Missing columns in Schwab transaction file`. Keep it
+  elsewhere and pass it with `--schwab-award-file`.
+- **Do not put exports from two different Schwab accounts in one directory.** The CSV does not say
+  which account a row belongs to, so cgt-calc cannot separate them. Combining several accounts is
+  not supported.
+
+Overlaps are **not** safe here, unlike some other brokers. A Schwab CSV carries no transaction ID,
+so cgt-calc cannot tell a row repeated by an overlap from a genuine repeat of the same trade: two
+identical buys of the same size and price on one day are a real thing. If two exports have
+overlapping transaction-date spans, cgt-calc refuses them rather than count both.
 
 ## Generate the report
 
@@ -43,6 +69,14 @@ cgt-calc --year 2025 --schwab-file schwab_transactions.csv
 
 `--year 2025` means 6 April 2025 to 5 April 2026. Follow [Generate Your First Report](../usage.md)
 to find and check the output.
+
+If your history needed several exports, point `--schwab-dir` at the directory holding them instead:
+
+```shell
+cgt-calc --year 2025 --schwab-dir schwab/
+```
+
+`--schwab-file` and `--schwab-dir` cannot be used together.
 
 If a `Stock Plan Activity` row has no price, also pass the supported Equity Awards CSV described
 below:
@@ -228,8 +262,11 @@ use the one with the correct quantity.
 - `Stock Split` supports extra shares from a split, not shares removed by a consolidation.
 - All values in Schwab CSV and JSON files are treated as USD. Changing a currency symbol in the CSV
   does not convert the data.
-- cgt-calc does not remove duplicates from overlapping Schwab exports. Every transaction must appear
-  exactly once.
+- cgt-calc does not remove duplicates from Schwab exports, because the CSV has no transaction ID to
+  tell a duplicate from a genuine repeat of the same trade. Every transaction must appear exactly
+  once. `--schwab-dir` refuses exports whose transaction-date spans overlap rather than count both.
+- Exports from more than one Schwab account cannot be combined. Nothing in the CSV identifies the
+  account.
 
 ## Troubleshooting
 
@@ -290,6 +327,18 @@ sanitised copy of the relevant records.
 This legacy JSON error means the purchased share count does not equal the shares deposited, withheld
 and sold for tax after any known split. Compare those figures with the ESPP confirmation and split
 history. Do not change a quantity merely to make the import continue.
+
+### An export overlaps another one
+
+Two files in the `--schwab-dir` directory have earliest-to-latest transaction-date spans that
+overlap. They need not share any individual date: one file running from March to December and
+another holding a single June transaction is enough, because cgt-calc cannot then rule out that the
+two exports cover the same period. Because a Schwab CSV has no transaction ID, it cannot tell which
+rows are repeats, so it refuses rather than count them twice. Re-export the ranges so they do not
+overlap, or delete the redundant file.
+
+If the two files are exports from different Schwab accounts, that is the cause: cgt-calc cannot
+combine accounts, because no column says which account a row came from.
 
 ### `Reached a negative balance` or `Tried to sell not owned symbol`
 

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -54,6 +54,7 @@ def test_print_completion_outputs_script(
     assert exc_info.value.code == 0
     output = capsys.readouterr().out
     assert "--trading212-dir" in output
+    assert "--schwab-dir" in output
     assert "--initial-prices-file" in output
 
 
@@ -242,6 +243,7 @@ def test_broker_file_arguments_reject_missing_path(
     [
         ("--hl-dir", "hl_dir", "hl"),
         ("--mssb-dir", "mssb_dir", "mssb"),
+        ("--schwab-dir", "schwab_dir", "schwab"),
         ("--sharesight-dir", "sharesight_dir", "sharesight"),
         ("--trading212-dir", "trading212_dir", "trading212"),
     ],
@@ -263,6 +265,7 @@ def test_broker_dir_arguments_accept_existing_directory(
     ("option", "attr"),
     [
         ("--mssb-dir", "mssb_dir"),
+        ("--schwab-dir", "schwab_dir"),
         ("--sharesight-dir", "sharesight_dir"),
         ("--trading212-dir", "trading212_dir"),
     ],

--- a/tests/schwab/test_schwab_cancel_buy.py
+++ b/tests/schwab/test_schwab_cancel_buy.py
@@ -234,8 +234,11 @@ def test_unmatched_cancel_buy_is_refused(tmp_path: Path) -> None:
         "01/05/2020,Buy,MSFT,MICROSOFT CORP,$200.00,5,$0.00,-$1000.00\n"
     )
 
-    with pytest.raises(ParsingError, match="no Buy to match it"):
+    with pytest.raises(ParsingError, match="no Buy to match it") as exc_info:
         SchwabParser().load_from_file(csv_file)
+
+    # The row is what the user has to remove, so the error has to point at it.
+    assert "row 2" in str(exc_info.value)
 
 
 def test_cancel_buy_is_not_typed_as_a_purchase(tmp_path: Path) -> None:

--- a/tests/schwab/test_schwab_dir.py
+++ b/tests/schwab/test_schwab_dir.py
@@ -8,6 +8,7 @@ of the merged result, and the overlap that cannot be deduplicated away.
 
 from __future__ import annotations
 
+from decimal import Decimal
 import logging
 from pathlib import Path
 import shutil
@@ -17,7 +18,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cgt_calc.args_parser import create_parser
-from cgt_calc.exceptions import ParsingError
+from cgt_calc.exceptions import CgtError, ParsingError
 from cgt_calc.parsers.schwab import AwardPrices, SchwabParser
 from tests.utils import build_cmd
 
@@ -171,6 +172,54 @@ def test_empty_directory_warns(
     assert "No transactions detected in directory" in caplog.text
 
 
+def test_csv_named_subdirectory_is_refused(tmp_path: Path) -> None:
+    """A directory matching the CSV glob gets an actionable parsing error."""
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "archive.csv").mkdir()
+
+    with pytest.raises(ParsingError) as exc_info:
+        _load(schwab_dir=str(directory))
+
+    message = str(exc_info.value)
+    assert "archive.csv" in message
+    assert "not a regular file" in message
+    assert "Remove or move it" in message
+
+
+def test_awards_csv_in_directory_points_to_award_flag(tmp_path: Path) -> None:
+    """An award-shaped CSV explains where it belongs."""
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "awards.csv").write_text(
+        "Date,Symbol,FairMarketValuePrice\n2024/01/01,AAPL,$150.00\n"
+    )
+
+    with pytest.raises(ParsingError) as exc_info:
+        _load(schwab_dir=str(directory))
+
+    message = str(exc_info.value)
+    assert "awards.csv" in message
+    assert "every *.csv" in message.lower()
+    assert "--schwab-award-file" in message
+    assert "remove or move this file" in message
+
+
+def test_foreign_csv_in_directory_says_to_remove_it(tmp_path: Path) -> None:
+    """An unrelated CSV explains that directory imports consume every CSV."""
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "freetrade.csv").write_text("Title,Type,Timestamp\nTrade,BUY,now\n")
+
+    with pytest.raises(ParsingError) as exc_info:
+        _load(schwab_dir=str(directory))
+
+    message = str(exc_info.value)
+    assert "freetrade.csv" in message
+    assert "every *.csv" in message.lower()
+    assert "remove or move this file" in message
+
+
 def test_directory_of_only_cancelled_buys_warns(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -278,3 +327,143 @@ def test_each_transaction_records_its_own_file(tmp_path: Path) -> None:
     ]
     assert len(older) == 2, "both rows of the older export are stamped"
     assert older == sorted(older)
+
+
+def test_overlap_splitting_a_corporate_action_reports_the_overlap(
+    tmp_path: Path,
+) -> None:
+    """The overlap is the fault, so the overlap is what gets reported.
+
+    A Cash Merger and its adjustment share a date, so an overlap is the only
+    thing that can put them in different files. Pairing them per file before
+    checking for the overlap blames the half that is missing from each file
+    and never mentions the redundant export that caused it.
+    """
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "newer.csv").write_text(
+        HEADER + "01/12/2024,Cash Merger,FOO,FOO CORP,,,,$1000.00\n"
+    )
+    (directory / "older.csv").write_text(
+        HEADER + "01/12/2024,Cash Merger Adj,FOO,FOO CORP,,-100,,\n"
+    )
+
+    with pytest.raises(ParsingError) as exc_info:
+        _load(schwab_dir=str(directory))
+
+    message = str(exc_info.value)
+    assert "newer.csv" in message
+    assert "older.csv" in message
+    assert "no transaction id" in message
+    assert "Cash Merger Adj must be preceded" not in message
+
+
+def test_corporate_action_pair_inside_one_file_still_combines(
+    tmp_path: Path,
+) -> None:
+    """Pairing after the overlap check still pairs what belongs together."""
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "transactions.csv").write_text(
+        HEADER
+        + "01/12/2024,Cash Merger,FOO,FOO CORP,,,,$1000.00\n"
+        + "01/12/2024,Cash Merger Adj,FOO,FOO CORP,,-100,,\n"
+    )
+
+    (transaction,) = _load(schwab_dir=str(directory))
+    assert transaction.quantity == Decimal(100)
+    assert transaction.price == Decimal("10.00")
+
+
+def test_unmatched_cancel_buy_names_its_own_file_and_row(tmp_path: Path) -> None:
+    """The row to remove is in one file, and the error has to say which.
+
+    Cancellation matching runs on the merged directory, so the path handed to
+    it is the directory. "Remove this row" is unusable unless the error points
+    at the file and line the row was read from.
+    """
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "a_older.csv").write_text(
+        HEADER + "01/01/2024,Buy,AAPL,APPLE INC,$1.00,1,$0.00,-$1.00\n"
+    )
+    (directory / "z_newer.csv").write_text(
+        HEADER
+        + "01/17/2024,Sell,AAPL,APPLE INC,$1.00,1,$0.00,$1.00\n"
+        + "01/16/2024,Cancel Buy,AAPL,APPLE INC,$150.00,10,$0.00,$0.00\n"
+    )
+
+    with pytest.raises(ParsingError) as exc_info:
+        _load(schwab_dir=str(directory))
+
+    message = str(exc_info.value)
+    assert "z_newer.csv" in message
+    assert "row 3" in message
+    assert "no Buy to match it" in message
+
+
+def test_load_from_args_refuses_file_and_dir_without_argparse(
+    tmp_path: Path,
+) -> None:
+    """The parser refuses both flags itself, not only through main().
+
+    argparse gives the usage message and exit code 2, but it is main() that
+    calls it. Taking the directory branch on its own would drop every
+    transaction in the file with nothing said.
+    """
+    whole = tmp_path / "whole.csv"
+    whole.write_text(HEADER + NEWER)
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "transactions.csv").write_text(HEADER + OLDER)
+
+    with pytest.raises(CgtError, match="cannot be used together"):
+        _load(schwab_file=str(whole), schwab_dir=str(directory))
+
+
+def test_directory_load_honours_the_file_path_filter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The directory conventions are read through cls, not hardcoded.
+
+    Schwab cannot inherit BaseDirParser, so glob_dir and file_path_filter are
+    declared on it instead. Reading them through cls is what keeps a later
+    change to those conventions from passing Schwab by.
+    """
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "a_2023.csv").write_text(HEADER + OLDER)
+    (directory / "z_2024.csv").write_text(HEADER + NEWER)
+
+    assert SchwabParser.glob_dir == "*.csv"
+    monkeypatch.setattr(
+        SchwabParser,
+        "file_path_filter",
+        classmethod(lambda cls, file_path: file_path.name != "z_2024.csv"),
+    )
+
+    transactions = _load(schwab_dir=str(directory))
+    assert {
+        transaction.source.file.name
+        for transaction in transactions
+        if transaction.source and transaction.source.file
+    } == {"a_2023.csv"}
+
+
+def test_export_with_no_rows_is_skipped_not_refused(tmp_path: Path) -> None:
+    """A range Schwab had nothing to report is a header and no rows.
+
+    It contributes no dates, so it cannot take part in the overlap check and
+    is simply left out rather than treated as an empty directory.
+    """
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "a_empty.csv").write_text(HEADER)
+    (directory / "z_2024.csv").write_text(HEADER + NEWER)
+
+    transactions = _load(schwab_dir=str(directory))
+    assert {
+        transaction.source.file.name
+        for transaction in transactions
+        if transaction.source and transaction.source.file
+    } == {"z_2024.csv"}

--- a/tests/schwab/test_schwab_dir.py
+++ b/tests/schwab/test_schwab_dir.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 import logging
+import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -187,6 +188,33 @@ def test_csv_named_subdirectory_is_refused(tmp_path: Path) -> None:
     assert "Remove or move it" in message
 
 
+@pytest.mark.skipif(
+    os.name == "nt" or os.geteuid() == 0,
+    reason="permission bits are POSIX only and root ignores them",
+)
+def test_unreadable_csv_in_directory_is_refused(tmp_path: Path) -> None:
+    """A file the current user cannot open gets a ParsingError, not a crash.
+
+    The directory-named-*.csv case above is one way opening a directory
+    entry can fail; a permission-denied file is another. Both must raise
+    ParsingError rather than let the underlying OSError escape.
+    """
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    locked = directory / "locked.csv"
+    locked.write_text(HEADER + OLDER)
+    locked.chmod(0o000)
+    try:
+        with pytest.raises(ParsingError) as exc_info:
+            _load(schwab_dir=str(directory))
+    finally:
+        locked.chmod(0o644)
+
+    message = str(exc_info.value)
+    assert "locked.csv" in message
+    assert "Remove or move it" in message
+
+
 def test_awards_csv_in_directory_points_to_award_flag(tmp_path: Path) -> None:
     """An award-shaped CSV explains where it belongs."""
     directory = tmp_path / "schwab"
@@ -217,6 +245,21 @@ def test_foreign_csv_in_directory_says_to_remove_it(tmp_path: Path) -> None:
     message = str(exc_info.value)
     assert "freetrade.csv" in message
     assert "every *.csv" in message.lower()
+    assert "remove or move this file" in message
+
+
+def test_empty_csv_in_directory_says_to_remove_it(tmp_path: Path) -> None:
+    """A zero-byte stray CSV gets the same directory guidance as a bad header."""
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "empty.csv").write_text("")
+
+    with pytest.raises(ParsingError) as exc_info:
+        _load(schwab_dir=str(directory))
+
+    message = str(exc_info.value)
+    assert "empty.csv" in message
+    assert "is empty" in message
     assert "remove or move this file" in message
 
 
@@ -419,6 +462,31 @@ def test_load_from_args_refuses_file_and_dir_without_argparse(
 
     with pytest.raises(CgtError, match="cannot be used together"):
         _load(schwab_file=str(whole), schwab_dir=str(directory))
+
+
+def test_both_flags_are_refused_before_the_award_file_is_read(
+    tmp_path: Path,
+) -> None:
+    """The flag conflict is reported even when the award file is broken too.
+
+    load_from_args used to read --schwab-award-file before checking the
+    flags, so a bad award file masked the real problem: fix the argument
+    error before doing any I/O on the arguments.
+    """
+    whole = tmp_path / "whole.csv"
+    whole.write_text(HEADER + NEWER)
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "transactions.csv").write_text(HEADER + OLDER)
+    bad_award_file = tmp_path / "bad-award.csv"
+    bad_award_file.write_text("")  # would itself raise "CSV file is empty"
+
+    with pytest.raises(CgtError, match="cannot be used together"):
+        _load(
+            schwab_file=str(whole),
+            schwab_dir=str(directory),
+            schwab_award_file=str(bad_award_file),
+        )
 
 
 def test_directory_load_honours_the_file_path_filter(

--- a/tests/schwab/test_schwab_dir.py
+++ b/tests/schwab/test_schwab_dir.py
@@ -1,0 +1,280 @@
+"""Test parsing a directory of Schwab exports with --schwab-dir.
+
+Schwab limits how much history one export covers, so a long history arrives as
+several date-range CSVs. These tests cover what splitting an export across
+files changes: a Cancel Buy whose Buy is in the neighbouring file, the ordering
+of the merged result, and the overlap that cannot be deduplicated away.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cgt_calc.args_parser import create_parser
+from cgt_calc.exceptions import ParsingError
+from cgt_calc.parsers.schwab import AwardPrices, SchwabParser
+from tests.utils import build_cmd
+
+if TYPE_CHECKING:
+    from cgt_calc.model import BrokerTransaction
+
+HEADER = "Date,Action,Symbol,Description,Price,Quantity,Fees & Comm,Amount\n"
+
+# Newest-first within each file, as a real Schwab export is.
+NEWER = (
+    "03/10/2024,Sell,AAPL,APPLE INC,$180.00,5,$0.00,$900.00\n"
+    "02/02/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+)
+OLDER = (
+    "11/20/2023,Buy,AAPL,APPLE INC,$120.00,20,$0.00,-$2400.00\n"
+    "06/05/2023,MoneyLink Transfer,,Deposit,,,,$5000.00\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_awards_prices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep changes to the class-level award prices out of other test modules."""
+    monkeypatch.setattr(SchwabParser, "awards_prices", AwardPrices(award_prices={}))
+
+
+def _load(**flags: str) -> list[BrokerTransaction]:
+    """Load through the CLI wiring rather than calling the parser directly.
+
+    load_from_args is what registers --schwab-dir and fills in awards_prices,
+    so bypassing it would let the flag be misregistered with every test still
+    passing.
+    """
+    argv = ["--year", "2023"]
+    for flag, value in flags.items():
+        argv += [f"--{flag.replace('_', '-')}", value]
+    args = create_parser().parse_args(argv)
+    return SchwabParser.load_from_args(args)
+
+
+def test_cancel_buy_matches_a_buy_in_another_file(tmp_path: Path) -> None:
+    """The Buy a Cancel Buy reverses may sit in the neighbouring export.
+
+    The pair is within CANCEL_BUY_SEARCH_DAYS but falls either side of a chunk
+    boundary. Parsing each file alone leaves the cancellation unmatched, which
+    is a hard error, so this only works once the files are merged.
+    """
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "newer.csv").write_text(
+        HEADER + "01/12/2024,Cancel Buy,AAPL,APPLE INC,$150.00,10,$0.00,$0.00\n"
+    )
+    (directory / "older.csv").write_text(
+        HEADER + "01/10/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+    )
+
+    assert _load(schwab_dir=str(directory)) == []
+
+
+def test_split_export_matches_the_whole_file(tmp_path: Path) -> None:
+    """A split export gives what the same rows give as one file.
+
+    The chunks are named so that sorting by filename yields the OLDEST first,
+    which is the opposite of the newest-first order the pipeline needs. Named
+    the other way round, filename order would happen to be correct and this
+    test would pass against an implementation that never sorts by date.
+    """
+    whole = tmp_path / "whole.csv"
+    whole.write_text(HEADER + NEWER + OLDER)
+
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "a_2023.csv").write_text(HEADER + OLDER)
+    (directory / "z_2024.csv").write_text(HEADER + NEWER)
+
+    from_dir = _load(schwab_dir=str(directory))
+    from_file = _load(schwab_file=str(whole))
+
+    assert [str(transaction) for transaction in from_dir] == [
+        str(transaction) for transaction in from_file
+    ]
+    assert [transaction.date for transaction in from_dir] == sorted(
+        transaction.date for transaction in from_dir
+    )
+
+
+def test_single_file_directory_matches_the_file_through_the_award_path(
+    tmp_path: Path,
+) -> None:
+    """A directory of one file equals that file, awards included.
+
+    Only transactions.csv is copied: the fixture directory also holds
+    awards.csv, which the *.csv glob would read as transaction history and
+    reject for missing Price and Fees & Comm.
+
+    That fixture's only Stock Plan Activity has a blank Price, so this raises
+    "Cannot price a vest" unless awards_prices reaches the row parser.
+    """
+    fixture = Path("tests") / "schwab" / "data" / "rsu_settlement"
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    shutil.copy(fixture / "transactions.csv", directory / "transactions.csv")
+    awards = str(fixture / "awards.csv")
+
+    from_dir = _load(schwab_dir=str(directory), schwab_award_file=awards)
+    from_file = _load(
+        schwab_file=str(fixture / "transactions.csv"), schwab_award_file=awards
+    )
+
+    assert from_dir
+    assert [str(transaction) for transaction in from_dir] == [
+        str(transaction) for transaction in from_file
+    ]
+
+
+def test_overlapping_exports_are_refused(tmp_path: Path) -> None:
+    """Overlapping exports cannot be deduplicated, so they are refused."""
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "first.csv").write_text(HEADER + NEWER + OLDER)
+    (directory / "second.csv").write_text(HEADER + NEWER)
+
+    with pytest.raises(ParsingError) as exc_info:
+        _load(schwab_dir=str(directory))
+
+    message = str(exc_info.value)
+    assert "second.csv" in message
+    assert "first.csv" in message
+    assert "no transaction id" in message
+
+
+def test_adjacent_exports_are_not_refused(tmp_path: Path) -> None:
+    """Consecutive ranges that merely touch in time are fine."""
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "a_2023.csv").write_text(HEADER + OLDER)
+    (directory / "z_2024.csv").write_text(HEADER + NEWER)
+
+    assert len(_load(schwab_dir=str(directory))) == 4
+
+
+def test_empty_directory_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A directory holding no CSV file reports nothing found."""
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+
+    with caplog.at_level(logging.WARNING):
+        assert _load(schwab_dir=str(directory)) == []
+
+    assert "No transactions detected in directory" in caplog.text
+
+
+def test_directory_of_only_cancelled_buys_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An all-cancelled directory is empty too, and has to say so.
+
+    The rows survive parsing and are only dropped by cancellation matching,
+    which runs after the files are merged. Checking for an empty result before
+    that would leave this case silent.
+    """
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "transactions.csv").write_text(
+        HEADER
+        + "01/12/2024,Cancel Buy,AAPL,APPLE INC,$150.00,10,$0.00,$0.00\n"
+        + "01/10/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert _load(schwab_dir=str(directory)) == []
+
+    assert "No transactions detected in directory" in caplog.text
+
+
+def test_identical_trades_are_not_deduplicated(tmp_path: Path) -> None:
+    """Two identical buys on one day are two real trades, not a duplicate.
+
+    A Schwab CSV has no transaction id, so nothing distinguishes a repeated
+    row from a genuine repeat. This is why the directory never deduplicates,
+    and why overlapping exports are refused instead.
+    """
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "transactions.csv").write_text(
+        HEADER
+        + "02/02/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+        + "02/02/2024,Buy,AAPL,APPLE INC,$150.00,10,$0.00,-$1500.00\n"
+    )
+
+    assert len(_load(schwab_dir=str(directory))) == 2
+
+
+def test_file_and_dir_together_are_refused(tmp_path: Path) -> None:
+    """Merging a file and a directory would reintroduce undetectable overlap.
+
+    Run the real CLI rather than calling the validator: the check only helps if
+    main() actually invokes it, and calling it directly would still pass if that
+    call were removed.
+    """
+    whole = tmp_path / "whole.csv"
+    whole.write_text(HEADER + NEWER)
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "transactions.csv").write_text(HEADER + OLDER)
+
+    result = subprocess.run(
+        build_cmd(
+            "--year",
+            "2023",
+            "--schwab-file",
+            str(whole),
+            "--schwab-dir",
+            str(directory),
+        ),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "--schwab-file and --schwab-dir cannot be used together" in result.stderr
+
+
+def test_each_transaction_records_its_own_file(tmp_path: Path) -> None:
+    """Provenance survives the merge: one account, but the right file each.
+
+    load_from_dir does its own reading rather than going through
+    load_from_file, so it has to stamp the source itself or every row in a
+    directory would come back with no parser, account or file.
+    """
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "a_2023.csv").write_text(HEADER + OLDER)
+    (directory / "z_2024.csv").write_text(HEADER + NEWER)
+
+    transactions = _load(schwab_dir=str(directory))
+    sources = []
+    for transaction in transactions:
+        assert transaction.source is not None, "every row must record its origin"
+        sources.append(transaction.source)
+
+    assert {source.file.name for source in sources if source.file} == {
+        "a_2023.csv",
+        "z_2024.csv",
+    }
+    assert len({source.account for source in sources}) == 1, (
+        "one directory is one declared account boundary"
+    )
+    assert {source.parser for source in sources} == {"Charles Schwab"}
+
+    # index rises with time, as it does on the single-file path.
+    older = [
+        source.index
+        for source in sources
+        if source.file and source.file.name == "a_2023.csv" and source.index is not None
+    ]
+    assert len(older) == 2, "both rows of the older export are stamped"
+    assert older == sorted(older)


### PR DESCRIPTION
Adds `--schwab-dir` so a history split across several Schwab exports does not
have to be merged by hand. `--schwab-file` is unchanged and the two cannot be
combined.

Overlapping exports are refused rather than deduplicated: a Schwab CSV has no
transaction id, so a repeated row cannot be told from a genuine repeat of the
same trade. A stray entry in the directory - a subdirectory, an unreadable or
empty file, an award CSV, an unrelated export - is refused with an error naming
it and where it belongs.

Builds on #1041 - a directory is one account boundary, with each row recording
its own file, so errors like an unmatched Cancel Buy name the file and row.
