### PR TITLE
Improve the Zensical documentation configuration

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -3,6 +3,7 @@ site_name = "UK Capital Gains Calculator"
 site_url = "https://cgt-calc.uk/"
 site_description = "Calculate UK capital gains from your investment transaction history and generate a detailed PDF report."
 site_author = "Ruslan Sayfutdinov"
+strict = true
 repo_url = "https://github.com/cgt-calc/capital-gains-calculator"
 repo_name = "cgt-calc/capital-gains-calculator"
 edit_uri = "edit/main/docs/"
@@ -52,6 +53,7 @@ features = [
   "content.action.edit",
   "content.action.view",
   "content.code.copy",
+  "content.tooltips",
   "navigation.footer",
   "navigation.indexes",
   "navigation.instant",
@@ -88,16 +90,11 @@ toggle.name = "Switch to system preference"
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
 link = "https://github.com/cgt-calc/capital-gains-calculator"
+name = "GitHub repository"
 
 [project.markdown_extensions]
 admonition = {}
-attr_list = {}
-md_in_html = {}
 tables = {}
 toc.permalink = true
-pymdownx.details = {}
-pymdownx.emoji.emoji_generator = "zensical.extensions.emoji.to_svg"
-pymdownx.emoji.emoji_index = "zensical.extensions.emoji.twemoji"
 pymdownx.highlight.pygments_lang_class = true
-pymdownx.inlinehilite = {}
 pymdownx.superfences = {}


### PR DESCRIPTION
Make documentation build warnings fail CI and improve tooltip labels across the generated site.

- Enable Zensical strict mode and content tooltips.
- Give the GitHub footer link a descriptive label.

Remove unused Markdown extensions; the current docs do not use their syntax, so the rendered content is unchanged.