### PR TITLE
Fix nested list rendering in documentation

### DIFF
--- a/docs/brokers/freetrade.md
+++ b/docs/brokers/freetrade.md
@@ -80,9 +80,9 @@ merger, split or other reorganisation:
 
 1. Compare the CSV with your contract notes, messages and statements.
 2. Ask Freetrade support for an
-   [activity statement that includes corporate actions](https://help.freetrade.io/en/articles/6416976-what-s-an-activity-statement-and-how-can-i-request-one).
+    [activity statement that includes corporate actions](https://help.freetrade.io/en/articles/6416976-what-s-an-activity-statement-and-how-can-i-request-one).
 3. Supply any missing transactions through another supported broker export or the
-   [RAW format](raw.md), after verifying the dates, costs and UK tax treatment.
+    [RAW format](raw.md), after verifying the dates, costs and UK tax treatment.
 
 The additional Freetrade statement is a source for finding missing activity; cgt-calc does not
 promise to import its corporate-action rows directly.
@@ -90,17 +90,17 @@ promise to import its corporate-action rows directly.
 ## Known limitations
 
 - Only the transaction types listed above are mapped. Another value stops the import; do not delete
-  a financial transaction merely to make the calculation run.
+    a financial transaction merely to make the calculation run.
 - Current exports add `Stock Split ...` columns, but `STOCK_SPLIT` rows are not yet mapped. The
-  columns are accepted so ordinary rows can still be imported; an actual split row stops with
-  `Unknown type`.
+    columns are accepted so ordinary rows can still be imported; an actual split row stops with
+    `Unknown type`.
 - The importer supports a GBP account currency only. Changing the currency text in the CSV would not
-  convert its amounts.
+    convert its amounts.
 - The export has no asset-class column, and the importer does not use one. Every `ORDER` is
-  processed as a share or fund acquisition or disposal; do not rely on this path for gilts, Treasury
-  bills or another instrument whose tax treatment differs.
+    processed as a share or fund acquisition or disposal; do not rely on this path for gilts,
+    Treasury bills or another instrument whose tax treatment differs.
 - A `FREESHARE_ORDER` is assigned zero acquisition cost. Check whether that treatment is appropriate
-  for the way you received the award before relying on its eventual gain.
+    for the way you received the award before relying on its eventual gain.
 
 ## Troubleshooting
 
@@ -111,9 +111,9 @@ cgt-calc ignores the two document types described under [Supported activity](#su
 Identify any other named row in Freetrade before deciding what to do with it:
 
 - a queued order should be replaced by its executed contract note if it later executed, or removed
-  if it was cancelled; and
+    if it was cancelled; and
 - a transfer or corporate action may need the extra records described in
-  [Check for missing activity](#check-for-missing-activity).
+    [Check for missing activity](#check-for-missing-activity).
 
 If the row is an executed transaction not covered by [Supported activity](#supported-activity),
 first upgrade cgt-calc using the same method you used to install it. If it still fails, open a

--- a/docs/brokers/hargreaves-lansdown.md
+++ b/docs/brokers/hargreaves-lansdown.md
@@ -18,12 +18,12 @@ non-overlapping periods so that the same transaction is not imported twice.
 1. Sign in to the HL website and open the Tax Centre, currently under **Accounts**.
 2. Generate the required Transaction Summary and download the CSV offered with the completed report.
 3. For every buy or sell in the CSV, download the linked PDF contract note. Contract notes are also
-   available from **Transaction History**. The HL instructions for
-   [share and ETF trades](https://www.hl.co.uk/help/buying-selling-investments/shares-investment-trusts-etfs/buy-shares)
-   and [fund trades](https://www.hl.co.uk/help/buying-selling-investments/funds/buy-funds) confirm
-   where completed trades and their notes appear.
+    available from **Transaction History**. The HL instructions for
+    [share and ETF trades](https://www.hl.co.uk/help/buying-selling-investments/shares-investment-trusts-etfs/buy-shares)
+    and [fund trades](https://www.hl.co.uk/help/buying-selling-investments/funds/buy-funds) confirm
+    where completed trades and their notes appear.
 4. Put all the Transaction Summary CSV files and their contract-note PDFs in one directory. Do not
-   put unrelated CSV files there; cgt-calc attempts to parse every CSV in the directory.
+    put unrelated CSV files there; cgt-calc attempts to parse every CSV in the directory.
 
 Each trade has a reference such as `B302087054` or `S302087055`. Its PDF filename must begin with
 that complete reference followed by an underscore, for example:
@@ -84,22 +84,22 @@ but any other non-blank reference stops the import with `Unknown transaction typ
 ## Known limitations
 
 - Dividends, tax deductions, transfers of investments and corporate actions are not mapped. A
-  non-blank row for any of them stops the import rather than being silently discarded.
+    non-blank row for any of them stops the import rather than being silently discarded.
 - Every recognised buy or sell requires a matching PDF. The
-  [HL service terms](https://www.hl.co.uk/__data/assets/pdf_file/0015/37122/Online-Ts-and-Cs.pdf)
-  say that it does not issue contract notes for some fund transactions, including certain regular
-  investments, automatic reinvestment and sales made to cover fees. Those trades cannot be imported
-  from the Transaction Summary alone.
+    [HL service terms](https://www.hl.co.uk/__data/assets/pdf_file/0015/37122/Online-Ts-and-Cs.pdf)
+    say that it does not issue contract notes for some fund transactions, including certain regular
+    investments, automatic reinvestment and sales made to cover fees. Those trades cannot be
+    imported from the Transaction Summary alone.
 - The PDF reader expects the text-based HL contract-note layout and extracts only the field labelled
-  `Dealing charge`. Scanned PDFs, changed layouts, foreign-currency trades, stamp duty or other
-  charges have not been validated and can make the trade fail its amount checks.
+    `Dealing charge`. Scanned PDFs, changed layouts, foreign-currency trades, stamp duty or other
+    charges have not been validated and can make the trade fail its amount checks.
 - The parser does not inspect the investment type. It has been tested with an ordinary GBP-priced
-  ETF; do not rely on this importer for gilts, bonds, derivatives or another instrument whose UK tax
-  treatment differs.
+    ETF; do not rely on this importer for gilts, bonds, derivatives or another instrument whose UK
+    tax treatment differs.
 - Every CSV in the directory is parsed and overlapping reports are not deduplicated. Keep unrelated
-  CSVs elsewhere and make each reporting period occur exactly once.
+    CSVs elsewhere and make each reporting period occur exactly once.
 - The action and trade date extracted from a PDF are not cross-checked with the CSV. The filename
-  reference is the link, so verify that each reference points to the correct note.
+    reference is the link, so verify that each reference points to the correct note.
 
 ## Troubleshooting
 

--- a/docs/brokers/interactive-brokers.md
+++ b/docs/brokers/interactive-brokers.md
@@ -15,11 +15,11 @@ balance check detect an incomplete export.
 
 1. Sign in to the Interactive Brokers Client Portal in a web browser.
 2. Open **Performance & Reports → Transaction History**. Alternatively, open **Menu → Reporting →
-   Transaction History**.
+    Transaction History**.
 3. Select **Custom** as the period and set the start to the account's first transaction. Set the end
-   to today, or at least 30 days after the end of the tax year you are calculating.
+    to today, or at least 30 days after the end of the tax year you are calculating.
 4. Clear any transaction-type or symbol filters so the export includes trades, income, fees and cash
-   movements.
+    movements.
 5. Download the table using its CSV export control.
 
 IBKR's current
@@ -78,18 +78,18 @@ treaty applies.
 ## Known limitations
 
 - Only the transaction types listed above are mapped. Any other value stops the import with
-  `Unknown type`; do not delete the row merely to make the calculation run.
+    `Unknown type`; do not delete the row merely to make the calculation run.
 - Cash `Deposit` and `Withdrawal` rows are supported, but transfers of shares or funds between
-  accounts are not. Corporate actions such as splits, mergers and spin-offs are not mapped from an
-  IBKR export either.
+    accounts are not. Corporate actions such as splits, mergers and spin-offs are not mapped from an
+    IBKR export either.
 - The importer does not read an asset-class field. It has been validated for ordinary share and fund
-  trades; do not rely on it to calculate options, futures, bonds, contracts for difference or crypto
-  assets.
+    trades; do not rely on it to calculate options, futures, bonds, contracts for difference or
+    crypto assets.
 - Every `Foreign Tax Withholding` row is treated as dividend tax. If IBKR withholds tax from credit
-  interest and does not reverse it, cgt-calc records that amount against a placeholder symbol. It
-  reduces the cash balance but is not reported as interest tax in the summary.
+    interest and does not reverse it, cgt-calc records that amount against a placeholder symbol. It
+    reduces the cash balance but is not reported as interest tax in the summary.
 - The `Account` column is not used to keep separate ledgers. Rows for multiple taxable IBKR accounts
-  in one CSV are combined under one broker balance and portfolio.
+    in one CSV are combined under one broker balance and portfolio.
 
 ## Troubleshooting
 

--- a/docs/brokers/morgan-stanley.md
+++ b/docs/brokers/morgan-stanley.md
@@ -66,17 +66,17 @@ July 2022.
 ## Known limitations
 
 - This is an Alphabet-specific equity-award importer, not general Morgan Stanley support. Any plan
-  other than the literal `GSU Class C` or `Cash` value stops with `Unknown plan`.
+    other than the literal `GSU Class C` or `Cash` value stops with `Unknown plan`.
 - Autosale releases are not supported. They can put a non-zero `Net Cash Proceeds` in the releases
-  report while recording the actual sale in a separate Autosale report that cgt-calc does not parse.
-  The import deliberately stops rather than silently losing either the vest or sale.
+    report while recording the actual sale in a separate Autosale report that cgt-calc does not
+    parse. The import deliberately stops rather than silently losing either the vest or sale.
 - Only the report names and row values listed above are recognised. Other report files are ignored;
-  another type, status, header layout or price currency stops the import.
+    another type, status, header layout or price currency stops the import.
 - Dividends, interest, wires, transfers of shares, and other corporate actions are not imported from
-  this report directory. Add any relevant missing activity through another supported export or the
-  [RAW format](raw.md), after verifying its date, amount and UK tax treatment.
+    this report directory. Add any relevant missing activity through another supported export or the
+    [RAW format](raw.md), after verifying its date, amount and UK tax treatment.
 - A `Staged` release is treated as an acquisition. Confirm that it completed and agrees with your
-  final award record before relying on it.
+    final award record before relying on it.
 
 ## Troubleshooting
 

--- a/docs/brokers/raw.md
+++ b/docs/brokers/raw.md
@@ -110,17 +110,17 @@ a price for both has to be available.
 ## Known limitations
 
 - The format has no ISIN or source-country column. For a dividend with withholding tax, when
-  cgt-calc cannot match the ticker to a known ISIN, it guesses the source country from the currency
-  when possible: `USD` is treated as US and `PLN` as Poland. An investment domiciled elsewhere can
-  consequently receive the wrong treaty treatment without a source-country warning; that warning is
-  issued only when withholding tax was deducted and cgt-calc cannot infer a country from the
-  currency. Verify foreign dividend income and tax against the broker statement rather than assuming
-  that treaty limits were applied.
+    cgt-calc cannot match the ticker to a known ISIN, it guesses the source country from the
+    currency when possible: `USD` is treated as US and `PLN` as Poland. An investment domiciled
+    elsewhere can consequently receive the wrong treaty treatment without a source-country warning;
+    that warning is issued only when withholding tax was deducted and cgt-calc cannot infer a
+    country from the currency. Verify foreign dividend income and tax against the broker statement
+    rather than assuming that treaty limits were applied.
 - The format does not identify the instrument type. It is intended for ordinary shares and funds; do
-  not rely on it for options, futures, bonds, contracts for difference, crypto assets or another
-  instrument whose UK tax treatment differs.
+    not rely on it for options, futures, bonds, contracts for difference, crypto assets or another
+    instrument whose UK tax treatment differs.
 - The seven columns cannot describe every internal action. Ticker renames and cancelled purchases
-  are examples that a RAW row cannot express; use only the documented actions above.
+    are examples that a RAW row cannot express; use only the documented actions above.
 
 ## Combining RAW with a broker export
 

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -15,11 +15,11 @@ Use the Schwab website rather than a positions export, statement, realised gain/
 
 1. Open the transaction history for the taxable brokerage account.
 2. Select the longest date range available. Start with the account's first transaction if possible,
-   as explained in [Before you start](../usage.md#before-you-start). End today or at least 30 days
-   after the end of the tax year you are calculating, because a purchase in the 30 days after a
-   disposal can affect how that disposal is matched.
+    as explained in [Before you start](../usage.md#before-you-start). End today or at least 30 days
+    after the end of the tax year you are calculating, because a purchase in the 30 days after a
+    disposal can affect how that disposal is matched.
 3. Include all transaction types. A trade-only export can omit deposits, dividends, tax, fees and
-   corporate actions needed by the calculation.
+    corporate actions needed by the calculation.
 4. Export the results as CSV.
 
 The exact controls are behind the Schwab login and may change. Use the account's transaction-history
@@ -48,11 +48,11 @@ it does not search subdirectories.
 Two rules to get right:
 
 - **Do not put the Equity Awards CSV in this directory.** It is also a `.csv`, so cgt-calc would
-  read it as transaction history and stop with `Missing columns in Schwab transaction file`. Keep it
-  elsewhere and pass it with `--schwab-award-file`.
+    read it as transaction history and stop with `Missing columns in Schwab transaction file`. Keep
+    it elsewhere and pass it with `--schwab-award-file`.
 - **Do not put exports from two different Schwab accounts in one directory.** The CSV does not say
-  which account a row belongs to, so cgt-calc cannot separate them. Combining several accounts is
-  not supported.
+    which account a row belongs to, so cgt-calc cannot separate them. Combining several accounts is
+    not supported.
 
 Overlaps are **not** safe here, unlike some other brokers. A Schwab CSV carries no transaction ID,
 so cgt-calc cannot tell a row repeated by an overlap from a genuine repeat of the same trade: two
@@ -179,8 +179,8 @@ Use this method when the main transaction CSV contains `Stock Plan Activity` row
 `Price`:
 
 1. In Schwab, open the Equity Awards account. Schwab's
-   [grant guide](https://eac.schwab.com/content/how-to-accept-your-grant) shows how to reach the
-   account from **Accounts → Equity Awards**.
+    [grant guide](https://eac.schwab.com/content/how-to-accept-your-grant) shows how to reach the
+    account from **Accounts → Equity Awards**.
 2. Export its complete transaction history as CSV.
 3. Check that the file's heading contains `Date`, `Symbol` and `FairMarketValuePrice`.
 4. Pass it with `--schwab-award-file` alongside the main CSV.
@@ -239,10 +239,10 @@ A JSON `Gift` row says that shares left the account but not who received them. c
 stops and asks you to classify it:
 
 - For a spouse or civil partner, follow
-  [Transfers to a spouse or civil partner](raw.md#transfers-to-a-spouse-or-civil-partner) and add
-  the suggested `TRANSFER_TO_SPOUSE` row through a small RAW file.
+    [Transfers to a spouse or civil partner](raw.md#transfers-to-a-spouse-or-civil-partner) and add
+    the suggested `TRANSFER_TO_SPOUSE` row through a small RAW file.
 - For anyone else, follow [Gifts to anyone else](raw.md#gifts-to-anyone-else) and add the suggested
-  `GIFT` or `GIFT_UNCONNECTED` row using a verified market value.
+    `GIFT` or `GIFT_UNCONNECTED` row using a verified market value.
 
 The error prints the complete RAW line to copy into a small CSV. The JSON importer can restate an
 old gift for a later split, so the quantity may not match the number of shares shown on the gift
@@ -252,21 +252,22 @@ use the one with the correct quantity.
 ## Known limitations
 
 - Transfers of shares are not reconstructed from the main CSV. In particular, `Journaled Shares` is
-  unsupported. Despite its name, `Security Transfer` is supported only as an `ACH`-related cash
-  movement: it requires an `Amount` and does not move shares. Follow the RAW transfer or gift
-  instructions only after establishing what the transfer was and what cost should move with it.
+    unsupported. Despite its name, `Security Transfer` is supported only as an `ACH`-related cash
+    movement: it requires an `Amount` and does not move shares. Follow the RAW transfer or gift
+    instructions only after establishing what the transfer was and what cost should move with it.
 - The newer Equity Awards CSV layout without `FairMarketValuePrice` is unsupported, as described
-  above.
+    above.
 - A cash merger that gives replacement shares as well as cash is not supported. The cash-only
-  importer prints a warning for every merger so you remember to check this.
+    importer prints a warning for every merger so you remember to check this.
 - `Stock Split` supports extra shares from a split, not shares removed by a consolidation.
 - All values in Schwab CSV and JSON files are treated as USD. Changing a currency symbol in the CSV
-  does not convert the data.
+    does not convert the data.
 - cgt-calc does not remove duplicates from Schwab exports, because the CSV has no transaction ID to
-  tell a duplicate from a genuine repeat of the same trade. Every transaction must appear exactly
-  once. `--schwab-dir` refuses exports whose transaction-date spans overlap rather than count both.
+    tell a duplicate from a genuine repeat of the same trade. Every transaction must appear exactly
+    once. `--schwab-dir` refuses exports whose transaction-date spans overlap rather than count
+    both.
 - Exports from more than one Schwab account cannot be combined. Nothing in the CSV identifies the
-  account.
+    account.
 
 ## Troubleshooting
 

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -19,7 +19,7 @@ disposals in the tax year you are reporting; see [Before you start](../usage.md#
 3. Select **Do not group (Holdings)**.
 4. Export the report to a spreadsheet or Google Drive. Do not use the PDF export.
 5. Open the exported spreadsheet and save or download the sheet containing the All Trades table as a
-   CSV file.
+    CSV file.
 
 See Sharesight's current
 [All Trades Report instructions](https://help.sharesight.com/uk/trades_report/) for the report
@@ -91,17 +91,17 @@ these markers.
 ## Known limitations
 
 - [`Opening Balance`](https://help.sharesight.com/opening-balance/) trades are not supported.
-  Sharesight uses them when the original buy and sell records are unavailable, but cgt-calc needs
-  the original acquisition dates and costs for UK share matching.
+    Sharesight uses them when the original buy and sell records are unavailable, but cgt-calc needs
+    the original acquisition dates and costs for UK share matching.
 - `Split`, `Consolidation` and `Bonus` rows are not supported. They stop the import with an unknown
-  action error. Do not delete such a row to make the calculation run: later quantities and gains
-  could be wrong.
+    action error. Do not delete such a row to make the calculation run: later quantities and gains
+    could be wrong.
 - Cash deposits, withdrawals and balances are not imported, which is why `--no-balance-check` is
-  required.
+    required.
 - Taxable Income sections other than local and foreign dividend payments are not imported.
 - If a newer All Trades report gives a non-zero brokerage charge in a currency different from the
-  trade currency (GBP for foreign-exchange rows), the import stops. That fee cannot yet be
-  represented exactly from this report without risking an incorrect allowable cost.
+    trade currency (GBP for foreign-exchange rows), the import stops. That fee cannot yet be
+    represented exactly from this report without risking an incorrect allowable cost.
 
 ## Troubleshooting
 

--- a/docs/brokers/trading212.md
+++ b/docs/brokers/trading212.md
@@ -13,12 +13,12 @@ identify the account type, so cgt-calc cannot separate the accounts later.
 1. In Trading 212, open **Menu**, then **History**.
 2. Select the export button.
 3. Choose the date range. Exporting the history since the account was opened is the safest option;
-   see [Before you start](../usage.md#before-you-start) for why earlier transactions may be needed.
+    see [Before you start](../usage.md#before-you-start) for why earlier transactions may be needed.
 4. Select every available data category so that orders, cash transactions, dividends and interest
-   are included.
+    are included.
 5. Download the CSV file.
 6. If your complete history requires multiple exports, repeat the process with consecutive date
-   ranges, making sure there are no gaps.
+    ranges, making sure there are no gaps.
 
 The official
 [Trading 212 export instructions](https://helpcentre.trading212.com/hc/en-us/articles/360016898917-Can-I-export-the-trading-data-from-my-account)
@@ -77,15 +77,15 @@ transaction stamped after 23:00 UTC on 5 April belongs to the following tax year
 ### Known limitations
 
 - Dividends are recorded at the CSV `Total`, which is net of withholding tax. The `Withholding tax`
-  column is only used to check the export for consistency and does not appear separately in the
-  report.
+    column is only used to check the export for consistency and does not appear separately in the
+    report.
 - Share transfers between accounts or brokers, labelled `Transfer in` or `Transfer out`, are not
-  supported.
+    supported.
 - Split transactions labelled `Stock split open` or `Stock split close` are not supported. Only the
-  single-row `Stock Split` action is recognised.
+    single-row `Stock Split` action is recognised.
 - The
-  [export for a Trading 212 contract for difference account](https://helpcentre.trading212.com/hc/en-us/articles/36243765206301-How-to-export-the-trading-data-from-my-CFD-account)
-  uses a different, record-based CSV format that this parser does not support.
+    [export for a Trading 212 contract for difference account](https://helpcentre.trading212.com/hc/en-us/articles/36243765206301-How-to-export-the-trading-data-from-my-CFD-account)
+    uses a different, record-based CSV format that this parser does not support.
 
 Do not delete an unsupported transaction from the export to make the calculation run. The missing
 activity could make the resulting holdings and gains incorrect.

--- a/docs/brokers/vanguard.md
+++ b/docs/brokers/vanguard.md
@@ -19,9 +19,9 @@ matching. See [Before you start](../usage.md#before-you-start).
 1. Sign in to Vanguard UK and open **Documents**, then the **Report Generator**.
 2. Request a **Client Transactions Listing** for the required period.
 3. Download the completed workbook. If it contains several account worksheets, select only the
-   taxable General Account.
+    taxable General Account.
 4. Save the entire worksheet as a comma-separated, UTF-8 CSV. Keep both the **Cash Transactions**
-   and **Investment Transactions** tables, including their original headings.
+    and **Investment Transactions** tables, including their original headings.
 
 Do not substitute an annual statement or Consolidated Tax Certificate. Vanguard says its
 [Consolidated Tax Certificate](https://www.vanguardinvestor.co.uk/need-help/answer/what-is-a-consolidated-tax-certificate)
@@ -148,35 +148,35 @@ taxed as interest rather than dividends; see
 ## Known limitations
 
 - When a file contains both tables, ordinary transactions come from Cash Transactions. An unmatched
-  Investment Transactions row is not imported as an additional transaction; ticker renames are the
-  exception. Compare both tables for missing activity.
+    Investment Transactions row is not imported as an additional transaction; ticker renames are the
+    exception. Compare both tables for missing activity.
 - Automatic sales of investments to cover an account fee are currently classified as cash movements,
-  not disposals. They do not reduce the calculated holding or generate a gain or loss.
+    not disposals. They do not reduce the calculated holding or generate a gain or loss.
 - Account fees and ETF dealing fees are not assigned to a purchase or disposal as allowable costs.
 - Corporate actions other than the supported `NameChange` pair are not mapped. A split, merger,
-  conversion, transfer of investments or other unfamiliar row can stop the import or be absent from
-  the cash table.
+    conversion, transfer of investments or other unfamiliar row can stop the import or be absent
+    from the cash table.
 - `NameChange` supports uppercase ticker-style codes, with an optional dot suffix, rather than fund
-  names. A row such as `NameChange: U.S. Equity Index Fund replaced with ...` stops with
-  `Unknown action`.
+    names. A row such as `NameChange: U.S. Equity Index Fund replaced with ...` stops with
+    `Unknown action`.
 - The dividend reader expects Vanguard's `DIV: ... @ ...` text layout. Changed dividend wording or
-  another income type is not mapped merely because it appears in the workbook.
+    another income type is not mapped merely because it appears in the workbook.
 - A reversed purchase or disposal stops the import. It has to be reconciled with the original trade,
-  which the row does not identify, so cgt-calc refuses it instead of guessing.
+    which the row does not identify, so cgt-calc refuses it instead of guessing.
 - The importer treats every transaction amount as GBP. Foreign-currency dividend text has not been
-  validated and is not converted.
+    validated and is not converted.
 - The final text in parentheses is always treated as the ticker. For example, an investment ending
-  in `(Accumulation)` is assigned the symbol `Accumulation`, which can silently combine different
-  funds in one holding.
+    in `(Accumulation)` is assigned the symbol `Accumulation`, which can silently combine different
+    funds in one holding.
 - A row cgt-calc cannot place stops the import instead of being skipped, and the error names the
-  file line. That covers a row with the wrong number of fields, a header that does not match the
-  section title above it, a conflicting header or section title, a transaction row above the first
-  header or after a `Balance` or `Cost` summary, and stray text inside a table.
+    file line. That covers a row with the wrong number of fields, a header that does not match the
+    section title above it, a conflicting header or section title, a transaction row above the first
+    header or after a `Balance` or `Cost` summary, and stray text inside a table.
 - Cosmetic rows are still ignored: trailing empty columns, a repeated page title or header, a
-  `Page 1 of 2` label in any column, and a text footer below the last row of its table.
+    `Page 1 of 2` label in any column, and a text footer below the last row of its table.
 - A legacy cash-only table can be calculated, but an investment-only table is rejected because its
-  unsigned `Cost` values do not provide usable cash movements. Use the complete worksheet with its
-  Cash Transactions table.
+    unsigned `Cost` values do not provide usable cash movements. Use the complete worksheet with its
+    Cash Transactions table.
 
 ## Troubleshooting
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,69 +5,70 @@ The following configuration files and options allow you to customize the calcula
 ## Automatic data fetching
 
 - **Exchange rates.** Monthly GBP exchange rates are automatically downloaded from the
-  [UK Trade Tariff API](https://www.trade-tariff.service.gov.uk/exchange_rates) and saved to
-  `out/exchange_rates.csv`. You can override these by providing your own file in the same format
-  using the `--exchange-rates-file` option.
+    [UK Trade Tariff API](https://www.trade-tariff.service.gov.uk/exchange_rates) and saved to
+    `out/exchange_rates.csv`. You can override these by providing your own file in the same format
+    using the `--exchange-rates-file` option.
 
 - **ISIN to ticker translation.** When your broker doesn't provide ticker symbols, the tool
-  automatically translates ISIN codes using the
-  [Open FIGI API](https://www.openfigi.com/api/overview). This is used for calculating Excess
-  Reportable Income (ERI) on offshore funds. The default read/write cache is
-  `out/isin_translation.csv`; `--isin-translation-file` selects a different cache path. Existing
-  entries are read, and cgt-calc can create or rewrite the file after a successful Open FIGI lookup
-  or after learning a mapping from broker transactions. Pre-packaged mappings are available in
-  [`initial_isin_translation.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_isin_translation.csv),
-  which you can extend using the cache file. A cache entry for an existing ISIN replaces the bundled
-  symbol set for that ISIN, so put every verified alias in additional columns on the same CSV row.
+    automatically translates ISIN codes using the
+    [Open FIGI API](https://www.openfigi.com/api/overview). This is used for calculating Excess
+    Reportable Income (ERI) on offshore funds. The default read/write cache is
+    `out/isin_translation.csv`; `--isin-translation-file` selects a different cache path. Existing
+    entries are read, and cgt-calc can create or rewrite the file after a successful Open FIGI
+    lookup or after learning a mapping from broker transactions. Pre-packaged mappings are available
+    in
+    [`initial_isin_translation.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_isin_translation.csv),
+    which you can extend using the cache file. A cache entry for an existing ISIN replaces the
+    bundled symbol set for that ISIN, so put every verified alias in additional columns on the same
+    CSV row.
 
 ## Manual configuration files
 
-<!-- dprint-ignore-start -->
 - **Initial stock prices.** Required for special events like vesting, splits, or spin-offs when
-  historical prices aren't available from your broker. Prices should be in USD.
-  [`initial_prices.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_prices.csv)
-  comes pre-packaged. The program will inform you when a required price is missing, and you can
-  supply custom data with `--initial-prices-file`.
+    historical prices aren't available from your broker. Prices should be in USD.
+    [`initial_prices.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_prices.csv)
+    comes pre-packaged. The program will inform you when a required price is missing, and you can
+    supply custom data with `--initial-prices-file`.
 
 - **Spin-off transactions.** Provide additional details for spin-off events using the
-  `--spin-offs-file` option.
+    `--spin-offs-file` option.
 
 - **Interest fund tickers.** Some bond funds and ETFs should be taxed as interest rather than
-  dividends. Specify these funds via the `--interest-fund-tickers` CLI option, using a
-  comma-separated list of ticker symbols.
+    dividends. Specify these funds via the `--interest-fund-tickers` CLI option, using a
+    comma-separated list of ticker symbols.
 
 - **CGT-exempt instrument classification (advanced manual override).** Use `--cgt-exempt-tickers`
-  with a comma-separated list only when you have established that each instrument is exempt under
-  [TCGA 1992 s115](https://www.legislation.gov.uk/ukpga/1992/12/section/115).
+    with a comma-separated list only when you have established that each instrument is exempt under
+    [TCGA 1992 s115](https://www.legislation.gov.uk/ukpga/1992/12/section/115).
 
     - This is your own unverified assertion. The calculator does not identify or validate gilts or
-      [qualifying corporate bonds (QCBs)](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg53702),
-      and QCB status cannot be inferred from a ticker or name.
-    - The override disregards both gains and losses on disposals. Do not use it where a disposal
-      can still produce a charge: disposing of a QCB acquired on a takeover or reorganisation can
-      bring a
-      [deferred gain](https://www.gov.uk/government/publications/share-reorganisations-company-takeovers-and-capital-gains-tax-hs285-self-assessment-helpsheet)
-      back into charge, and the profit on a
-      [deeply discounted security](https://www.gov.uk/hmrc-internal-manuals/savings-and-investment-manual/saim3010)
-      is taxable as income. Neither is calculated here.
+        [qualifying corporate bonds (QCBs)](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg53702),
+        and QCB status cannot be inferred from a ticker or name.
+    - The override disregards both gains and losses on disposals. Do not use it where a disposal can
+        still produce a charge: disposing of a QCB acquired on a takeover or reorganisation can
+        bring a
+        [deferred gain](https://www.gov.uk/government/publications/share-reorganisations-company-takeovers-and-capital-gains-tax-hs285-self-assessment-helpsheet)
+        back into charge, and the profit on a
+        [deeply discounted security](https://www.gov.uk/hmrc-internal-manuals/savings-and-investment-manual/saim3010)
+        is taxable as income. Neither is calculated here.
     - The per-disposal breakdown in the PDF applies the ordinary same-day, 30-day and Section 104
-      share identification rules. Those are not the identification rules HMRC gives for gilts, QCBs
-      and other relevant securities, so read the breakdown as workings for the quantities only. It
-      has no effect on the figures reported, because the gain or loss is disregarded.
+        share identification rules. Those are not the identification rules HMRC gives for gilts,
+        QCBs and other relevant securities, so read the breakdown as workings for the quantities
+        only. It has no effect on the figures reported, because the gain or loss is disregarded.
     - Coupon and accrued interest remain taxable income. The calculator does not implement the
-      [Accrued Income Scheme](https://www.gov.uk/government/publications/accrued-income-scheme-hs343-self-assessment-helpsheet).
+        [Accrued Income Scheme](https://www.gov.uk/government/publications/accrued-income-scheme-hs343-self-assessment-helpsheet).
     - The importers for [Freetrade](brokers/freetrade.md),
-      [Hargreaves Lansdown](brokers/hargreaves-lansdown.md) and
-      [Interactive Brokers](brokers/interactive-brokers.md) are documented as unvalidated for bonds
-      and gilts. This override does not validate them either.
+        [Hargreaves Lansdown](brokers/hargreaves-lansdown.md) and
+        [Interactive Brokers](brokers/interactive-brokers.md) are documented as unvalidated for
+        bonds and gilts. This override does not validate them either.
     - The override changes the capital gains calculation only. A coupon is reported in whichever box
-      its broker rows put it in. `--interest-fund-tickers` reports as foreign interest, so it is not a
-      fix for a UK gilt coupon. Check the interest and dividend figures against your own records.
+        its broker rows put it in. `--interest-fund-tickers` reports as foreign interest, so it is
+        not a fix for a UK gilt coupon. Check the interest and dividend figures against your own
+        records.
     - Matching uses the ticker at the disposal, so an instrument renamed part-way through the
-      history has to be listed under both names.
-    - A gift of a listed instrument is reported as an exempt disposal and does not also appear in the
-      **Gifts at market value** section.
+        history has to be listed under both names.
+    - A gift of a listed instrument is reported as an exempt disposal and does not also appear in
+        the **Gifts at market value** section.
     - Listing an instrument does not lift the restrictions on disposing of it in more than one way
-      on a single day. A sale and a gift to a connected person on the same day are still refused,
-      even though the loss they cannot apportion would be disregarded.
-<!-- dprint-ignore-end -->
+        on a single day. A sale and a gift to a connected person on the same day are still refused,
+        even though the loss they cannot apportion would be disregarded.

--- a/docs/custom-eri-data.md
+++ b/docs/custom-eri-data.md
@@ -6,8 +6,8 @@ the [bundled data](offshore-funds.md#bundled-data) first.
 ## ERI_RAW format
 
 - **CSV using the ERI_RAW format.** This is currently the only format supported for excess reported
-  income.
-  [See example.](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/eri/vanguard_eri.csv)
+    income.
+    [See example.](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/eri/vanguard_eri.csv)
 
 Example usage for the tax year 2024/25:
 
@@ -77,7 +77,7 @@ Columns mapping to ERI_RAW:
 - **Fund Reporting Period End Date:** Reporting Period End Date column
 - **Currency:** Currency of the following amounts column
 - **Excess of reporting income over distribution:** Per unit excess reportable income over
-  distributions in respect of the reporting period column
+    distributions in respect of the reporting period column
 
 ### Invesco
 
@@ -93,7 +93,7 @@ Columns mapping to ERI_RAW:
 - **Fund Reporting Period End Date:** Stated in the report header before the main table
 - **Currency:** Currency of Share Class column
 - **Excess of reporting income over distribution:** Per unit excess reportable income over
-  distributions in respect of the reporting period column
+    distributions in respect of the reporting period column
 
 ## Contributing data back
 

--- a/docs/development/adding-a-broker.md
+++ b/docs/development/adding-a-broker.md
@@ -1,11 +1,11 @@
 # Adding a Broker
 
 1. Add a new parser class in
-   [`cgt_calc/parsers/`](https://github.com/cgt-calc/capital-gains-calculator/tree/main/cgt_calc/parsers)
+    [`cgt_calc/parsers/`](https://github.com/cgt-calc/capital-gains-calculator/tree/main/cgt_calc/parsers)
 2. Register it in
-   [`cgt_calc/parsers/broker_registry.py`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/parsers/broker_registry.py)
+    [`cgt_calc/parsers/broker_registry.py`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/parsers/broker_registry.py)
 3. Add tests in `tests/`
 4. Add a docs page under `docs/brokers/` and a nav entry in `zensical.toml`, and add the broker to
-   the table in [Brokers](../brokers/index.md) and the list in the README. All three are sorted by
-   broker name, with the RAW format left last
+    the table in [Brokers](../brokers/index.md) and the list in the README. All three are sorted by
+    broker name, with the RAW format left last
 5. Submit a pull request describing your changes

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -46,7 +46,7 @@ We use:
 - [shfmt](https://github.com/mvdan/sh#shfmt) - for formatting shell scripts
 - [codespell](https://github.com/codespell-project/codespell) - for catching common misspellings
 - [Harper](https://writewithharper.com/) - for grammar and spell checking of comments, docstrings,
-  and Markdown docs
+    and Markdown docs
 
 `prek` can be used to run all checks with one command (see below).
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -9,4 +9,4 @@ GitHub Actions will automatically:
 1. Extract the version from the release tag (e.g. `v1.2.3`)
 2. Run tests and checks
 3. Build and publish the package to PyPI using `uv publish` and
-   [Trusted Publisher](https://docs.pypi.org/trusted-publishers/) on PyPI
+    [Trusted Publisher](https://docs.pypi.org/trusted-publishers/) on PyPI

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 
 - **Python 3.12** or newer (tested on 3.12, 3.13, and 3.14)
 - **pdflatex** must be available in your `PATH` to generate PDF reports (with `--no-pdflatex` the
-  LaTeX source is saved instead)
+    LaTeX source is saved instead)
 
 ## Install cgt-calc
 

--- a/docs/offshore-funds.md
+++ b/docs/offshore-funds.md
@@ -33,11 +33,11 @@ override ISIN translation see the **ISIN to ticker translation** entry on the
 There are a few **unsupported** functionalities at the moment for taxation on offshore funds:
 
 - Tax calculations for offshore funds that are **not reporting to HMRC** as they don't report taxes
-  as CGT but as income tax.
+    as CGT but as income tax.
 - Excess Reported Income
-  [equalisation](https://www.gov.uk/hmrc-internal-manuals/investment-funds/ifm13224) support which
-  is an optional arrangement which certain funds can support to reduce the amount of excess reported
-  income in case you held the fund stocks for less than the reporting period.
+    [equalisation](https://www.gov.uk/hmrc-internal-manuals/investment-funds/ifm13224) support which
+    is an optional arrangement which certain funds can support to reduce the amount of excess
+    reported income in case you held the fund stocks for less than the reporting period.
 
 ## Providing custom ERI data
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -8,9 +8,9 @@ does **not send your transaction history or personal information** to any extern
 The only external API calls made are:
 
 - [**UK Trade Tariff API**](https://www.trade-tariff.service.gov.uk/exchange_rates) – to fetch
-  monthly GBP exchange rates (no personal data sent)
+    monthly GBP exchange rates (no personal data sent)
 - [**Open FIGI API**](https://www.openfigi.com/api/overview) – to translate ISIN codes to tickers
-  when needed (only ISIN codes are queried, no transaction amounts or personal details)
+    when needed (only ISIN codes are queried, no transaction amounts or personal details)
 
 ## Disclaimer
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,17 +5,17 @@
 You will need:
 
 - **cgt-calc and LaTeX installed.** Follow the [installation guide](installation.md) before
-  continuing.
+    continuing.
 - **A complete transaction history from every relevant account.** Follow the instructions for each
-  [supported broker](brokers/index.md). Include transactions from before the tax year when they are
-  needed to establish the cost of shares you owned or sold during that year. Exporting the history
-  since the account was opened is the safest option.
+    [supported broker](brokers/index.md). Include transactions from before the tax year when they
+    are needed to establish the cost of shares you owned or sold during that year. Exporting the
+    history since the account was opened is the safest option.
 - **Excess Reported Income data when applicable.** If you own or have owned funds from outside the
-  UK, whether accumulating or distributing, check the [offshore funds guide](offshore-funds.md).
+    UK, whether accumulating or distributing, check the [offshore funds guide](offshore-funds.md).
 - **Transfers to or from a spouse or civil partner, recorded by hand.** No broker export marks
-  these. Add them in a small RAW file using the
-  [`TRANSFER_TO_SPOUSE` or `TRANSFER_FROM_SPOUSE`](brokers/raw.md#transfers-to-a-spouse-or-civil-partner)
-  action and pass it alongside your export.
+    these. Add them in a small RAW file using the
+    [`TRANSFER_TO_SPOUSE` or `TRANSFER_FROM_SPOUSE`](brokers/raw.md#transfers-to-a-spouse-or-civil-partner)
+    action and pass it alongside your export.
 
 Do not include the same transaction in more than one export. cgt-calc can validate the transactions
 it receives, but it cannot detect every missing or duplicated export.
@@ -74,7 +74,7 @@ Before relying on the figures:
 
 1. Read every warning printed while the calculator runs.
 2. Check that the section headed “Portfolio at the end of … tax year” agrees with your records at
-   the end of that tax year.
+    the end of that tax year.
 3. Compare the disposal count and proceeds with your broker statements.
 4. Check that dividends and interest are present when you expect them.
 5. Confirm that every relevant account was included once, without overlapping exports.

--- a/dprint.json
+++ b/dprint.json
@@ -32,7 +32,7 @@
         "https://plugins.dprint.dev/dockerfile-0.3.3.wasm",
         "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm",
         "https://plugins.dprint.dev/json-0.20.0.wasm",
-        "https://plugins.dprint.dev/markdown-0.20.0.wasm",
+        "https://plugins.dprint.dev/markdown-0.22.1.wasm",
         "https://plugins.dprint.dev/toml-0.7.0.wasm"
     ],
 
@@ -42,6 +42,7 @@
     },
 
     "markdown": {
+        "listIndentKind": "pythonMarkdown",
         "textWrap": "always",
         "lineWidth": 100
     },


### PR DESCRIPTION
Some documentation lists render flat instead of nested because Zensical's Python-Markdown-based renderer requires 4-space indentation for nested list items, while dprint was formatting them at 2 spaces. This silently affected `docs/brokers/raw.md` and `docs/configuration.md` CGT-exempt instrument classification caveats.

- Bump dprint's markdown plugin from 0.20.0 to 0.22.1 and set `listIndentKind` to `pythonMarkdown`, so dprint always indents nested list content 4 spaces to match Zensical's renderer
- Run dprint fmt across the repo; reformats 18 markdown files (word-wrap reflow only, verified byte-identical rendered HTML except for the two fixed lists)
- Remove the dprint-ignore workaround around `docs/configuration.md` Manual configuration files list, now unnecessary since dprint owns the correct indentation natively